### PR TITLE
chore(ci): Job-level権限への移行 (PERM-001)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ name: CI/CD Pipeline - 4-Tier Test Pyramid
 # Coverage Target: 85% (baseline protection, dynamic targets in local dev)
 # Reference: .serena/memories/test_strategy_part1_overview.md
 
-# Permissions for SARIF upload (Trivy security scan)
+# Default permissions (least privilege principle)
+# security-events: write is granted at job level where needed
 permissions:
   contents: read
-  security-events: write
 
 on:
   push:
@@ -156,6 +156,10 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 8  # Docker Build + Trivy追加のため5→8分に変更
+    # Explicit permissions for Trivy SARIF upload (security hardening)
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- ワークフローレベルからsecurity-events: write権限を削除し、Job-level権限に移行
- post-merge-validationジョブに明示的なJob-level権限を追加
- 最小権限の原則に準拠（5ジョブ中2ジョブのみにelevated権限）

## Test plan
- [ ] pr-validationジョブがcontents: readのみで正常実行
- [ ] pr-security-scanジョブが正常実行（既存のJob-level権限）
- [ ] マージ後、post-merge-validationがTrivy SARIF uploadに成功

Closes #19