### PR TITLE
[docs] CRITICAL RULES拡張とIssue-PR自動紐付けドキュメント追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1063,7 +1063,7 @@ AIが自動的に適切なPluginを発動するためのルール。詳細（パ
 2. PRテンプレートに `Closes #XXX` を自動挿入
 3. PR作成後、該当IssueにPR参照コメントを自動追加
 
-**エラーハンドリング**: 詳細は `/Users/yuta/.claude/commands/commit-push-pr.md` 270-464行参照
+**エラーハンドリング**: 詳細は `~/.claude/commands/commit-push-pr.md` 270-464行参照
 
 `/feature` スキルのブランチ命名規則:
 - Issue対応時: `issue-<番号>-<説明>` 形式を**強制**（バリデーション失敗 → エラー表示 → 作成中断）


### PR DESCRIPTION
## 概要
developブランチの最新2件のドキュメント更新をmainにマージします。

## 変更内容
- **CRITICAL RULES拡張**: AskUserQuestion使用要件を追加（11項目目）
- **Issue-PR自動紐付け**: `/commit-push-pr` と `/feature` スキルの自動紐付け機能をドキュメント化
- **Plugin分類更新**: `/make-it-pretty` をMediumカテゴリに移動

## 変更理由
- ユーザー選択が2つ以上ある場合、AskUserQuestionの使用を必須化し、AI判断の透明性を向上
- Issue-PR間のトレーサビリティ向上のため、自動紐付け機能の仕様を明文化
- Plugin使用頻度に基づき、分類を最適化

## テスト方法
1. CLAUDE.mdの「CRITICAL RULES」セクションを確認（11項目）
2. Issue-PR自動紐付けドキュメント（※6）を確認
3. Plugin自動発動ルールで `/make-it-pretty` がMediumカテゴリにあることを確認

## チェックリスト
- [x] テスト追加・更新済み（ドキュメント変更のため該当なし）
- [x] ドキュメント更新済み（本PR自体がドキュメント更新）
- [x] 破壊的変更なし

## 関連Issue
Closes #144
