### PR TITLE
fix(ci): PR Validationからexternalテストを除外しRateLimitError回避

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,16 +52,18 @@ jobs:
 
       - name: Set test markers based on target branch
         id: markers
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          if [ "${{ github.base_ref }}" = "main" ]; then
-            echo "value=unit or integration or smoke" >> $GITHUB_OUTPUT
-            echo "🎯 Target: main - Will run Unit + Integration + Smoke tests"
-          elif [ "${{ github.base_ref }}" = "develop" ]; then
-            echo "value=unit or integration" >> $GITHUB_OUTPUT
-            echo "🎯 Target: develop - Will run Unit + Integration tests"
+          if [ "$BASE_REF" = "main" ]; then
+            echo "value=(unit or integration or smoke) and not external" >> $GITHUB_OUTPUT
+            echo "🎯 Target: main - Will run Unit + Integration + Smoke tests (excluding external)"
+          elif [ "$BASE_REF" = "develop" ]; then
+            echo "value=(unit or integration) and not external" >> $GITHUB_OUTPUT
+            echo "🎯 Target: develop - Will run Unit + Integration tests (excluding external)"
           else
-            echo "::warning::Unknown base_ref: ${{ github.base_ref }}, using develop default"
-            echo "value=unit or integration" >> $GITHUB_OUTPUT
+            echo "::warning::Unknown base_ref: $BASE_REF, using develop default"
+            echo "value=(unit or integration) and not external" >> $GITHUB_OUTPUT
           fi
 
       - name: Run tests


### PR DESCRIPTION
## Summary
- PR ValidationのpytestマーカーからexternalテストをGitHub API制限のため除外
- env変数経由でbase_ref参照（セキュリティベストプラクティス準拠）
- RateLimitError（60 req/h制限）による断続的なCI失敗を解消

## Changes
- `.github/workflows/ci.yml`: pytestマーカーに `and not external` を追加
  - main向け: `(unit or integration or smoke) and not external`
  - develop向け: `(unit or integration) and not external`
  - fallback: `(unit or integration) and not external`

## Root Cause Analysis
- `test_github_api.py`は`@pytest.mark.external`と`@pytest.mark.integration`の両方を持つ
- CI workflowは`-m "unit or integration"`で実行 → externalテストも含まれる
- 認証なしGitHub API制限（60 req/h）を超過 → RateLimitError

## Test Plan
- [ ] PR Validationが`external`テストを除外して実行されることを確認
- [ ] 既存のunit/integrationテストが正常に実行されることを確認

Refs: PR #30 (このPRマージ後に再実行予定)