### PR TITLE
docs(claude): worktree運用ルールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -866,6 +866,8 @@ if settings.is_development():
 **Git運用** (Git Flow):
 - `main`: 本番リリース用（タグ付きリリースのみ）
 - `develop`: 開発統合ブランチ（次期リリース準備）main へマージ
+   - 理由: Protected branchには直接pushできないため、ローカル更新は不要
+   - `git fetch` + 新ブランチ作成により、常に最新のリモート状態から作業開始
 - `feature/*`: 機能開発 → develop へPR・Squash Merge
 - `hotfix/*`: 緊急修正 → main + develop へマージ
 - **コミットメッセージ** (Conventional Commits準拠):


### PR DESCRIPTION
## 概要

CLAUDE.mdにworktree運用ルールを追加し、develop/mainでの直接変更を禁止するルールを明文化。

## 変更内容

- 作業前に`/superpowers:using-git-worktrees`でworktree作成を必須化
- develop, mainでの直接変更作業を禁止
- worktree作成フォルダパスを明記

## 目的

このPRはClaude Code Review機能の動作確認も兼ねています。

## テスト計画

- [ ] Claude Code Reviewが正常に実行されることを確認
- [ ] インラインコメントが日本語で出力されることを確認