### PR TITLE
test(github): validate_github_repoのセキュリティ境界テストを追加

### DIFF
--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -591,6 +591,17 @@ def test_repo_validation_valid() -> None:
     validate_github_repo("my-repo")
     validate_github_repo("a")
     validate_github_repo("a" * 100)  # 上限（100文字）
+    validate_github_repo("my_repo")  # アンダースコア
+    validate_github_repo("my.repo")  # ドットを含む名前
+    validate_github_repo("123")  # 数字のみ
+
+
+def test_repo_validation_dot_series_currently_allowed() -> None:
+    """'.'/'..': 現在のREGEXをパスする（既知の許容動作）"""
+    # GITHUB_REPO_PATTERN はドットを許可するため '.' と '..' はValueErrorにならない
+    # GitHubでは予約済みだが本バリデーション関数ではブロックしない（許容として文書化）
+    validate_github_repo(".")
+    validate_github_repo("..")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -20,6 +20,7 @@ from utils.github_client import (
     GitHubServerError,
     NotFoundError,
     RateLimitError,
+    validate_github_repo,
 )
 
 pytestmark = pytest.mark.unit
@@ -521,3 +522,39 @@ async def test_base_exception_propagates_through_request(
         with patch.object(client._client, "request", side_effect=exception_class(*exception_args)):
             with pytest.raises(exception_class):
                 await client.get_user("octocat")
+
+
+# =============================================================================
+# validate_github_repo バリデーションテスト
+# =============================================================================
+
+
+def test_repo_validation_valid() -> None:
+    """有効なリポジトリ名でValueError未発生を確認"""
+    validate_github_repo("my-repo")
+    validate_github_repo("a")
+    validate_github_repo("a" * 100)  # 上限（100文字）
+
+
+def test_repo_validation_invalid() -> None:
+    """無効なリポジトリ名でValueError発生（セキュリティ境界テスト）
+
+    GITHUB_REPO_PATTERN = r"^[a-zA-Z0-9._-]{1,100}$" に基づく検証。
+    Path Traversal・文字数超過・空文字列・特殊文字の4境界をテストする。
+    バリデーションはHTTPリクエスト前に完了するため非同期不要。
+    """
+    # Path Traversal攻撃パターン（'/'はREGEX許可文字外）
+    with pytest.raises(ValueError, match="Invalid GitHub repository name"):
+        validate_github_repo("../etc/passwd")
+
+    # 文字数上限超過（101文字 > 上限100文字）
+    with pytest.raises(ValueError, match="Invalid GitHub repository name"):
+        validate_github_repo("a" * 101)
+
+    # 空文字列（not repoでキャッチ）
+    with pytest.raises(ValueError, match="Invalid GitHub repository name"):
+        validate_github_repo("")
+
+    # 特殊文字（スペース・! はREGEX許可文字外）
+    with pytest.raises(ValueError, match="Invalid GitHub repository name"):
+        validate_github_repo("repo name!")

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -586,22 +586,20 @@ async def test_base_exception_propagates_through_request(
 # =============================================================================
 
 
-def test_repo_validation_valid() -> None:
+@pytest.mark.parametrize(
+    "repo",
+    [
+        pytest.param("my-repo", id="hyphen"),
+        pytest.param("a", id="single_char"),
+        pytest.param("a" * 100, id="max_length"),  # 上限（100文字）
+        pytest.param("my_repo", id="underscore"),
+        pytest.param("my.repo", id="dot"),
+        pytest.param("123", id="digits_only"),
+    ],
+)
+def test_repo_validation_valid(repo: str) -> None:
     """有効なリポジトリ名でValueError未発生を確認"""
-    validate_github_repo("my-repo")
-    validate_github_repo("a")
-    validate_github_repo("a" * 100)  # 上限（100文字）
-    validate_github_repo("my_repo")  # アンダースコア
-    validate_github_repo("my.repo")  # ドットを含む名前
-    validate_github_repo("123")  # 数字のみ
-
-
-def test_repo_validation_dot_series_currently_allowed() -> None:
-    """'.'/'..': 現在のREGEXをパスする（既知の許容動作）"""
-    # GITHUB_REPO_PATTERN はドットを許可するため '.' と '..' はValueErrorにならない
-    # GitHubでは予約済みだが本バリデーション関数ではブロックしない（許容として文書化）
-    validate_github_repo(".")
-    validate_github_repo("..")
+    assert validate_github_repo(repo) is None
 
 
 @pytest.mark.parametrize(
@@ -617,6 +615,9 @@ def test_repo_validation_dot_series_currently_allowed() -> None:
         pytest.param("repo name!", id="special_chars"),
         # NULLバイトインジェクション（REGEXが[a-zA-Z0-9._-]のみ許可のため拒否）
         pytest.param("repo\x00name", id="null_byte"),
+        # URLパスインジェクション防止（repos/. や repos/.. になる）
+        pytest.param(".", id="dot_single"),
+        pytest.param("..", id="dot_double"),
     ],
 )
 def test_repo_validation_invalid(repo: str) -> None:

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -551,7 +551,7 @@ def test_repo_validation_invalid() -> None:
     with pytest.raises(ValueError, match="Invalid GitHub repository name"):
         validate_github_repo("a" * 101)
 
-    # 空文字列（not repoでキャッチ）
+    # 空文字列（`not repo` が True → REGEX到達前にValueError）
     with pytest.raises(ValueError, match="Invalid GitHub repository name"):
         validate_github_repo("")
 

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -611,7 +611,7 @@ def test_repo_validation_dot_series_currently_allowed() -> None:
         pytest.param("../etc/passwd", id="path_traversal"),
         # 文字数上限超過（101文字 > 上限100文字）
         pytest.param("a" * 101, id="too_long"),
-        # not repoによる短絡評価 + REGEXも{1,100}により空文字列を拒否
+        # not repoによる短絡評価で拒否（REGEX は実行されない）
         pytest.param("", id="empty_string"),
         # 特殊文字（スペース・!はREGEX許可文字外）
         pytest.param("repo name!", id="special_chars"),

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -593,25 +593,22 @@ def test_repo_validation_valid() -> None:
     validate_github_repo("a" * 100)  # 上限（100文字）
 
 
-def test_repo_validation_invalid() -> None:
-    """無効なリポジトリ名でValueError発生（セキュリティ境界テスト）
-
-    GITHUB_REPO_PATTERN = r"^[a-zA-Z0-9._-]{1,100}$" に基づく検証。
-    Path Traversal・文字数超過・空文字列・特殊文字の4境界をテストする。
-    バリデーションはHTTPリクエスト前に完了するため非同期不要。
-    """
-    # Path Traversal攻撃パターン（'/'はREGEX許可文字外）
+@pytest.mark.parametrize(
+    "repo",
+    [
+        # Path Traversal攻撃パターン（'/'はREGEX許可文字外）
+        pytest.param("../etc/passwd", id="path_traversal"),
+        # 文字数上限超過（101文字 > 上限100文字）
+        pytest.param("a" * 101, id="too_long"),
+        # not repoによる短絡評価 + REGEXも{1,100}により空文字列を拒否
+        pytest.param("", id="empty_string"),
+        # 特殊文字（スペース・!はREGEX許可文字外）
+        pytest.param("repo name!", id="special_chars"),
+        # NULLバイトインジェクション（REGEXが[a-zA-Z0-9._-]のみ許可のため拒否）
+        pytest.param("repo\x00name", id="null_byte"),
+    ],
+)
+def test_repo_validation_invalid(repo: str) -> None:
+    """無効なリポジトリ名でValueError発生（セキュリティ境界テスト）"""
     with pytest.raises(ValueError, match="Invalid GitHub repository name"):
-        validate_github_repo("../etc/passwd")
-
-    # 文字数上限超過（101文字 > 上限100文字）
-    with pytest.raises(ValueError, match="Invalid GitHub repository name"):
-        validate_github_repo("a" * 101)
-
-    # 空文字列（`not repo` が True → REGEX到達前にValueError）
-    with pytest.raises(ValueError, match="Invalid GitHub repository name"):
-        validate_github_repo("")
-
-    # 特殊文字（スペース・! はREGEX許可文字外）
-    with pytest.raises(ValueError, match="Invalid GitHub repository name"):
-        validate_github_repo("repo name!")
+        validate_github_repo(repo)

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -599,13 +599,14 @@ async def test_base_exception_propagates_through_request(
 )
 def test_repo_validation_valid(repo: str) -> None:
     """有効なリポジトリ名でValueError未発生を確認"""
-    assert validate_github_repo(repo) is None
+    validate_github_repo(repo)  # -> None: ValueError未発生 = 成功（例外がpytestに伝播すれば失敗）
 
 
 @pytest.mark.parametrize(
     "repo",
     [
-        # Path Traversal攻撃パターン（'/'はREGEX許可文字外）
+        # Path Traversal: '/'がREGEX許可文字外（[a-zA-Z0-9._-]）のため拒否
+        # （先頭の'..'はREGEX通過するが、'/'を含む文字列全体が拒否される）
         pytest.param("../etc/passwd", id="path_traversal"),
         # 文字数上限超過（101文字 > 上限100文字）
         pytest.param("a" * 101, id="too_long"),
@@ -615,7 +616,8 @@ def test_repo_validation_valid(repo: str) -> None:
         pytest.param("repo name!", id="special_chars"),
         # NULLバイトインジェクション（REGEXが[a-zA-Z0-9._-]のみ許可のため拒否）
         pytest.param("repo\x00name", id="null_byte"),
-        # URLパスインジェクション防止（repos/. や repos/.. になる）
+        # URLパスインジェクション防止: '.'/'..'' は REGEX許可文字 [a-zA-Z0-9._-] を通過するが
+        # repo in {".", ".."} の明示チェックで拒否（repos/. や repos/.. を防ぐ）
         pytest.param(".", id="dot_single"),
         pytest.param("..", id="dot_double"),
     ],

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -599,25 +599,17 @@ async def test_base_exception_propagates_through_request(
 )
 def test_repo_validation_valid(repo: str) -> None:
     """有効なリポジトリ名でValueError未発生を確認"""
-    validate_github_repo(repo)  # -> None: ValueError未発生 = 成功（例外がpytestに伝播すれば失敗）
+    validate_github_repo(repo)
 
 
 @pytest.mark.parametrize(
     "repo",
     [
-        # Path Traversal: '/'がREGEX許可文字外（[a-zA-Z0-9._-]）のため拒否
-        # （先頭の'..'はREGEX通過するが、'/'を含む文字列全体が拒否される）
         pytest.param("../etc/passwd", id="path_traversal"),
-        # 文字数上限超過（101文字 > 上限100文字）
         pytest.param("a" * 101, id="too_long"),
-        # not repoによる短絡評価で拒否（REGEX は実行されない）
         pytest.param("", id="empty_string"),
-        # 特殊文字（スペース・!はREGEX許可文字外）
         pytest.param("repo name!", id="special_chars"),
-        # NULLバイトインジェクション（REGEXが[a-zA-Z0-9._-]のみ許可のため拒否）
         pytest.param("repo\x00name", id="null_byte"),
-        # URLパスインジェクション防止: '.'/'..'' は REGEX許可文字 [a-zA-Z0-9._-] を通過するが
-        # repo in {".", ".."} の明示チェックで拒否（repos/. や repos/.. を防ぐ）
         pytest.param(".", id="dot_single"),
         pytest.param("..", id="dot_double"),
     ],

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -392,12 +392,7 @@ class AsyncGitHubClient:
                 self.logger.warning("request_timeout", endpoint=endpoint, method=method)
                 raise GitHubAPIError(f"Request timeout: {e}") from e
 
-            except (  # fmt: skip  # noqa: E722 - Python 3構文（括弧必須）、ruff-format除外
-                KeyboardInterrupt,
-                SystemExit,
-                MemoryError,
-                asyncio.CancelledError,
-            ):
+            except KeyboardInterrupt, SystemExit, MemoryError, asyncio.CancelledError:
                 # システム例外は再発生
                 # - KeyboardInterrupt/SystemExit: graceful shutdown対応
                 # - MemoryError: K8s OOMKilled等のリソース枯渇検知

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -57,7 +57,7 @@ def validate_github_repo(repo: str) -> None:
         ValueError: バリデーション失敗
 
     """
-    if not repo or not GITHUB_REPO_PATTERN.match(repo):
+    if not repo or repo in {".", ".."} or not GITHUB_REPO_PATTERN.match(repo):
         raise ValueError(f"Invalid GitHub repository name: '{repo}'")
 
 
@@ -392,7 +392,7 @@ class AsyncGitHubClient:
                 self.logger.warning("request_timeout", endpoint=endpoint, method=method)
                 raise GitHubAPIError(f"Request timeout: {e}") from e
 
-            except (KeyboardInterrupt, SystemExit, MemoryError, asyncio.CancelledError):
+            except KeyboardInterrupt, SystemExit, MemoryError, asyncio.CancelledError:
                 # システム例外は再発生
                 # - KeyboardInterrupt/SystemExit: graceful shutdown対応
                 # - MemoryError: K8s OOMKilled等のリソース枯渇検知

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -392,7 +392,12 @@ class AsyncGitHubClient:
                 self.logger.warning("request_timeout", endpoint=endpoint, method=method)
                 raise GitHubAPIError(f"Request timeout: {e}") from e
 
-            except KeyboardInterrupt, SystemExit, MemoryError, asyncio.CancelledError:
+            except (  # fmt: skip  # noqa: E722 - Python 3構文（括弧必須）、ruff-format除外
+                KeyboardInterrupt,
+                SystemExit,
+                MemoryError,
+                asyncio.CancelledError,
+            ):
                 # システム例外は再発生
                 # - KeyboardInterrupt/SystemExit: graceful shutdown対応
                 # - MemoryError: K8s OOMKilled等のリソース枯渇検知


### PR DESCRIPTION
## 概要
validate_github_repoのセキュリティ境界入力バリデーションテストを追加。
無効リポジトリ名のparametrize化、正常系テスト、境界値テストを実装。

## 変更内容
- tests/unit/test_github_client.py: 無効リポジトリテストをparametrize化、正常系テスト・境界値テスト追加
- tests/unit/test_sync_client.py: 関連テスト追加
- utils/api_client.py: バリデーション共通ヘルパー追加（重複解消）
- utils/github_client.py: "."と".."のリポジトリ名を拒否、PEP 758形式修正

8 files changed, 273 insertions(+), 68 deletions(-)

## テスト
- [x] ローカルテスト完了（569テスト、93.70%カバレッジ）
- [ ] CI/CD パイプライン確認

## 関連Issue/PR
Closes #232 (Issue)

> 注記: 旧PR #267 (feature/issue#232-validate-repo-tests) はブランチ名の`#`文字によりGitHub @claudeメンション非対応のためリネームして再作成。旧PRのコミット内容を完全引き継ぎ。

---
このPRは /push-pr スキルで自動生成されました。