### PR TITLE
docs(workflow): 標準フローにsimplifyとcritique条件付きステップを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -963,14 +963,18 @@ AIが自動的に適切なPluginを発動するためのルール。詳細（パ
 1. コード変更 → security-guidance (hook自動)
 2. 品質ゲート → pytest + ruff + mypy 全合格（※1）
 3. 自己改善  → /reflexion:reflect
-4. 日常レビュー → /code-review:code-review (80点閾値)
-5. コミット   → /commit-commands:commit
-6. PR時      → /pr-review-toolkit:review-pr (品質) + /code-review:review-pr (防御)
-7. 重要PR時  → /comprehensive-pr-review (10エージェント統合)
-8. PR作成    → /commit-commands:commit-push-pr
+4. コード簡素化 → /pr-review-toolkit:review-pr simplify 【条件付き※2】
+5. 多角的レビュー → /reflexion:critique 【条件付き※3】
+6. 日常レビュー → /code-review:code-review (80点閾値)
+7. コミット   → /commit-commands:commit
+8. PR時      → /pr-review-toolkit:review-pr (品質) + /code-review:review-pr (防御)
+9. 重要PR時  → /comprehensive-pr-review (10エージェント統合)
+10. PR作成   → /commit-commands:commit-push-pr
 ```
 
 **※1 品質ゲート**: `uv run pytest && uv run ruff check . && uv run mypy utils/ config/`
+**※2 simplify条件**: 長時間セッション(2h+)または複雑ロジック実装時のみ
+**※3 critique条件**: 追加行≥200 OR ファイル変更≥3 OR セキュリティ関連ファイル変更
 
 ## 🦸 superpowers使い分けルール
 


### PR DESCRIPTION
## 概要
標準開発ワークフローにコード簡素化（simplify）と多角的レビュー（critique）の条件付きステップを追加しました。

## 変更内容
- **Step 4追加**: `/pr-review-toolkit:review-pr simplify`（条件付き※2）
- **Step 5追加**: `/reflexion:critique`（条件付き※3）
- **Step番号更新**: 旧4-8 → 新6-10
- **※2条件**: 長時間セッション(2h+)または複雑ロジック実装時のみ
- **※3条件**: 追加行≥200 OR ファイル変更≥3 OR セキュリティ関連ファイル変更

## 変更ファイル
- `CLAUDE.md`: 行966-977

## テスト
- [x] pre-commit hook通過（ruff, gitleaks）
- [x] ドキュメント変更のみ（コード変更なし）