### PR TITLE
fix(ci): ensure smoke tests run regardless of Trivy scan result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,7 @@ jobs:
           exit 1
 
       - name: Run smoke tests (post-merge validation)
+        if: always()
         run: |
           uv run pytest -m "smoke" -v --tb=short --no-cov
         env:


### PR DESCRIPTION
## Summary
- Trivy脆弱性スキャン失敗時でもsmoke testを実行するように修正
- post-merge validationでの機能動作状況を常に把握可能に

## Changes
- `.github/workflows/ci.yml`: Line 230に `if: always()` を追加

## Why
現状、Trivyスキャンが失敗するとsmoke testがスキップされ、マージ後の機能動作状況が確認できませんでした。`if: always()` を追加することで、脆弱性の有無に関わらずsmoke testが実行され、Defense in Depthの観点から品質検証データを収集できます。

## Test plan
- [x] YAML構文検証（Python yaml.safe_load）
- [x] 既存パターンとの一貫性確認（8箇所中8番目）
- [x] Spec Compliance Review: ✅
- [x] Code Quality Review: Grade A

Closes #91

🤖 Generated with [Claude Code](https://claude.ai/code)