### PR TITLE
fix(ci): Docker buildとSARIF uploadエラーの修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ name: CI/CD Pipeline - 4-Tier Test Pyramid
 # Coverage Target: 85% (baseline protection, dynamic targets in local dev)
 # Reference: .serena/memories/test_strategy_part1_overview.md
 
+# Permissions for SARIF upload (Trivy security scan)
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [main, develop]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN pip install --no-cache-dir uv
 COPY pyproject.toml uv.lock ./
 
 # 依存関係インストール（本番用、devパッケージ除外）
-RUN uv sync --frozen --no-dev
+# --no-install-project: ローカルパッケージビルドをスキップ（ソース未コピー状態で hatchling エラー回避）
+RUN uv sync --frozen --no-dev --no-install-project
 
 # ============================================================
 # Stage 3: Runtime - 本番実行環境
@@ -80,7 +81,8 @@ RUN pip install --no-cache-dir uv
 COPY pyproject.toml uv.lock ./
 
 # 全依存関係インストール（devパッケージ含む）
-RUN uv sync --frozen
+# --no-install-project: ソース未コピー状態でhatchlingエラー回避（dependencies stageと同様）
+RUN uv sync --frozen --no-install-project
 
 # PATH設定
 ENV PATH="/app/.venv/bin:$PATH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["utils", "config"]
+packages = ["utils", "config", "models"]
 
 [project]
 name = "api-test-devops-portfolio"


### PR DESCRIPTION
## 概要
- Dockerfileの`uv sync`に`--no-install-project`フラグを追加（dependencies/test両stage）
- Trivy SARIF uploadに必要な`security-events: write`権限を追加
- hatchlingパッケージリストに`models`を追加

## 根本原因分析
| 問題 | 根本原因 | 修正内容 |
|------|---------|---------|
| Docker build失敗 | ソースコピー前に`uv sync`実行 → hatchling.build.build_editableエラー | `--no-install-project`フラグ追加 |
| Trivy SARIF uploadエラー | `security-events: write`権限不足 | permissions block追加 |

## 変更ファイル
- `Dockerfile` (Line 43, 85)
- `.github/workflows/ci.yml` (Line 8-11)
- `pyproject.toml` (Line 6)

## テスト計画
- [ ] CIパイプライン成功（Docker build + Trivyスキャン）
- [ ] PR Validation成功
- [ ] SARIF結果がSecurityタブに表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)