### PR TITLE
test(client): APIクライアント回帰テスト追加+DNSキャッシュ分離

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from typing import Any
 import pytest
 import pytest_asyncio
 
-from config.settings import reload_settings
+from config.settings import _resolve_hostname_cached, reload_settings
 from utils.api_client import AsyncAPIClient
 
 # =============================================================================
@@ -327,8 +327,10 @@ def reset_settings():
     将来的な並列実行（pytest -n auto）導入時に、
     グローバルシングルトンsettingsのテスト間汚染を防止
     """
+    _resolve_hostname_cached.cache_clear()
     reload_settings()
     yield
+    _resolve_hostname_cached.cache_clear()
 
 
 # =============================================================================

--- a/tests/unit/test_async_client.py
+++ b/tests/unit/test_async_client.py
@@ -2030,6 +2030,48 @@ async def test_async_client_timeout_zero_not_overridden() -> None:
         )
 
 
+async def test_async_client_retry_count_zero_not_overridden() -> None:
+    """retry_count=0がデフォルト設定値に上書きされないことを確認（r2850768833回帰テスト）
+
+    retry_count=0 はリトライ無効化を意味する有効な設定値。
+    falsyな値として `or` パターンで設定値に上書きされてはならない。
+
+    AsyncAPIClientは非同期コンテキストマネージャーのため async with で使用するが、
+    retry_count属性は __init__ で設定されるため、エントリー直後に検証可能。
+
+    学習ポイント:
+    - is not None パターンの必要性: 0/0.0/False 等の有効なfalsy値を保護する
+    - retry_count=0 の用途: リトライを行わず即座に失敗させたい場合に使用
+    - 非同期クライアントでも同期クライアントと同じコンストラクタ挙動を持つ
+    """
+    async with AsyncAPIClient(retry_count=0) as client:
+        assert client.retry_count == 0, (
+            "retry_count=0 はリトライ無効化を意味する有効な設定値のため"
+            "デフォルト設定値に上書きされてはならない"
+        )
+
+
+async def test_async_client_retry_delay_zero_not_overridden() -> None:
+    """retry_delay=0.0がデフォルト設定値に上書きされないことを確認（r2850768833回帰テスト）
+
+    retry_delay=0.0 はリトライ間の遅延なしを意味する有効な設定値。
+    falsyな値として `or` パターンで設定値に上書きされてはならない。
+
+    AsyncAPIClientは非同期コンテキストマネージャーのため async with で使用するが、
+    retry_delay属性は __init__ で設定されるため、エントリー直後に検証可能。
+
+    学習ポイント:
+    - is not None パターンの必要性: 0/0.0/False 等の有効なfalsy値を保護する
+    - retry_delay=0.0 の用途: リトライ間隔を0にして即座にリトライしたい場合に使用
+    - 非同期クライアントでも同期クライアントと同じコンストラクタ挙動を持つ
+    """
+    async with AsyncAPIClient(retry_delay=0.0) as client:
+        assert client.retry_delay == 0.0, (
+            "retry_delay=0.0 はリトライ遅延なしを意味する有効な設定値のため"
+            "デフォルト設定値に上書きされてはならない"
+        )
+
+
 # ===============================================================================
 # Test: AsyncJSONPlaceholderClient.get_users() - ユーザー一覧取得
 # ===============================================================================

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -7,6 +7,7 @@ GitHub API非同期クライアントのUnit Tests
 - カバレッジ目標: 80%以上
 """
 
+import asyncio
 from unittest.mock import ANY, Mock, patch
 
 import httpx
@@ -483,3 +484,50 @@ async def test_json_decode_error():
             await client.get_user("octocat")
 
     assert route.call_count == 1  # GETリクエストが1回発行されたことを確認
+
+
+# =============================================================================
+# システム例外伝播テスト（Issue #222）
+# =============================================================================
+
+
+async def test_system_exit_propagates_through_request():
+    """SystemExitが_requestメソッドを透過的に伝播することを検証
+
+    SystemExitはgraceful shutdown対応に不可欠であり、
+    汎用の例外ハンドラで捕捉・ラップしてはならない。
+    catchされるとプロセス終了シグナルが握りつぶされ、
+    コンテナオーケストレーション（K8s等）のライフサイクル管理が破綻する。
+    """
+    async with AsyncGitHubClient() as client:
+        with patch.object(client._client, "request", side_effect=SystemExit(1)):
+            with pytest.raises(SystemExit):
+                await client.get_user("octocat")
+
+
+async def test_memory_error_propagates_through_request():
+    """MemoryErrorが_requestメソッドを透過的に伝播することを検証
+
+    MemoryErrorはK8s OOMKilled等のリソース枯渇検知に不可欠であり、
+    汎用の例外ハンドラで捕捉・ラップしてはならない。
+    catchされるとOOM状態が隠蔽され、Podの再スケジューリングや
+    アラート発火が遅延し、カスケード障害の原因となる。
+    """
+    async with AsyncGitHubClient() as client:
+        with patch.object(client._client, "request", side_effect=MemoryError("Out of memory")):
+            with pytest.raises(MemoryError):
+                await client.get_user("octocat")
+
+
+async def test_cancelled_error_propagates_through_request():
+    """asyncio.CancelledErrorが_requestメソッドを透過的に伝播することを検証
+
+    CancelledErrorはasyncioタスクキャンセル伝播に不可欠であり、
+    汎用の例外ハンドラで捕捉・ラップしてはならない。
+    catchされるとTaskGroup/gather等のキャンセルチェーンが途切れ、
+    リソースリーク（未クローズのコネクション等）やデッドロックの原因となる。
+    """
+    async with AsyncGitHubClient() as client:
+        with patch.object(client._client, "request", side_effect=asyncio.CancelledError()):
+            with pytest.raises(asyncio.CancelledError):
+                await client.get_user("octocat")

--- a/tests/unit/test_sync_client.py
+++ b/tests/unit/test_sync_client.py
@@ -222,6 +222,40 @@ def test_sync_client_timeout_zero_not_overridden() -> None:
     )
 
 
+def test_sync_client_retry_count_zero_not_overridden() -> None:
+    """retry_count=0がデフォルト設定値に上書きされないことを確認（r2850768833回帰テスト）
+
+    retry_count=0 はリトライ無効化を意味する有効な設定値。
+    falsyな値として `or` パターンで設定値に上書きされてはならない。
+
+    学習ポイント:
+    - is not None パターンの必要性: 0/0.0/False 等の有効なfalsy値を保護する
+    - retry_count=0 の用途: リトライを行わず即座に失敗させたい場合に使用
+    """
+    client = SyncAPIClient(retry_count=0)
+    assert client.retry_count == 0, (
+        "retry_count=0 はリトライ無効化を意味する有効な設定値のため"
+        "デフォルト設定値に上書きされてはならない"
+    )
+
+
+def test_sync_client_retry_delay_zero_not_overridden() -> None:
+    """retry_delay=0.0がデフォルト設定値に上書きされないことを確認（r2850768833回帰テスト）
+
+    retry_delay=0.0 はリトライ間の遅延なしを意味する有効な設定値。
+    falsyな値として `or` パターンで設定値に上書きされてはならない。
+
+    学習ポイント:
+    - is not None パターンの必要性: 0/0.0/False 等の有効なfalsy値を保護する
+    - retry_delay=0.0 の用途: リトライ間隔を0にして即座にリトライしたい場合に使用
+    """
+    client = SyncAPIClient(retry_delay=0.0)
+    assert client.retry_delay == 0.0, (
+        "retry_delay=0.0 はリトライ遅延なしを意味する有効な設定値のため"
+        "デフォルト設定値に上書きされてはならない"
+    )
+
+
 # =============================================================================
 # 学習ポイント:
 #


### PR DESCRIPTION
## 概要
PR#213のis not None修正で不足していた回帰テストを追加し、テスト間のDNSキャッシュ汚染を防止。

## 変更内容
- `retry_count=0` / `retry_delay=0.0` 保持テスト4件追加（Sync/Async各2件）
- `SystemExit` / `MemoryError` / `asyncio.CancelledError` 伝播テスト3件追加
- `conftest.py` の `reset_settings()` に `_resolve_hostname_cached.cache_clear()` 追加

## 技術的判断
- github_clientのシステム例外テストでは`respx.mock`ではなく`patch.object`を使用（BaseExceptionサブクラスがrespx内部でキャッチされるため）
- Issue本文の`_resolve_hostname.cache_clear()`は誤り → 正しくは`_resolve_hostname_cached.cache_clear()`（`@lru_cache`は後者に付与）

## テスト
- [x] pytest: 498 passed / 93.28% coverage
- [x] ruff: All checks passed
- [x] mypy: no issues found

## 関連Issue/PR
Closes #222 (Issue)

---
このPRは /push-pr スキルで自動生成されました。