### PR TITLE
docs(rules): 並列タスク実行の安全なルール追加

### DIFF
--- a/.claude/rules/workflow/RULES.md
+++ b/.claude/rules/workflow/RULES.md
@@ -35,10 +35,13 @@ Practical rules for **api-test-devops-portfolio** project development with Claud
 - Session pattern: Load → Work → Checkpoint (30 min) → Save
 - Use `/sc:load` and `/sc:save` if superclaude available
 - **Parallel Dispatch Rule** (extension of "One task per subagent invocation" above — each agent still handles exactly one task): When 2+ independent TodoList tasks exist, dispatch each as a separate Task tool invocation (parallel recommended)
-  - Independence criteria (all must be satisfied): 1. No output dependency between tasks (no A→B ordering constraint) 2. No simultaneous edits to the same file 3. No conflicting writes to shared resources (examples: conftest.py, pyproject.toml, uv.lock, config files, .env files — when in doubt, treat as shared)
+  - Independence criteria (all must be satisfied):
+    1. No output dependency between tasks (no A→B ordering constraint)
+    2. No simultaneous edits to the same file
+    3. No conflicting **writes** to shared resources (examples: conftest.py, pyproject.toml, uv.lock, config files, .env files — read-only access does not count as conflicting; when write conflicts cannot be ruled out, treat as shared)
   - Worktree isolation: instruct each agent to invoke `/using-git-worktrees` skill in their prompt
-  - Exception: if one task is 3x+ larger than the other, sequential execution is acceptable
-  - On failure: if **any** agent reports failure or partial completion, the parent agent must (1) stop remaining parallel invocations, (2) collect and log status of all agents (success/failure/unknown), and (3) report complete status summary to the user before further action
+  - Exception: if one task has 3x+ more TodoWrite sub-items (or estimated file changes) than the other, sequential execution is acceptable
+  - On failure: if **any** agent reports failure or partial completion, the parent agent must (1) allow already-running invocations to complete (Task tool has no cancel API), (2) collect and log agent statuses (success/failure/unknown), and (3) report full status summary to user before further action
   - Silent continuation after ambiguous/empty results is prohibited
   - On completion: after all parallel agents complete, the parent agent must explicitly verify that each artifact exists in its expected final state before marking the parent task complete
 


### PR DESCRIPTION
## 概要
複数の独立したTodoListタスクを並列実行する際の
正式なルール（Parallel Dispatch Rule）を追加しました。

## 変更内容
- RULES.md の「Workflow Rules」セクションに Parallel Dispatch Rule を追加
- タスク独立性の判定基準（出力依存性、ファイル競合、リソース競合）を定義
- worktree分離戦略とエラーハンドリング方針を記載

## 詳細
- 独立タスク: 2個以上の場合は並列実行を推奨
- 独立性判定基準: 全3項目を満たす必要あり
  1. タスク間の出力依存性なし
  2. 同一ファイルの同時編集なし
  3. 共有リソースの書き込み競合なし
- worktree分離: 各エージェントが /using-git-worktrees を実行
- 例外: 片方が3倍以上大きい場合は順序実行可

## テスト
- [ ] ローカルレビュー完了
- [ ] CI/CDパイプライン確認

---
このPRは /push-pr スキルで自動生成されました。