### PR TITLE
fix(ci): markdown-link-checkのエラーハンドリングを全トリガーで統一

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,6 +456,9 @@ jobs:
 
   # ============================================================
   # Stage 3.5: Weekly Link Check
+  # Role: Detailed log collection — runs all files with continue-on-error
+  #   and saves results as artifact (does not fail the workflow)
+  # Counterpart: markdown-link-check.yml acts as gate check (fails on broken links)
   # Triggers: schedule (Sunday 00:00 UTC)
   # Checks: markdown-link-check (external/internal links)
   # ============================================================

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -36,7 +36,6 @@ jobs:
 
       - name: Run markdown link check
         run: npm run lint:links
-        continue-on-error: ${{ github.event_name == 'schedule' }}
 
       - name: Run verbose check on failure (debug)
         if: failure()

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,5 +1,7 @@
 # Markdown Link Check Workflow
 # Validates internal and external links in all markdown files
+# Role: Gate check — fails the workflow on broken links (pass/fail verdict)
+# Counterpart: ci.yml weekly-link-check job collects detailed per-file logs as artifact
 # Runs on PR (markdown changes), weekly schedule, and manual dispatch
 
 name: Markdown Link Check


### PR DESCRIPTION
## 概要
schedule時のみ`continue-on-error: true`でリンク切れを許容する設計が、`if: failure()`デバッグステップの機能不全を招いていた。全トリガー（PR/schedule/workflow_dispatch）で厳格チェックに統一し、一貫性を確保。

## 変更内容
- `.github/workflows/markdown-link-check.yml`: `continue-on-error: ${{ github.event_name == 'schedule' }}` を削除（1行）

## 選択理由（案1: 全トリガーで厳格チェック）
1. markdown-link-checkの主目的は「リンク切れ検出」— エラー許容は目的に反する
2. `continue-on-error`により`failure()`デバッグステップがschedule時に発火しない二重障害パターンの解消
3. 実装コスト最小（1行削除）
4. 外部リンク障害は通常一時的（数時間以内に復旧）

## テスト
- [x] ローカル品質ゲート: 551 tests passed / 93.37% coverage / ruff 0 errors / mypy 0 errors
- [ ] CI/CD パイプライン確認

## 関連Issue/PR
Closes #188 (Issue)

前提Issue #186（同ファイルのサイレント障害修正）は PR #260 で対応済み。

---
このPRは /push-pr スキルで自動生成されました。