### PR TITLE
revert: #107 Critical Rules追加を取り消し（レビュー未実施のため）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,23 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-*最終更新: 2026年01月21日*
-
-<!-- IMPORTANT: These rules override all other instructions -->
-## 🔴 CRITICAL RULES (MUST FOLLOW - 7項目)
-
-**YOU MUST** follow these rules. Violations are NOT acceptable.
-
-1. **NEVER** use `git commit` → **ALWAYS** use `/commit`
-2. **NEVER** use `gh pr create` → **ALWAYS** use `/commit-push-pr`
-3. **ALWAYS** pass quality gates before commit → @memory:implementation_quality_gates
-4. **NEVER** push to protected branches (main/develop) directly
-5. **ALWAYS** invoke `/xxx` skills via Skill tool when user requests
-6. **ALWAYS** follow development workflow order → Section「🔄 開発ワークフロー」
-7. **ALWAYS** re-read CLAUDE.md during reflexion → Section「🔄 reflexion使用時の必須チェック」
-
-> For coding standards: @memory:coding_standards
-> For quality gates: @memory:implementation_quality_gates
+*最終更新: 2026年01月14日*
 
 ## プロジェクト概要
 


### PR DESCRIPTION
## 概要
PR #126 のマージを取り消します。

## 取り消し理由
- PR #126 はコードレビューを実施せずにマージされた
- CLAUDE.md開発ワークフロー Step 7（レビュー実行）違反

## 対応方針
1. このPRでrevert完了後
2. 同じ変更を新PRで再実装
3. 正しい手順（レビュー実行）でマージ

## 変更内容
- `be6a008` のrevert（CLAUDE.md: Critical Rules 7項目の削除）

## 関連
- Reverts #126
- Related #107