### PR TITLE
chore(ci): dependabotのターゲットブランチをdevelopに明示的に設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,9 @@
 version: 2
 updates:
   # Python dependencies (uv)
-  # Note: target-branch not needed since develop is default branch
   - package-ecosystem: "uv"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -40,9 +40,9 @@ updates:
           - "bandit"
 
   # GitHub Actions
-  # Note: target-branch not needed since develop is default branch
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary

- dependabot.ymlに`target-branch: develop`を明示的に追加
- Python dependencies (uv) と GitHub Actions の両方に適用
- GitHubデフォルトブランチ(main)ではなく、Git Flow戦略に従ってdevelopをターゲットに設定

## Background

PR #28でbaseをmain→developに変更した際、dependabotがmainをターゲットにしていることが判明。
これはdependabot.ymlで`target-branch`が明示されていなかったため、GitHubのデフォルトブランチ(main)が使用されていた。

## Changes

- `.github/dependabot.yml`: 2箇所に`target-branch: "develop"`を追加
- 古いコメント（"Note: target-branch not needed..."）を削除

## Test Plan

- [x] YAML構文エラーなし
- [ ] 次回のdependabot実行時にdevelopをターゲットにしたPRが作成されることを確認