### PR TITLE
[feat] Claude Code ReviewにAST構造解析（ast-grep MCP）を統合

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,7 +28,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --allowedTools "Read,Glob,Grep,Task,WebFetch,WebSearch,TodoWrite,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --mcp-config '{"mcpServers": {"ast-grep": {"command": "npx", "args": ["-y", "@notprolands/ast-grep-mcp"]}}}'
+            --allowedTools "Read,Glob,Grep,Task,WebFetch,WebSearch,TodoWrite,mcp__github_inline_comment__create_inline_comment,mcp__ast-grep__find_code,mcp__ast-grep__find_code_by_rule,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
             /review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
## 概要

Claude Code ReviewワークフローにAST構造解析能力（ast-grep MCP）を追加し、コードレビューの精度を向上させる。

## 変更内容

- `.github/workflows/claude-code-review.yml`
  - `--mcp-config`でast-grep MCPサーバー設定を追加
  - `--allowedTools`に`mcp__ast-grep__find_code`と`mcp__ast-grep__find_code_by_rule`を追加

## 変更理由

テキストベースのGrepでは検出困難な以下のパターンをAST構造検索で検出可能にするため：
- `try: ... except: pass`（空except）
- 深いネスト（3層以上のif文）
- 未使用関数定義
- コメント内文字列とコード本体の区別

## テスト方法

1. このPRをマージ後、別のPRを作成
2. Claude Code Reviewが発火することを確認
3. GitHub Actionsログで`ast-grep MCP server is running`が表示されることを確認

## チェックリスト

- [x] yaml-lint検証済み
- [x] MCPサーバー動作確認済み（7ツール登録）
- [x] 破壊的変更なし（既存ツールは引き続き利用可能）

## 備考

- `@notprolands/ast-grep-mcp`パッケージはnpx経由で自動インストール（初回約10秒）
- バージョンピン留めなし（将来の安定性問題発生時に対応予定）