### PR TITLE
fix(ci): Claude Code Review plugin設定を復元

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,16 +2,18 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened]
+    # All PRs (Max 200 plan - no cost concern)
 
 jobs:
   claude-review:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
+      issues: write
       id-token: write
-      actions: read
+      actions: read # Required for Claude to read CI results on PRs
 
     steps:
       - name: Checkout repository
@@ -24,10 +26,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'pr-review-toolkit@claude-code-plugins'
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment"
           prompt: |
-            /review-pr ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            /pr-review-toolkit:review-pr ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 
             重要: レビュー結果は必ず日本語で出力してください。
             - 問題点の説明は日本語


### PR DESCRIPTION
## Summary
- PR#87で誤削除されたplugin_marketplaces/plugins設定を復元
- types: [opened, synchronize, reopened]に拡張（修正commit対応）
- /pr-review-toolkit:review-prコマンドを使用（CLAUDE.md準拠）

## 根本原因
c0fe090コミット（PR#87）で「構文エラー修正」と称して以下が誤削除された：
- `plugin_marketplaces`
- `plugins`

これにより`/review-pr`スラッシュコマンドが認識されなくなった。

## 変更内容
| 項目 | Before | After |
|-----|--------|-------|
| types | `[opened]` | `[opened, synchronize, reopened]` |
| contents | `read` | `write` |
| plugin_marketplaces | なし | 復元 |
| plugins | なし | `pr-review-toolkit@claude-code-plugins` |
| prompt | `/review-pr` | `/pr-review-toolkit:review-pr` |

## Test plan
- [ ] PRマージ後、新規PRでClaude Code Reviewが自動実行される
- [ ] レビュー結果がPRにコメントされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)