### PR TITLE
[fix] Trivy DBキャッシュ修正リリース (#157)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,8 @@ jobs:
       # Step 1: Filesystem scan (both develop and main)
       - name: Trivy filesystem scan (dependencies)
         uses: aquasecurity/trivy-action@0.33.1
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -156,6 +158,7 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
           trivyignores: '.trivyignore'
+          cache: 'false'
 
       # Step 2: Docker image scan (main PRs only)
       - name: Build Docker image for scanning
@@ -171,6 +174,8 @@ jobs:
       - name: Trivy image scan (main PRs only)
         if: github.base_ref == 'main' && steps.docker-build.outcome == 'success'
         uses: aquasecurity/trivy-action@0.33.1
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
         with:
           image-ref: 'security-scan:${{ github.sha }}'
           format: 'table'
@@ -178,6 +183,7 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
           trivyignores: '.trivyignore'
+          cache: 'false'
 
       # Step 4: Cleanup Docker image (resource hygiene)
       - name: Clean up Docker image
@@ -235,6 +241,8 @@ jobs:
       - name: Trivy image scan (CRITICAL + HIGH)
         id: trivy-scan
         uses: aquasecurity/trivy-action@0.33.1
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
         with:
           image-ref: ${{ steps.image-tag.outputs.tag }}
           severity: 'CRITICAL,HIGH'
@@ -243,17 +251,35 @@ jobs:
           output: 'trivy-results.sarif'
           ignore-unfixed: true
           trivyignores: '.trivyignore'
+          cache: 'false'
         continue-on-error: true
 
       - name: Verify Trivy scan execution
         if: always()
         run: |
           if [ ! -f "trivy-results.sarif" ]; then
-            echo "::error::Trivy scan did not produce SARIF output (crash/timeout/disk issue)"
+            echo "::error::Trivy scan did not produce SARIF output"
+            echo "::warning::Possible causes: crash/timeout/disk issue/DB download failure"
             echo "Check 'Trivy image scan' step logs for details"
             exit 1
           fi
-          echo "✅ Trivy SARIF output verified"
+
+          # SARIF内容の妥当性確認（空ファイル・極小ファイル検出）
+          SARIF_SIZE=$(wc -c < "trivy-results.sarif")
+          if [ "$SARIF_SIZE" -lt 100 ]; then
+            echo "::error::SARIF file is too small ($SARIF_SIZE bytes) - likely incomplete"
+            echo "::warning::This indicates Trivy crashed during SARIF generation"
+            exit 1
+          fi
+
+          # JSON構文検証（破損ファイル検出）
+          if ! jq empty trivy-results.sarif 2>/dev/null; then
+            echo "::error::SARIF file is not valid JSON"
+            echo "::warning::File may be corrupted or incomplete"
+            exit 1
+          fi
+
+          echo "✅ Trivy SARIF output verified ($SARIF_SIZE bytes, valid JSON)"
 
       - name: Upload Trivy results to Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile - 4-stage Multi-stage builds
-# 最終更新: 2026年01月08日
+# 最終更新: 2026年01月29日
 # 品質基準: イメージサイズ < 200MB, ビルド時間 < 3分
 
 # ============================================================
@@ -7,7 +7,8 @@
 # ============================================================
 # セキュリティ: SHA256ダイジェスト固定（サプライチェーン攻撃防止）
 # 更新時: docker pull python:3.12-slim && docker inspect --format='{{index .RepoDigests 0}}' python:3.12-slim
-FROM python:3.12-slim@sha256:a75662dfec8d90bd7161c91050be2e0a9b21d284f3b7a7253d5db25f7d583fb3 AS base
+# 2026-01-29更新: 定期セキュリティパッチ適用（OpenSSL等）
+FROM python:3.12-slim@sha256:5e2dbd4bbdd9c0e67412aea9463906f74a22c60f89eb7b5bbb7d45b66a2b68a6 AS base
 
 WORKDIR /app
 


### PR DESCRIPTION
## 概要
Trivy DBキャッシュ無効化によるCVE検出ギャップの修正をmainブランチにリリース

## 変更内容
- Trivy DBキャッシュを無効化し、常に最新のDBを使用するよう変更
- SARIF検証強化（ファイルサイズチェック + JSON構文検証追加）
- Dockerfileのセキュリティパッチドキュメント更新

## 変更理由
キャッシュされた古いDBを使用することで、新しいCVEが検出されないギャップが発生していた

## テスト方法
1. CI全ジョブ通過確認（PR#157でテスト済み）
2. Trivyスキャン正常動作確認

## チェックリスト
- [x] テスト追加・更新済み
- [x] ドキュメント更新済み
- [x] 破壊的変更なし

## 関連Issue
Closes #156
