### PR TITLE
[docs] PR#147レビュー2回目対応 - パス参照形式修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1063,7 +1063,7 @@ AIが自動的に適切なPluginを発動するためのルール。詳細（パ
 2. PRテンプレートに `Closes #XXX` を自動挿入
 3. PR作成後、該当IssueにPR参照コメントを自動追加
 
-**エラーハンドリング**: 詳細は `/Users/yuta/.claude/commands/commit-push-pr.md` 270-464行参照
+**エラーハンドリング**: 詳細は `~/.claude/commands/commit-push-pr.md` 270-464行参照
 
 `/feature` スキルのブランチ命名規則:
 - Issue対応時: `issue-<番号>-<説明>` 形式を**強制**（バリデーション失敗 → エラー表示 → 作成中断）


### PR DESCRIPTION
## 概要
PR#147のレビュー指摘2回目対応。エラーハンドリング参照パスを相対形式に修正。

## 変更内容
- CLAUDE.md:L1066: 絶対パス `/Users/yuta/...` → 相対パス `~/.claude/...` に変更

## 変更理由
レビュー指摘: 絶対パスは他環境で参照不可。個人開発プロジェクトのため、Option C（相対パス）を選択。
- チーム共有より保守性（DRY原則）を優先
- CLAUDE.md肥大化回避（ADR-007）

## テスト方法
1. markdownlint通過確認済み

## チェックリスト
- [x] ドキュメント更新済み
- [x] 破壊的変更なし

## 関連Issue
Refs #147
