### PR TITLE
chore: develop → main 同期 (CVE-2025-8869対応)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,9 @@ jobs:
   # ============================================================
   # Stage 1: PR Validation
   # Triggers: pull_request
-  # Tests: 
+  # Tests:
   # - develop: Unit + Integration(標準)
   # - main: Unit + Integration + Smoke（厳格化）
-  # - other:Unit + Integration (標準)
   # ============================================================
   pr-validation:
     name: PR Validation
@@ -62,12 +61,10 @@ jobs:
           if [ "$BASE_REF" = "main" ]; then
             echo "value=(unit or integration or smoke) and not external" >> $GITHUB_OUTPUT
             echo "🎯 Target: main - Will run Unit + Integration + Smoke tests (excluding external)"
-          elif [ "$BASE_REF" = "develop" ]; then
+          else
+            # develop (デフォルト)
             echo "value=(unit or integration) and not external" >> $GITHUB_OUTPUT
             echo "🎯 Target: develop - Will run Unit + Integration tests (excluding external)"
-          else
-            echo "::warning::Unknown base_ref: $BASE_REF, using develop default"
-            echo "value=(unit or integration) and not external" >> $GITHUB_OUTPUT
           fi
 
       - name: Run tests
@@ -88,6 +85,26 @@ jobs:
             reports/
             coverage.json
           if-no-files-found: warn
+
+      # Trivy セキュリティスキャン（Python 3.12 のみ、他バージョンでの重複実行を回避）
+      - name: Build Docker image for Trivy scan
+        id: docker-build
+        if: matrix.python-version == '3.12'
+        run: |
+          if ! docker build -t test-image:${{ github.sha }} --target runtime .; then
+            echo "::error::Docker build failed - check Dockerfile syntax or base image availability"
+            exit 1
+          fi
+
+      - name: Trivy vulnerability scan
+        if: matrix.python-version == '3.12' && steps.docker-build.outcome == 'success'
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: 'test-image:${{ github.sha }}'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
+          ignore-unfixed: true
+          trivyignores: '.trivyignore'
 
   # NOTE: post-merge-validation uses Python 3.12 only (matches Dockerfile)
   # ============================================================
@@ -145,7 +162,18 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           ignore-unfixed: true
+          trivyignores: '.trivyignore'
         continue-on-error: true
+
+      - name: Verify Trivy scan execution
+        if: always()
+        run: |
+          if [ ! -f "trivy-results.sarif" ]; then
+            echo "::error::Trivy scan did not produce SARIF output (crash/timeout/disk issue)"
+            echo "Check 'Trivy image scan' step logs for details"
+            exit 1
+          fi
+          echo "✅ Trivy SARIF output verified"
 
       - name: Upload Trivy results to Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,12 @@
+# .trivyignore
+# 最終更新: 2026-01-08
+# 期限: 2026-02-08（30日後にレビュー）
+#
+# CVE-2025-8869: pip tar extraction path traversal vulnerability
+# 深刻度: MEDIUM (CVSS v4.0: 5.9)
+# 検出理由: python:3.12-slim内のpip (<25.3) がTrivyで検出される
+# 実際のリスク: 低（Python 3.12はPEP 706実装済み、脆弱コードパス未使用）
+# 修正状況: pip 25.3で修正済み、base image更新待ち
+# 参照: https://github.com/advisories/GHSA-4xh5-x5gv-qwph
+# 対応: base image更新時に削除検討
+CVE-2025-8869

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,8 @@ RUN groupadd --gid 1000 appgroup && \
 # ============================================================
 FROM base AS dependencies
 
-# pip最新化（CVE-2025-8869対応）+ uv インストール
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir uv
+# uv インストール
+RUN pip install --no-cache-dir uv
 
 # 依存関係ファイルのみコピー（キャッシュ効率化）
 COPY pyproject.toml uv.lock ./
@@ -75,9 +74,8 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 # ============================================================
 FROM base AS test
 
-# pip最新化（CVE-2025-8869対応）+ uv インストール
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir uv
+# uv インストール
+RUN pip install --no-cache-dir uv
 
 # 依存関係ファイルコピー
 COPY pyproject.toml uv.lock ./


### PR DESCRIPTION
## Summary
- PR #43 の変更を main に同期
- CVE-2025-8869 一時対応 + Trivy スキャン追加

## Changes
- PR Validation に Trivy セキュリティスキャン追加
- `.trivyignore` で CVE-2025-8869 を30日間一時無視
- Post-Merge Trivy 実行検証ステップ追加
- Dockerfile から無効な pip upgrade 削除

## Merge Strategy
**Regular Merge 必須**（Squash Merge 禁止）
- 履歴統合維持のため

🤖 Generated with [Claude Code](https://claude.ai/code)