### PR TITLE
fix(github_client): Rate LimitヘッダーのValueErrorを適切にハンドリング

### DIFF
--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -687,3 +687,45 @@ async def test_invalid_rate_limit_reset_header_low_remaining():
     # フォールバック: reset_time=0 → epoch（1970-01-01T00:00:00+00:00）
     expected_reset_time = datetime(1970, 1, 1, 0, 0, tzinfo=UTC).isoformat()
     assert rate_limit_low_logs[0]["reset_time"] == expected_reset_time
+
+
+@respx.mock
+async def test_invalid_rate_limit_reset_header_rate_limit_exceeded():
+    """rate_remaining==0かつX-RateLimit-Resetが不正値の場合、警告ログ後RateLimitError発生
+
+    検証項目:
+    - RateLimitError が発生すること（rate_remaining==0のため）
+    - invalid_rate_limit_header warning ログが2件出力されること
+      （L293の共通remaining<10チェックパス + L341の403固有rate_remaining==0パスの両方）
+    - rate_limit_low warning ログが1件出力されること（remaining=0 < 10）
+    - header="X-RateLimit-Reset", value="broken" がログに含まれること
+    """
+    respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        status_code=403,
+        json={"message": "Forbidden"},
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "broken",
+        },
+    )
+
+    with capture_logs() as log_output:
+        async with AsyncGitHubClient() as client:
+            with pytest.raises(RateLimitError):
+                await client.get_user("octocat")
+
+    # invalid_rate_limit_header warningが2件（共通パス + 403固有パス）
+    invalid_header_logs = [
+        log for log in log_output if log.get("event") == "invalid_rate_limit_header"
+    ]
+    assert len(invalid_header_logs) == 2
+    for log_entry in invalid_header_logs:
+        assert log_entry["log_level"] == "warning"
+        assert log_entry["header"] == "X-RateLimit-Reset"
+        assert log_entry["value"] == "broken"
+
+    # rate_limit_low warningが1件（remaining=0 < 10）
+    rate_limit_low_logs = [log for log in log_output if log.get("event") == "rate_limit_low"]
+    assert len(rate_limit_low_logs) == 1
+    assert rate_limit_low_logs[0]["log_level"] == "warning"
+    assert rate_limit_low_logs[0]["remaining"] == 0

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -578,3 +578,66 @@ async def test_base_exception_propagates_through_request(
         with patch.object(client._client, "request", side_effect=exception_class(*exception_args)):
             with pytest.raises(exception_class):
                 await client.get_user("octocat")
+
+
+# =============================================================================
+# Rate Limitヘッダー不正値テスト（Issue #230）
+# =============================================================================
+
+
+@respx.mock
+async def test_invalid_rate_limit_header_remaining():
+    """X-RateLimit-Remaining に不正値が含まれる場合、warningログ出力して処理継続
+
+    検証項目:
+    - ValueError が外部に伝播しないこと（正常完了）
+    - invalid_rate_limit_header warning ログが出力されること
+    - header/value フィールドがログに含まれること
+    """
+    respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        status_code=200,
+        json={"login": "octocat"},
+        headers={"X-RateLimit-Remaining": "N/A"},
+    )
+
+    with capture_logs() as log_output:
+        async with AsyncGitHubClient() as client:
+            result = await client.get_user("octocat")
+
+    assert result["login"] == "octocat"
+    warning_logs = [log for log in log_output if log.get("event") == "invalid_rate_limit_header"]
+    assert len(warning_logs) == 1
+    assert warning_logs[0]["log_level"] == "warning"
+    assert warning_logs[0]["header"] == "X-RateLimit-Remaining"
+    assert warning_logs[0]["value"] == "N/A"
+
+
+@respx.mock
+async def test_invalid_rate_limit_header_403():
+    """403応答時に X-RateLimit-Remaining が不正値の場合、warningログ後 GitHubAPIError 発生
+
+    検証項目:
+    - RateLimitError ではなく GitHubAPIError（Access forbidden）が発生すること
+    - invalid_rate_limit_header warning ログが2件出力されること
+      （共通Rate Limit監視パス + 403固有パスの両方でValueErrorが発生）
+    - header/value フィールドがログに含まれること
+    """
+    respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        status_code=403,
+        json={"message": "Forbidden"},
+        headers={"X-RateLimit-Remaining": "invalid"},
+    )
+
+    with capture_logs() as log_output:
+        async with AsyncGitHubClient() as client:
+            with pytest.raises(GitHubAPIError, match="Access forbidden") as exc_info:
+                await client.get_user("octocat")
+
+    assert not isinstance(exc_info.value, RateLimitError)
+    warning_logs = [log for log in log_output if log.get("event") == "invalid_rate_limit_header"]
+    # 共通パス（remaining監視）と403固有パス（rate_remaining判定）の2箇所でwarning発生
+    assert len(warning_logs) == 2
+    for log_entry in warning_logs:
+        assert log_entry["log_level"] == "warning"
+        assert log_entry["header"] == "X-RateLimit-Remaining"
+        assert log_entry["value"] == "invalid"

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -620,7 +620,8 @@ async def test_invalid_rate_limit_header_403():
     検証項目:
     - RateLimitError ではなく GitHubAPIError（Access forbidden）が発生すること
     - invalid_rate_limit_header warning ログが2件出力されること
-      （共通Rate Limit監視パス + 403固有パスの両方でValueErrorが発生）
+      （X-RateLimit-Remainingを共通パス（remaining監視）と403固有パス
+       （rate_remaining判定）の2箇所で読み取り、どちらもValueError発生）
     - header/value フィールドがログに含まれること
     """
     respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -641,3 +641,50 @@ async def test_invalid_rate_limit_header_403():
         assert log_entry["log_level"] == "warning"
         assert log_entry["header"] == "X-RateLimit-Remaining"
         assert log_entry["value"] == "invalid"
+
+
+@respx.mock
+async def test_invalid_rate_limit_reset_header_low_remaining():
+    """remaining<10かつX-RateLimit-Resetが不正値の場合、2つのwarningログを出力して処理継続
+
+    検証項目:
+    - ValueError が外部に伝播しないこと（正常完了）
+    - invalid_rate_limit_header warning ログが出力されること
+      （header="X-RateLimit-Reset", value="not-a-timestamp"）
+    - rate_limit_low warning ログが出力されること（remaining=5）
+    - reset_time はフォールバック値（epoch: 1970-01-01T00:00:00+00:00）になること
+    """
+    from datetime import UTC, datetime
+
+    respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        status_code=200,
+        json={"login": "octocat"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Reset": "not-a-timestamp",
+        },
+    )
+
+    with capture_logs() as log_output:
+        async with AsyncGitHubClient() as client:
+            result = await client.get_user("octocat")
+
+    assert result["login"] == "octocat"
+
+    # invalid_rate_limit_header warning（X-RateLimit-Reset不正値）
+    invalid_header_logs = [
+        log for log in log_output if log.get("event") == "invalid_rate_limit_header"
+    ]
+    assert len(invalid_header_logs) == 1
+    assert invalid_header_logs[0]["log_level"] == "warning"
+    assert invalid_header_logs[0]["header"] == "X-RateLimit-Reset"
+    assert invalid_header_logs[0]["value"] == "not-a-timestamp"
+
+    # rate_limit_low warning（remaining=5 < 10）
+    rate_limit_low_logs = [log for log in log_output if log.get("event") == "rate_limit_low"]
+    assert len(rate_limit_low_logs) == 1
+    assert rate_limit_low_logs[0]["log_level"] == "warning"
+    assert rate_limit_low_logs[0]["remaining"] == 5
+    # フォールバック: reset_time=0 → epoch（1970-01-01T00:00:00+00:00）
+    expected_reset_time = datetime(1970, 1, 1, 0, 0, tzinfo=UTC).isoformat()
+    assert rate_limit_low_logs[0]["reset_time"] == expected_reset_time

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -8,6 +8,7 @@ GitHub API非同期クライアントのUnit Tests
 """
 
 import asyncio
+from datetime import UTC, datetime
 from unittest.mock import ANY, Mock, patch
 
 import httpx
@@ -654,8 +655,6 @@ async def test_invalid_rate_limit_reset_header_low_remaining():
     - rate_limit_low warning ログが出力されること（remaining=5）
     - reset_time はフォールバック値（epoch: 1970-01-01T00:00:00+00:00）になること
     """
-    from datetime import UTC, datetime
-
     respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
         status_code=200,
         json={"login": "octocat"},

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -231,6 +231,27 @@ class AsyncGitHubClient:
             raise GitHubAPIError(f"Expected dict response, got {type(result).__name__}")
         return result
 
+    def _parse_rate_limit_header(self, headers: httpx.Headers, name: str, default: int) -> int:
+        """Rate Limitヘッダーを安全にパースする。
+
+        Args:
+            headers: HTTPレスポンスヘッダー
+            name: ヘッダー名（例: "X-RateLimit-Remaining"）
+            default: パース失敗時のフォールバック値
+
+        Returns:
+            パース済み整数値、またはデフォルト値
+        """
+        try:
+            return int(headers.get(name, default))
+        except ValueError:
+            self.logger.warning(
+                "invalid_rate_limit_header",
+                header=name,
+                value=headers.get(name),
+            )
+            return default
+
     async def _request(  # noqa: C901 - 統合HTTPリクエスト処理（Rate Limit/ETag/リトライ統合）のため許容
         self,
         method: str,
@@ -279,25 +300,13 @@ class AsyncGitHubClient:
                 )
 
                 # Rate Limit監視
-                try:
-                    remaining = int(response.headers.get("X-RateLimit-Remaining", 999))
-                except ValueError:
-                    self.logger.warning(
-                        "invalid_rate_limit_header",
-                        header="X-RateLimit-Remaining",
-                        value=response.headers.get("X-RateLimit-Remaining"),
-                    )
-                    remaining = 999  # フォールバック: 残量十分と見なす
+                remaining = self._parse_rate_limit_header(
+                    response.headers, "X-RateLimit-Remaining", 999
+                )  # フォールバック: 残量十分と見なす
                 if remaining < 10:
-                    try:
-                        reset_time = int(response.headers.get("X-RateLimit-Reset", 0))
-                    except ValueError:
-                        self.logger.warning(
-                            "invalid_rate_limit_header",
-                            header="X-RateLimit-Reset",
-                            value=response.headers.get("X-RateLimit-Reset"),
-                        )
-                        reset_time = 0  # フォールバック: リセット時刻不明
+                    reset_time = self._parse_rate_limit_header(
+                        response.headers, "X-RateLimit-Reset", 0
+                    )  # フォールバック: リセット時刻不明
                     reset_dt = datetime.fromtimestamp(reset_time, tz=UTC)
                     self.logger.warning(
                         "rate_limit_low",
@@ -327,26 +336,14 @@ class AsyncGitHubClient:
 
                 if response.status_code == 403:
                     # 403判定: Rate Limit超過 vs その他のアクセス禁止
-                    try:
-                        rate_remaining = int(response.headers.get("X-RateLimit-Remaining", -1))
-                    except ValueError:
-                        self.logger.warning(
-                            "invalid_rate_limit_header",
-                            header="X-RateLimit-Remaining",
-                            value=response.headers.get("X-RateLimit-Remaining"),
-                        )
-                        rate_remaining = -1  # フォールバック: rate limit起因でないと見なす
+                    rate_remaining = self._parse_rate_limit_header(
+                        response.headers, "X-RateLimit-Remaining", -1
+                    )  # フォールバック: rate limit起因でないと見なす
                     if rate_remaining == 0:
                         # Rate Limit超過確定
-                        try:
-                            reset_time = int(response.headers.get("X-RateLimit-Reset", 0))
-                        except ValueError:
-                            self.logger.warning(
-                                "invalid_rate_limit_header",
-                                header="X-RateLimit-Reset",
-                                value=response.headers.get("X-RateLimit-Reset"),
-                            )
-                            reset_time = 0  # フォールバック: リセット時刻不明
+                        reset_time = self._parse_rate_limit_header(
+                            response.headers, "X-RateLimit-Reset", 0
+                        )  # フォールバック: リセット時刻不明
                         raise RateLimitError(reset_time)
                     # その他の403エラー（IPブロック、アクセス権限不足等）
                     error_message = "Access forbidden"

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -279,9 +279,25 @@ class AsyncGitHubClient:
                 )
 
                 # Rate Limit監視
-                remaining = int(response.headers.get("X-RateLimit-Remaining", 999))
+                try:
+                    remaining = int(response.headers.get("X-RateLimit-Remaining", 999))
+                except ValueError:
+                    self.logger.warning(
+                        "invalid_rate_limit_header",
+                        header="X-RateLimit-Remaining",
+                        value=response.headers.get("X-RateLimit-Remaining"),
+                    )
+                    remaining = 999  # フォールバック: 残量十分と見なす
                 if remaining < 10:
-                    reset_time = int(response.headers.get("X-RateLimit-Reset", 0))
+                    try:
+                        reset_time = int(response.headers.get("X-RateLimit-Reset", 0))
+                    except ValueError:
+                        self.logger.warning(
+                            "invalid_rate_limit_header",
+                            header="X-RateLimit-Reset",
+                            value=response.headers.get("X-RateLimit-Reset"),
+                        )
+                        reset_time = 0  # フォールバック: リセット時刻不明
                     reset_dt = datetime.fromtimestamp(reset_time, tz=UTC)
                     self.logger.warning(
                         "rate_limit_low",
@@ -311,10 +327,26 @@ class AsyncGitHubClient:
 
                 if response.status_code == 403:
                     # 403判定: Rate Limit超過 vs その他のアクセス禁止
-                    rate_remaining = int(response.headers.get("X-RateLimit-Remaining", -1))
+                    try:
+                        rate_remaining = int(response.headers.get("X-RateLimit-Remaining", -1))
+                    except ValueError:
+                        self.logger.warning(
+                            "invalid_rate_limit_header",
+                            header="X-RateLimit-Remaining",
+                            value=response.headers.get("X-RateLimit-Remaining"),
+                        )
+                        rate_remaining = -1  # フォールバック: rate limit起因でないと見なす
                     if rate_remaining == 0:
                         # Rate Limit超過確定
-                        reset_time = int(response.headers.get("X-RateLimit-Reset", 0))
+                        try:
+                            reset_time = int(response.headers.get("X-RateLimit-Reset", 0))
+                        except ValueError:
+                            self.logger.warning(
+                                "invalid_rate_limit_header",
+                                header="X-RateLimit-Reset",
+                                value=response.headers.get("X-RateLimit-Reset"),
+                            )
+                            reset_time = 0  # フォールバック: リセット時刻不明
                         raise RateLimitError(reset_time)
                     # その他の403エラー（IPブロック、アクセス権限不足等）
                     error_message = "Access forbidden"
@@ -392,7 +424,7 @@ class AsyncGitHubClient:
                 self.logger.warning("request_timeout", endpoint=endpoint, method=method)
                 raise GitHubAPIError(f"Request timeout: {e}") from e
 
-            except (KeyboardInterrupt, SystemExit, MemoryError, asyncio.CancelledError):
+            except KeyboardInterrupt, SystemExit, MemoryError, asyncio.CancelledError:
                 # システム例外は再発生
                 # - KeyboardInterrupt/SystemExit: graceful shutdown対応
                 # - MemoryError: K8s OOMKilled等のリソース枯渇検知


### PR DESCRIPTION
## 概要

GitHub API レスポンスの Rate Limit ヘッダー（, ）が非数値の場合、`int()` 変換で `ValueError` が発生し、汎用エラーハンドラーに捕捉されて「Unexpected error」として再送出されていた問題を修正。ログから Root Cause を特定できない問題を解消する。

## 変更内容

- `utils/github_client.py`: 4箇所の `int()` 変換を `try/except ValueError` で保護
  - L282: 共通 Rate Limit 監視パス（`X-RateLimit-Remaining`）
  - L292: 残量低下時（`X-RateLimit-Reset`）
  - L327: 403応答固有パス（`X-RateLimit-Remaining`）
  - L342: Rate Limit 超過確定時（`X-RateLimit-Reset`）
- フォールバック値: `remaining=999`（継続可と見なす）、`rate_remaining=-1`（rate limit起因でないと見なす）、`reset_time=0`
- 不正ヘッダー時に `invalid_rate_limit_header` warning ログ（header/valueフィールド付き）を出力

```
 tests/unit/test_github_client.py | 63 ++++++++++++++++++
 utils/github_client.py           | 42 +++++++++++++---
 2 files changed, 100 insertions(+), 5 deletions(-)
```

## テスト

- [x] `test_invalid_rate_limit_header_remaining`: 200応答で不正ヘッダー → warning ログ + 正常完了
- [x] `test_invalid_rate_limit_header_403`: 403応答で不正ヘッダー → 2件 warning + `GitHubAPIError`（`RateLimitError` ではない）
- [x] 品質ゲート: 558 tests passed / 93.13% coverage / ruff 0 errors / mypy 0 errors

## 関連Issue/PR

Closes #230 (Issue)

---
このPRは /push-pr スキルで自動生成されました。

## Review Response (2026-03-19)

| 分類 | 件数 | 対応 |
|------|------|------|
| AUTO-FIX | 0件 | - |
| NEEDS-DECISION (修正) | 4件 | テスト追加×2 + docstring修正 + ヘルパー抽出 |
| SKIP | 3件 | pushback返信済み |

コミット: `345a9ab`〜`975650d`（5コミット）
