### PR TITLE
refactor(test): reset_settings() fixtureの冗長なteardown呼出を削除

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -329,7 +329,6 @@ def reset_settings():
     """
     reload_settings()
     yield
-    reload_settings()
 
 
 # =============================================================================


### PR DESCRIPTION
## 概要
reset_settings() fixtureのyield後のreload_settings()呼出を削除。
各テストのsetup時に必ずreload_settings()が実行されるため、teardownでの再呼出は冗長。

## 変更内容
- tests/conftest.py: yield後のreload_settings()を1行削除

## テスト
- [x] ローカルテスト完了（491 passed / 93.20% coverage）
- [x] ruff 0 errors / mypy 0 errors
- [ ] CI/CD パイプライン確認

## 関連Issue/PR
Closes #214 (Issue)

---
このPRは /push-pr スキルで自動生成されました。