### PR TITLE
refactor(ci): Python matrix を 3.12 のみに統一

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,10 @@ jobs:
     name: PR Validation
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 15  # main PR時のDocker Build + Trivy追加（初回キャッシュミス時の安全マージン確保）
+    timeout-minutes: 10  # 単一Python版（3.12固定、Dockerfile一致）
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
-      fail-fast: false
+        python-version: ['3.12']
 
     steps:
       - name: Checkout code
@@ -248,8 +247,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
-      fail-fast: false
+        python-version: ['3.12']
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![CI/CD Pipeline](https://github.com/yuta158/api-test-portfolio/actions/workflows/ci.yml/badge.svg)](https://github.com/yuta158/api-test-portfolio/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-66%25-green)](https://yuta158.github.io/api-test-portfolio/htmlcov/)
-![Python](https://img.shields.io/badge/Python-3.10%20%7C%203.11%20%7C%203.12-blue)
+![Python](https://img.shields.io/badge/Python-3.12-blue)
 [![Docker](https://img.shields.io/badge/docker-multi--stage-blue)](./Dockerfile)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)


### PR DESCRIPTION
## Summary
- 本番環境（Docker 3.12固定）とCI/CDを一致
- 不要な3.10/3.11テストを削除
- PR Validation ジョブ数: 3→1

## Design Rationale
| 観点 | メリット |
|------|---------|
| 設計一貫性 | Dockerfile 3.12 ↔ CI 3.12 |
| CI時間短縮 | 3ジョブ→1ジョブ（約66%削減） |
| 保守性 | 単一バージョン管理 |

## Test Plan
- [ ] PR Validation (3.12) のみ実行される
- [ ] PR Security Scan 実行される
- [ ] Weekly Comprehensive (3.12) のみ設定される