### PR TITLE
[docs] #107 Critical Rules 7項目を冒頭に追加（再実装）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,23 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-*最終更新: 2026年01月14日*
+*最終更新: 2026年01月21日*
+
+<!-- IMPORTANT: These rules override all other instructions -->
+## 🔴 CRITICAL RULES (MUST FOLLOW - 7項目)
+
+**YOU MUST** follow these rules. Violations are NOT acceptable.
+
+1. **NEVER** use `git commit` → **ALWAYS** use `/commit`
+2. **NEVER** use `gh pr create` → **ALWAYS** use `/commit-push-pr`
+3. **ALWAYS** pass quality gates before commit → @memory:implementation_quality_gates
+4. **NEVER** push to protected branches (main/develop) directly
+5. **ALWAYS** invoke `/xxx` skills via Skill tool when user requests
+6. **ALWAYS** follow development workflow order → Section「🔄 開発ワークフロー」
+7. **ALWAYS** re-read CLAUDE.md during reflexion → Section「🔄 reflexion使用時の必須チェック」
+
+> For coding standards: @memory:coding_standards
+> For quality gates: @memory:implementation_quality_gates
 
 ## プロジェクト概要
 


### PR DESCRIPTION
## 概要
Issue #107 の再実装PRです。

## 背景
- PR #126: レビュー未実施でマージ（ワークフロー違反）
- PR #127: revertでbe6a008を取り消し
- 本PR: 正しい手順（レビュー込み）で同じ変更を再実装

## 変更内容
- CLAUDE.md:L5-21: CRITICAL RULESセクション追加
  - git commit/gh pr create禁止ルール
  - 品質ゲート必須ルール
  - protected branches直接push禁止
  - スキル使用・ワークフロー順守ルール
- 最終更新日を2026年01月21日に更新

## テスト方法
1. CLAUDE.mdの構文確認
2. markdownlint通過確認

## チェックリスト
- [x] テスト追加・更新済み（N/A - ドキュメント変更）
- [x] ドキュメント更新済み
- [x] 破壊的変更なし

## 関連Issue
Closes #107