### PR TITLE
chore(deps): Dependabot GitHub Actions グループ化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,3 +54,12 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "chore(ci)"
+    groups:
+      # minor/patch更新を1PRにグループ化（auto-merge対象）
+      # major更新は個別PR（手動確認必須）
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- GitHub Actions の依存関係更新を minor/patch グループ化
- major 更新は個別PRで手動確認を維持
- 既存の auto-merge workflow と連携

## Changes
- `.github/dependabot.yml`: `groups.minor-and-patch` 設定追加
  - `patterns: ["*"]` - 全 GitHub Actions を対象
  - `update-types: ["minor", "patch"]` - minor/patch のみグループ化

## Expected Behavior
| 更新タイプ | 変更前 | 変更後 |
|-----------|--------|--------|
| minor/patch | 個別PR | 1グループPR → auto-merge |
| major | 個別PR | 個別PR → 手動確認 |

## Test plan
- [x] YAML構文検証: `python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`
- [ ] 次回 Dependabot 実行時にグループ化されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)