### PR TITLE
[fix] PR#132レビュー指摘対応: test_partial_failure追加, SENTRY__DSN修正, error_type追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ SENTRY__ENVIRONMENT="development"                     # Environment name (develo
 SENTRY__TRACES_SAMPLE_RATE="0.1"                      # Traces sampling rate (0.0-1.0)
 SENTRY__PROFILES_SAMPLE_RATE="0.1"                    # Profiles sampling rate (0.0-1.0)
 SENTRY__SEND_DEFAULT_PII="false"                      # Send personally identifiable information
-# SENTRY__DSN=""                                        # Sentry DSN URL (required when SENTRY__ENABLED=true)
+SENTRY__DSN=""                                          # Required when SENTRY__ENABLED=true. Example: https://xxx@xxx.ingest.us.sentry.io/xxx
 
 # Security Configuration
 # SECURITY__API_KEY=""                                  # API authentication key (optional in dev, required in production)

--- a/tests/unit/test_async_client.py
+++ b/tests/unit/test_async_client.py
@@ -22,6 +22,7 @@ import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from httpx import Request, Response
 
@@ -217,6 +218,81 @@ async def test_async_multiple_users_with_semaphore():
 
             # 全ユーザー取得成功確認
             assert mock_client_instance.request.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_graceful_degradation():
+    """
+    一部リクエスト失敗時のgraceful degradationテスト
+
+    検証項目：
+    - 5件中2件が失敗するシナリオ
+    - 失敗したリクエストはNoneとして返される
+    - 成功したリクエストは正常に取得できる
+    - システム全体はクラッシュせず継続動作
+
+    学習ポイント:
+    - graceful degradation: 部分的失敗でもシステム全体は継続動作
+    - asyncio.gather(return_exceptions=True)との違い
+    - 実運用でのエラー耐性設計
+    """
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client_instance = AsyncMock()
+        mock_client_class.return_value = mock_client_instance
+
+        # 5件中2件失敗（ID=2, 4が失敗）
+        def create_response_or_error(user_id: int):
+            if user_id in [2, 4]:
+                # 失敗ケース: HTTPStatusError
+                mock_response = MagicMock(spec=Response)
+                mock_response.status_code = 500
+                error = httpx.HTTPStatusError(
+                    message=f"Server Error for user {user_id}",
+                    request=MagicMock(),
+                    response=mock_response,
+                )
+                raise error
+            # 成功ケース
+            return MagicMock(
+                spec=Response,
+                status_code=200,
+                json=MagicMock(return_value={"id": user_id, "name": f"User {user_id}"}),
+                raise_for_status=MagicMock(return_value=None),
+                content=f'{{"id": {user_id}, "name": "User {user_id}"}}'.encode(),
+            )
+
+        # side_effectで動的にレスポンス生成
+        call_count = [0]
+        user_ids_order = [1, 2, 3, 4, 5]
+
+        def side_effect_handler(*args, **kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            user_id = user_ids_order[idx]
+            return create_response_or_error(user_id)
+
+        mock_client_instance.request.side_effect = side_effect_handler
+
+        async with AsyncJSONPlaceholderClient() as client:
+            results = await client.get_multiple_users([1, 2, 3, 4, 5], max_concurrent=2)
+
+            # graceful degradation検証
+            # 実装によって失敗時の挙動が異なる:
+            # - None返却パターン: len(results) == 5, results[1] is None
+            # - スキップパターン: len(results) == 3
+            # - 例外パターン: 全体が失敗
+            #
+            # 現在の実装は成功分のみ返却（スキップパターン）
+            assert len(results) == 3, f"Expected 3 successful results, got {len(results)}"
+            assert all(isinstance(r, dict) for r in results)
+
+            # 成功したID (1, 3, 5) のみ含まれる
+            result_ids = [r["id"] for r in results]
+            assert 1 in result_ids
+            assert 3 in result_ids
+            assert 5 in result_ids
+            assert 2 not in result_ids  # 失敗
+            assert 4 not in result_ids  # 失敗
 
 
 # ===============================================================================

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -506,7 +506,11 @@ class SyncJSONPlaceholderClient(SyncAPIClient):
             response = self.get("/users", params={"_limit": 1})
             return response.status_code == 200
         except Exception as e:
-            self.logger.warning("health_check_failed", error=str(e))
+            self.logger.warning(
+                "health_check_failed",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
             return False
 
 
@@ -958,7 +962,11 @@ class AsyncJSONPlaceholderClient(AsyncAPIClient):
             response = await self.get("/users", params={"_limit": 1})
             return response.status_code == 200
         except Exception as e:
-            self.logger.warning("health_check_failed", error=str(e))
+            self.logger.warning(
+                "health_check_failed",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
             return False
 
     # 複数ユーザー取得（Semaphore制御）


### PR DESCRIPTION
## 概要
PR#132の自動コードレビューで指摘された3点への対応を実施しました。

## 変更内容
- `tests/unit/test_async_client.py`: `test_partial_failure_graceful_degradation`テスト追加（76行）
- `utils/api_client.py`: health_check メソッドに `error_type` パラメータ追加（sync/async両方）
- `.env.example`: SENTRY__DSN のコメント解除とExample URL追加

## 変更理由
PR#132の自動コードレビュー検証プロセスで、以下の指摘が技術的に妥当と判断されました:

1. **test_partial_failure_graceful_degradation**: 既存テストは `graceful degradation` をdocstringで言及するも、実際のテストは全成功シナリオのみ。部分失敗時の動作検証が不足。
2. **error_type ロギング**: `health_check` の例外ログに `type(e).__name__` を追加し、Kubernetesトラブルシューティング時のエラー分類を改善。
3. **SENTRY__DSN ドキュメント**: PR#132で新規追加された `.env.example` にて、コメントアウトされたSENTRY__DSNにExample URL形式を追加。

## テスト方法
1. `uv run pytest tests/unit/test_async_client.py -v` でテスト実行
2. 全401テスト合格、カバレッジ83.06%達成

## チェックリスト
- [x] テスト追加・更新済み
- [x] ドキュメント更新済み（.env.example）
- [x] 破壊的変更なし

## 関連Issue
Refs #132, #133