### PR TITLE
[docs] /make-it-pretty をMediumカテゴリに追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1047,6 +1047,7 @@ AIが自動的に適切なPluginを発動するためのルール。詳細（パ
 | `/documentation-generator:update-docs` | ドキュメント更新時 | 一括同期・バッジ自動生成 |
 | `/security-pro:security-audit`, `/security-pro:dependency-audit` | 週次/リリース前 | セキュリティ・依存関係監査 |
 | `/performance-optimizer:performance-audit` | パフォーマンス懸念時 | ボトルネック特定・最適化 |
+| `/make-it-pretty` | 週次/スプリント境界 | 全体リファクタリング |
 
 ### Low（特定場面）
 


### PR DESCRIPTION
## 概要
/make-it-pretty コマンドをCLAUDE.mdのPlugin自動発動ルール（Mediumカテゴリ）に追加

## 変更内容
- CLAUDE.md:L1050: Mediumカテゴリに `/make-it-pretty` 行を追加
- 発動トリガー: 週次/スプリント境界
- 用途: 全体リファクタリング

## 変更理由
- /make-it-pretty コマンドに worktree安全機構、CLAUDE.md参照、プロジェクトワークフローを追加したため
- 週次/スプリント境界での定期実行を想定した Medium カテゴリ配置

## テスト方法
1. /make-it-pretty コマンド実行時にMediumカテゴリとして認識されることを確認
2. 週次実行トリガーが適切に機能することを確認

## チェックリスト
- [x] テスト追加・更新済み（N/A - ドキュメント変更のみ）
- [x] ドキュメント更新済み
- [x] 破壊的変更なし

## 関連作業
- グローバルファイル更新: ~/.claude/commands/make-it-pretty.md
  - Safety First セクション: worktreeベース安全機構に更新
  - Project Standards セクション: CLAUDE.md参照追加
  - Cleanup After Refactoring セクション: worktreeクリーンアップ手順追加
