### PR TITLE
sync: main → develop Claude Code Review設定同期

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,16 +2,18 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened]
+    # All PRs (Max 200 plan - no cost concern)
 
 jobs:
   claude-review:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
+      issues: write
       id-token: write
-      actions: read
+      actions: read # Required for Claude to read CI results on PRs
 
     steps:
       - name: Checkout repository
@@ -24,10 +26,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'pr-review-toolkit@claude-code-plugins'
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment"
           prompt: |
-            /review-pr ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            /pr-review-toolkit:review-pr ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 
             重要: レビュー結果は必ず日本語で出力してください。
             - 問題点の説明は日本語


### PR DESCRIPTION
## Summary

- main ブランチの Claude Code Review 設定を develop に同期

## 変更内容

PR#100 でマージされた設定を develop に反映:
- `plugin_marketplaces` 追加
- `plugins: pr-review-toolkit@claude-code-plugins` 追加
- `claude_args: --allowedTools "mcp__github_inline_comment__create_inline_comment"` 追加
- `types: [opened, synchronize, reopened]` に変更
- `contents: write`, `issues: write` 権限追加

## Merge 方式

**Regular Merge を使用してください**（Squash Merge 禁止）
- 理由: 同期PRは履歴統合を維持するため

🤖 Generated with [Claude Code](https://claude.ai/code)