### PR TITLE
docs(ci): developブランチのCI実行列を修正 (PR #176 review)

### DIFF
--- a/docs/guides/ci_cd_guide.md
+++ b/docs/guides/ci_cd_guide.md
@@ -132,7 +132,7 @@ uv run pytest -n auto -m "(unit or integration) and not external" \
 | ブランチ | 用途 | CI実行 | マージ先 |
 |---------|------|--------|---------|
 | `feature/*` | 新機能開発 | PR Validation + PR Security Scan | `develop` |
-| `develop` | 統合ブランチ | - | `main` |
+| `develop` | 統合ブランチ | PR Validation + PR Security Scan | `main` |
 | `main` | 本番環境 | Post-Merge + Deploy | - |
 | `hotfix/*` | 緊急修正 | PR Validation + PR Security Scan | `main` + `develop` |
 


### PR DESCRIPTION
## 概要
PR #176 のレビュー指摘対応。CI/CD ガイドの develop ブランチ行を修正しました。

## 変更内容
`docs/guides/ci_cd_guide.md` の Git Flow ブランチ戦略テーブル:
- develop 行の「CI実行」列を `-` から `PR Validation + PR Security Scan` に修正

develop ブランチを対象にした PR が作成されると、PR Validation と PR Security Scan が実行されることを明確化。

## テスト
- [x] ローカルで Markdown 構文確認済み
- [x] Git Workflow に基づいて検証済み

## 関連PR
Refs #176 (PR)

---
このPRは `/push-pr` スキルで自動生成されました。