### PR TITLE
fix(client): main()の例外キャッチをAPIClientErrorに限定

### DIFF
--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -1288,7 +1288,7 @@ def main() -> None:
             print(f"  - Created post ID: {new_post.get('id', 'N/A')}")
             print(f"  - Title: {new_post.get('title', 'N/A')}")
 
-        except Exception as e:
+        except APIClientError as e:
             print(f"エラーが発生しました: {e}")
             if settings.debug:
                 import traceback


### PR DESCRIPTION
## 概要
main()デモ関数の例外キャッチを `except Exception` から `except APIClientError` に変更。coding-standards.md Section 5「階層的例外設計」規約への準拠。

## 変更内容
- utils/api_client.py: 1行変更（L1291）

## テスト
- [x] ローカルテスト完了（556 tests passed / 93.53% coverage）
- [ ] CI/CD パイプライン確認

## 関連Issue/PR
Closes #227 (Issue)

---
このPRは /push-pr スキルで自動生成されました。