### PR TITLE
feat(ci): Claude自動レビュー改善（日本語出力 + pr-review-toolkit + 全PR対象）

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,21 +3,10 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    # All PRs (Max 200 plan - no cost concern)
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -38,8 +27,12 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          plugins: 'pr-review-toolkit@claude-code-plugins'
+          prompt: |
+            /pr-review-toolkit:review-pr ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 
+            重要: レビュー結果は必ず日本語で出力してください。
+            - 問題点の説明は日本語
+            - 推奨修正も日本語
+            - コード例のコメントも日本語
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Summary
- Claude自動レビューの出力を日本語に設定
- レビューコマンドを `/pr-review-toolkit:review-pr` に変更（品質観点重視）
- paths フィルタ削除（Max 200プランのため全PR対象）

## Changes
- `plugins`: `code-review` → `pr-review-toolkit`
- `prompt`: `/code-review:code-review` → `/pr-review-toolkit:review-pr`
- `paths`: 削除（全PRでレビュー実行）
- 日本語出力指示追加

## Why
- `/pr-review-toolkit:review-pr`: 品質観点（型・テスト・コメント）で日常PRに最適
- 全PR対象: Max 200プランでAPIコスト制約なし
- 日本語: レビュー結果の可読性向上

## Test Plan
- [ ] PRマージ後、次のPRで日本語レビューを確認
- [ ] 品質観点のレビュー内容を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)