### PR TITLE
fix(github_client): Rate LimitヘッダーのValueErrorを適切にハンドリング

### DIFF
--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -687,3 +687,45 @@ async def test_invalid_rate_limit_reset_header_low_remaining():
     # フォールバック: reset_time=0 → epoch（1970-01-01T00:00:00+00:00）
     expected_reset_time = datetime(1970, 1, 1, 0, 0, tzinfo=UTC).isoformat()
     assert rate_limit_low_logs[0]["reset_time"] == expected_reset_time
+
+
+@respx.mock
+async def test_invalid_rate_limit_reset_header_rate_limit_exceeded():
+    """rate_remaining==0かつX-RateLimit-Resetが不正値の場合、警告ログ後RateLimitError発生
+
+    検証項目:
+    - RateLimitError が発生すること（rate_remaining==0のため）
+    - invalid_rate_limit_header warning ログが2件出力されること
+      （L293の共通remaining<10チェックパス + L341の403固有rate_remaining==0パスの両方）
+    - rate_limit_low warning ログが1件出力されること（remaining=0 < 10）
+    - header="X-RateLimit-Reset", value="broken" がログに含まれること
+    """
+    respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        status_code=403,
+        json={"message": "Forbidden"},
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "broken",
+        },
+    )
+
+    with capture_logs() as log_output:
+        async with AsyncGitHubClient() as client:
+            with pytest.raises(RateLimitError):
+                await client.get_user("octocat")
+
+    # invalid_rate_limit_header warningが2件（共通パス + 403固有パス）
+    invalid_header_logs = [
+        log for log in log_output if log.get("event") == "invalid_rate_limit_header"
+    ]
+    assert len(invalid_header_logs) == 2
+    for log_entry in invalid_header_logs:
+        assert log_entry["log_level"] == "warning"
+        assert log_entry["header"] == "X-RateLimit-Reset"
+        assert log_entry["value"] == "broken"
+
+    # rate_limit_low warningが1件（remaining=0 < 10）
+    rate_limit_low_logs = [log for log in log_output if log.get("event") == "rate_limit_low"]
+    assert len(rate_limit_low_logs) == 1
+    assert rate_limit_low_logs[0]["log_level"] == "warning"
+    assert rate_limit_low_logs[0]["remaining"] == 0

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -639,7 +639,7 @@ async def test_invalid_rate_limit_header_403():
     assert not isinstance(exc_info.value, RateLimitError)
     warning_logs = [log for log in log_output if log.get("event") == "invalid_rate_limit_header"]
     # 共通パス（remaining監視）と403固有パス（rate_remaining判定）の2箇所でwarning発生
-    assert len(warning_logs) >= 1
+    assert len(warning_logs) == 2
     for log_entry in warning_logs:
         assert log_entry["log_level"] == "warning"
         assert log_entry["header"] == "X-RateLimit-Remaining"
@@ -698,7 +698,8 @@ async def test_invalid_rate_limit_reset_header_rate_limit_exceeded():
     検証項目:
     - RateLimitError が発生すること（rate_remaining==0のため）
     - invalid_rate_limit_header warning ログが2件出力されること
-      （L293の共通remaining<10チェックパス + L341の403固有rate_remaining==0パスの両方）
+      （共通remaining<10チェックパスにおけるX-RateLimit-Resetパース +
+       403固有rate_remaining==0パスにおけるX-RateLimit-Resetパース の2箇所で発生）
     - rate_limit_low warning ログが1件出力されること（remaining=0 < 10）
     - header="X-RateLimit-Reset", value="broken" がログに含まれること
     """
@@ -720,7 +721,7 @@ async def test_invalid_rate_limit_reset_header_rate_limit_exceeded():
     invalid_header_logs = [
         log for log in log_output if log.get("event") == "invalid_rate_limit_header"
     ]
-    assert len(invalid_header_logs) >= 1
+    assert len(invalid_header_logs) == 2
     for log_entry in invalid_header_logs:
         assert log_entry["log_level"] == "warning"
         assert log_entry["header"] == "X-RateLimit-Reset"

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -578,3 +578,66 @@ async def test_base_exception_propagates_through_request(
         with patch.object(client._client, "request", side_effect=exception_class(*exception_args)):
             with pytest.raises(exception_class):
                 await client.get_user("octocat")
+
+
+# =============================================================================
+# Rate Limitヘッダー不正値テスト（Issue #230）
+# =============================================================================
+
+
+@respx.mock
+async def test_invalid_rate_limit_header_remaining():
+    """X-RateLimit-Remaining に不正値が含まれる場合、warningログ出力して処理継続
+
+    検証項目:
+    - ValueError が外部に伝播しないこと（正常完了）
+    - invalid_rate_limit_header warning ログが出力されること
+    - header/value フィールドがログに含まれること
+    """
+    respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        status_code=200,
+        json={"login": "octocat"},
+        headers={"X-RateLimit-Remaining": "N/A"},
+    )
+
+    with capture_logs() as log_output:
+        async with AsyncGitHubClient() as client:
+            result = await client.get_user("octocat")
+
+    assert result["login"] == "octocat"
+    warning_logs = [log for log in log_output if log.get("event") == "invalid_rate_limit_header"]
+    assert len(warning_logs) == 1
+    assert warning_logs[0]["log_level"] == "warning"
+    assert warning_logs[0]["header"] == "X-RateLimit-Remaining"
+    assert warning_logs[0]["value"] == "N/A"
+
+
+@respx.mock
+async def test_invalid_rate_limit_header_403():
+    """403応答時に X-RateLimit-Remaining が不正値の場合、warningログ後 GitHubAPIError 発生
+
+    検証項目:
+    - RateLimitError ではなく GitHubAPIError（Access forbidden）が発生すること
+    - invalid_rate_limit_header warning ログが2件出力されること
+      （共通Rate Limit監視パス + 403固有パスの両方でValueErrorが発生）
+    - header/value フィールドがログに含まれること
+    """
+    respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        status_code=403,
+        json={"message": "Forbidden"},
+        headers={"X-RateLimit-Remaining": "invalid"},
+    )
+
+    with capture_logs() as log_output:
+        async with AsyncGitHubClient() as client:
+            with pytest.raises(GitHubAPIError, match="Access forbidden") as exc_info:
+                await client.get_user("octocat")
+
+    assert not isinstance(exc_info.value, RateLimitError)
+    warning_logs = [log for log in log_output if log.get("event") == "invalid_rate_limit_header"]
+    # 共通パス（remaining監視）と403固有パス（rate_remaining判定）の2箇所でwarning発生
+    assert len(warning_logs) == 2
+    for log_entry in warning_logs:
+        assert log_entry["log_level"] == "warning"
+        assert log_entry["header"] == "X-RateLimit-Remaining"
+        assert log_entry["value"] == "invalid"

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -620,7 +620,8 @@ async def test_invalid_rate_limit_header_403():
     検証項目:
     - RateLimitError ではなく GitHubAPIError（Access forbidden）が発生すること
     - invalid_rate_limit_header warning ログが2件出力されること
-      （共通Rate Limit監視パス + 403固有パスの両方でValueErrorが発生）
+      （X-RateLimit-Remainingを共通パス（remaining監視）と403固有パス
+       （rate_remaining判定）の2箇所で読み取り、どちらもValueError発生）
     - header/value フィールドがログに含まれること
     """
     respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -641,3 +641,50 @@ async def test_invalid_rate_limit_header_403():
         assert log_entry["log_level"] == "warning"
         assert log_entry["header"] == "X-RateLimit-Remaining"
         assert log_entry["value"] == "invalid"
+
+
+@respx.mock
+async def test_invalid_rate_limit_reset_header_low_remaining():
+    """remaining<10かつX-RateLimit-Resetが不正値の場合、2つのwarningログを出力して処理継続
+
+    検証項目:
+    - ValueError が外部に伝播しないこと（正常完了）
+    - invalid_rate_limit_header warning ログが出力されること
+      （header="X-RateLimit-Reset", value="not-a-timestamp"）
+    - rate_limit_low warning ログが出力されること（remaining=5）
+    - reset_time はフォールバック値（epoch: 1970-01-01T00:00:00+00:00）になること
+    """
+    from datetime import UTC, datetime
+
+    respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        status_code=200,
+        json={"login": "octocat"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Reset": "not-a-timestamp",
+        },
+    )
+
+    with capture_logs() as log_output:
+        async with AsyncGitHubClient() as client:
+            result = await client.get_user("octocat")
+
+    assert result["login"] == "octocat"
+
+    # invalid_rate_limit_header warning（X-RateLimit-Reset不正値）
+    invalid_header_logs = [
+        log for log in log_output if log.get("event") == "invalid_rate_limit_header"
+    ]
+    assert len(invalid_header_logs) == 1
+    assert invalid_header_logs[0]["log_level"] == "warning"
+    assert invalid_header_logs[0]["header"] == "X-RateLimit-Reset"
+    assert invalid_header_logs[0]["value"] == "not-a-timestamp"
+
+    # rate_limit_low warning（remaining=5 < 10）
+    rate_limit_low_logs = [log for log in log_output if log.get("event") == "rate_limit_low"]
+    assert len(rate_limit_low_logs) == 1
+    assert rate_limit_low_logs[0]["log_level"] == "warning"
+    assert rate_limit_low_logs[0]["remaining"] == 5
+    # フォールバック: reset_time=0 → epoch（1970-01-01T00:00:00+00:00）
+    expected_reset_time = datetime(1970, 1, 1, 0, 0, tzinfo=UTC).isoformat()
+    assert rate_limit_low_logs[0]["reset_time"] == expected_reset_time

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -611,15 +611,15 @@ async def test_invalid_rate_limit_header_remaining():
     assert len(warning_logs) == 1
     assert warning_logs[0]["log_level"] == "warning"
     assert warning_logs[0]["header"] == "X-RateLimit-Remaining"
-    assert warning_logs[0]["value"] == "N/A"
+    assert warning_logs[0]["value"] == repr("N/A")
 
 
 @respx.mock
 async def test_invalid_rate_limit_header_403():
-    """403応答時に X-RateLimit-Remaining が不正値の場合、warningログ後 GitHubAPIError 発生
+    """403応答時に X-RateLimit-Remaining が不正値の場合、warningログ後 RateLimitError 発生
 
     検証項目:
-    - RateLimitError ではなく GitHubAPIError（Access forbidden）が発生すること
+    - フォールバック 0 により rate_remaining == 0 となり RateLimitError が発生すること
     - invalid_rate_limit_header warning ログが2件出力されること
       （X-RateLimit-Remainingを共通パス（remaining監視）と403固有パス
        （rate_remaining判定）の2箇所で読み取り、どちらもValueError発生）
@@ -633,17 +633,16 @@ async def test_invalid_rate_limit_header_403():
 
     with capture_logs() as log_output:
         async with AsyncGitHubClient() as client:
-            with pytest.raises(GitHubAPIError, match="Access forbidden") as exc_info:
+            with pytest.raises(RateLimitError):
                 await client.get_user("octocat")
 
-    assert not isinstance(exc_info.value, RateLimitError)
     warning_logs = [log for log in log_output if log.get("event") == "invalid_rate_limit_header"]
     # 共通パス（remaining監視）と403固有パス（rate_remaining判定）の2箇所でwarning発生
     assert len(warning_logs) == 2
     for log_entry in warning_logs:
         assert log_entry["log_level"] == "warning"
         assert log_entry["header"] == "X-RateLimit-Remaining"
-        assert log_entry["value"] == "invalid"
+        assert log_entry["value"] == repr("invalid")
 
 
 @respx.mock
@@ -679,7 +678,7 @@ async def test_invalid_rate_limit_reset_header_low_remaining():
     assert len(invalid_header_logs) == 1
     assert invalid_header_logs[0]["log_level"] == "warning"
     assert invalid_header_logs[0]["header"] == "X-RateLimit-Reset"
-    assert invalid_header_logs[0]["value"] == "not-a-timestamp"
+    assert invalid_header_logs[0]["value"] == repr("not-a-timestamp")
 
     # rate_limit_low warning（remaining=5 < 10）
     rate_limit_low_logs = [log for log in log_output if log.get("event") == "rate_limit_low"]
@@ -725,7 +724,7 @@ async def test_invalid_rate_limit_reset_header_rate_limit_exceeded():
     for log_entry in invalid_header_logs:
         assert log_entry["log_level"] == "warning"
         assert log_entry["header"] == "X-RateLimit-Reset"
-        assert log_entry["value"] == "broken"
+        assert log_entry["value"] == repr("broken")
 
     # rate_limit_low warningが1件（remaining=0 < 10）
     rate_limit_low_logs = [log for log in log_output if log.get("event") == "rate_limit_low"]

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -8,6 +8,7 @@ GitHub API非同期クライアントのUnit Tests
 """
 
 import asyncio
+from datetime import UTC, datetime
 from unittest.mock import ANY, Mock, patch
 
 import httpx
@@ -654,8 +655,6 @@ async def test_invalid_rate_limit_reset_header_low_remaining():
     - rate_limit_low warning ログが出力されること（remaining=5）
     - reset_time はフォールバック値（epoch: 1970-01-01T00:00:00+00:00）になること
     """
-    from datetime import UTC, datetime
-
     respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
         status_code=200,
         json={"login": "octocat"},

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -639,7 +639,7 @@ async def test_invalid_rate_limit_header_403():
     assert not isinstance(exc_info.value, RateLimitError)
     warning_logs = [log for log in log_output if log.get("event") == "invalid_rate_limit_header"]
     # 共通パス（remaining監視）と403固有パス（rate_remaining判定）の2箇所でwarning発生
-    assert len(warning_logs) == 2
+    assert len(warning_logs) >= 1
     for log_entry in warning_logs:
         assert log_entry["log_level"] == "warning"
         assert log_entry["header"] == "X-RateLimit-Remaining"
@@ -720,7 +720,7 @@ async def test_invalid_rate_limit_reset_header_rate_limit_exceeded():
     invalid_header_logs = [
         log for log in log_output if log.get("event") == "invalid_rate_limit_header"
     ]
-    assert len(invalid_header_logs) == 2
+    assert len(invalid_header_logs) >= 1
     for log_entry in invalid_header_logs:
         assert log_entry["log_level"] == "warning"
         assert log_entry["header"] == "X-RateLimit-Reset"

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -616,10 +616,10 @@ async def test_invalid_rate_limit_header_remaining():
 
 @respx.mock
 async def test_invalid_rate_limit_header_403():
-    """403応答時に X-RateLimit-Remaining が不正値の場合、warningログ後 RateLimitError 発生
+    """403応答時にX-RateLimit-Remainingが不正値の場合、warningログ後 GitHubAPIError 発生
 
     検証項目:
-    - フォールバック 0 により rate_remaining == 0 となり RateLimitError が発生すること
+    - フォールバック -1 により rate_remaining == 0 は偽 → GitHubAPIError("Access forbidden") が発生
     - invalid_rate_limit_header warning ログが2件出力されること
       （X-RateLimit-Remainingを共通パス（remaining監視）と403固有パス
        （rate_remaining判定）の2箇所で読み取り、どちらもValueError発生）
@@ -633,11 +633,12 @@ async def test_invalid_rate_limit_header_403():
 
     with capture_logs() as log_output:
         async with AsyncGitHubClient() as client:
-            with pytest.raises(RateLimitError):
+            with pytest.raises(GitHubAPIError):
                 await client.get_user("octocat")
 
     warning_logs = [log for log in log_output if log.get("event") == "invalid_rate_limit_header"]
-    # 共通パス（remaining監視）と403固有パス（rate_remaining判定）の2箇所でwarning発生
+    # 共通パス(default=999)と403固有パス(default=-1)の2箇所でwarning発生
+    # 999 >= 10 のため rate_limit_low は未発生、invalid_rate_limit_header のみ2件
     assert len(warning_logs) == 2
     for log_entry in warning_logs:
         assert log_entry["log_level"] == "warning"
@@ -731,6 +732,9 @@ async def test_invalid_rate_limit_reset_header_rate_limit_exceeded():
     assert len(rate_limit_low_logs) == 1
     assert rate_limit_low_logs[0]["log_level"] == "warning"
     assert rate_limit_low_logs[0]["remaining"] == 0
+    # フォールバック: reset_time=0 → epoch（1970-01-01T00:00:00+00:00）
+    expected_reset_time = datetime(1970, 1, 1, 0, 0, tzinfo=UTC).isoformat()
+    assert rate_limit_low_logs[0]["reset_time"] == expected_reset_time
 
 
 # =============================================================================

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -231,6 +231,27 @@ class AsyncGitHubClient:
             raise GitHubAPIError(f"Expected dict response, got {type(result).__name__}")
         return result
 
+    def _parse_rate_limit_header(self, headers: httpx.Headers, name: str, default: int) -> int:
+        """Rate Limitヘッダーを安全にパースする。
+
+        Args:
+            headers: HTTPレスポンスヘッダー
+            name: ヘッダー名（例: "X-RateLimit-Remaining"）
+            default: パース失敗時のフォールバック値
+
+        Returns:
+            パース済み整数値、またはデフォルト値
+        """
+        try:
+            return int(headers.get(name, default))
+        except ValueError:
+            self.logger.warning(
+                "invalid_rate_limit_header",
+                header=name,
+                value=headers.get(name),
+            )
+            return default
+
     async def _request(  # noqa: C901 - 統合HTTPリクエスト処理（Rate Limit/ETag/リトライ統合）のため許容
         self,
         method: str,
@@ -279,25 +300,13 @@ class AsyncGitHubClient:
                 )
 
                 # Rate Limit監視
-                try:
-                    remaining = int(response.headers.get("X-RateLimit-Remaining", 999))
-                except ValueError:
-                    self.logger.warning(
-                        "invalid_rate_limit_header",
-                        header="X-RateLimit-Remaining",
-                        value=response.headers.get("X-RateLimit-Remaining"),
-                    )
-                    remaining = 999  # フォールバック: 残量十分と見なす
+                remaining = self._parse_rate_limit_header(
+                    response.headers, "X-RateLimit-Remaining", 999
+                )  # フォールバック: 残量十分と見なす
                 if remaining < 10:
-                    try:
-                        reset_time = int(response.headers.get("X-RateLimit-Reset", 0))
-                    except ValueError:
-                        self.logger.warning(
-                            "invalid_rate_limit_header",
-                            header="X-RateLimit-Reset",
-                            value=response.headers.get("X-RateLimit-Reset"),
-                        )
-                        reset_time = 0  # フォールバック: リセット時刻不明
+                    reset_time = self._parse_rate_limit_header(
+                        response.headers, "X-RateLimit-Reset", 0
+                    )  # フォールバック: リセット時刻不明
                     reset_dt = datetime.fromtimestamp(reset_time, tz=UTC)
                     self.logger.warning(
                         "rate_limit_low",
@@ -327,26 +336,14 @@ class AsyncGitHubClient:
 
                 if response.status_code == 403:
                     # 403判定: Rate Limit超過 vs その他のアクセス禁止
-                    try:
-                        rate_remaining = int(response.headers.get("X-RateLimit-Remaining", -1))
-                    except ValueError:
-                        self.logger.warning(
-                            "invalid_rate_limit_header",
-                            header="X-RateLimit-Remaining",
-                            value=response.headers.get("X-RateLimit-Remaining"),
-                        )
-                        rate_remaining = -1  # フォールバック: rate limit起因でないと見なす
+                    rate_remaining = self._parse_rate_limit_header(
+                        response.headers, "X-RateLimit-Remaining", -1
+                    )  # フォールバック: rate limit起因でないと見なす
                     if rate_remaining == 0:
                         # Rate Limit超過確定
-                        try:
-                            reset_time = int(response.headers.get("X-RateLimit-Reset", 0))
-                        except ValueError:
-                            self.logger.warning(
-                                "invalid_rate_limit_header",
-                                header="X-RateLimit-Reset",
-                                value=response.headers.get("X-RateLimit-Reset"),
-                            )
-                            reset_time = 0  # フォールバック: リセット時刻不明
+                        reset_time = self._parse_rate_limit_header(
+                            response.headers, "X-RateLimit-Reset", 0
+                        )  # フォールバック: リセット時刻不明
                         raise RateLimitError(reset_time)
                     # その他の403エラー（IPブロック、アクセス権限不足等）
                     error_message = "Access forbidden"

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -291,7 +291,10 @@ class AsyncGitHubClient:
             X-RateLimit-Remaining ヘッダーが不正値の場合:
             - 監視パス: フォールバック999（残量十分と見なし、rate_limit_low警告なし）
             - 403判定パス: フォールバック-1（Rate Limit超過と判定せず、GitHubAPIError発生）
-            いずれのパスでも不正値検出時は invalid_rate_limit_header warningを出力する。
+            いずれのパスでも不正値（ValueError）検出時は
+            invalid_rate_limit_header warningを出力する。
+            なお、ヘッダー自体が未設定（None）の場合は
+            warningを出力せずフォールバック値を返す。
         """
         if not self._client:
             raise RuntimeError("Client not initialized. Use 'async with' context.")

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -232,13 +232,25 @@ class AsyncGitHubClient:
         return result
 
     def _parse_rate_limit_header(self, headers: httpx.Headers, name: str, default: int) -> int:
-        """Rate Limitヘッダーを安全にパースする。失敗時は default を返す。"""
+        """Rate Limitヘッダーを安全にパースする。
+
+        Args:
+            headers: HTTPレスポンスヘッダー
+            name: ヘッダー名（例: "X-RateLimit-Remaining"）
+            default: パース失敗時のフォールバック値
+
+        Returns:
+            パースされた整数値。ヘッダー未設定またはパース失敗時は default を返す。
+
+        Note:
+            ValueErrorをキャッチし、warningログを出力してフォールバック値を返す。
+        """
         raw = headers.get(name)
         if raw is None:
             return default
         try:
             return int(raw)
-        except ValueError, TypeError:
+        except ValueError:
             self.logger.warning(
                 "invalid_rate_limit_header",
                 header=name,
@@ -275,6 +287,11 @@ class AsyncGitHubClient:
             GitHubServerError: 5xxエラー（リトライ上限後）
             GitHubAPIError: タイムアウト等の予期しないエラー
 
+        Note:
+            X-RateLimit-Remaining ヘッダーが不正値の場合:
+            - 監視パス: フォールバック999（残量十分と見なし、rate_limit_low警告なし）
+            - 403判定パス: フォールバック-1（Rate Limit超過と判定せず、GitHubAPIError発生）
+            いずれのパスでも不正値検出時は invalid_rate_limit_header warningを出力する。
         """
         if not self._client:
             raise RuntimeError("Client not initialized. Use 'async with' context.")
@@ -293,7 +310,8 @@ class AsyncGitHubClient:
                     headers=headers,
                 )
 
-                # Rate Limit監視
+                # Rate Limit監視: 残量少でwarning出力
+                # フォールバック999 = 残量十分と見なす
                 remaining = self._parse_rate_limit_header(
                     response.headers, "X-RateLimit-Remaining", 999
                 )  # フォールバック: 残量十分と見なす
@@ -329,10 +347,11 @@ class AsyncGitHubClient:
                     raise NotFoundError(f"Resource not found: {endpoint}")
 
                 if response.status_code == 403:
-                    # 403判定: Rate Limit超過 vs その他のアクセス禁止
+                    # 403分類: Rate Limit超過 vs その他の403を判別
+                    # フォールバック -1 = 不正値時はRate Limit超過と判定せずGitHubAPIErrorへ
                     rate_remaining = self._parse_rate_limit_header(
-                        response.headers, "X-RateLimit-Remaining", 0
-                    )  # フォールバック 0（不正値時はRate Limit超過として扱う）
+                        response.headers, "X-RateLimit-Remaining", -1
+                    )
                     if rate_remaining == 0:
                         # Rate Limit超過確定
                         reset_time = self._parse_rate_limit_header(

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -242,7 +242,7 @@ class AsyncGitHubClient:
             self.logger.warning(
                 "invalid_rate_limit_header",
                 header=name,
-                value=raw,
+                value=repr(raw)[:100],
             )
             return default
 
@@ -331,8 +331,8 @@ class AsyncGitHubClient:
                 if response.status_code == 403:
                     # 403判定: Rate Limit超過 vs その他のアクセス禁止
                     rate_remaining = self._parse_rate_limit_header(
-                        response.headers, "X-RateLimit-Remaining", -1
-                    )  # フォールバック -1（不正値時はRateLimitError未発生リスクあり）
+                        response.headers, "X-RateLimit-Remaining", 0
+                    )  # フォールバック 0（不正値時はRate Limit超過として扱う）
                     if rate_remaining == 0:
                         # Rate Limit超過確定
                         reset_time = self._parse_rate_limit_header(

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -279,9 +279,25 @@ class AsyncGitHubClient:
                 )
 
                 # Rate Limit監視
-                remaining = int(response.headers.get("X-RateLimit-Remaining", 999))
+                try:
+                    remaining = int(response.headers.get("X-RateLimit-Remaining", 999))
+                except ValueError:
+                    self.logger.warning(
+                        "invalid_rate_limit_header",
+                        header="X-RateLimit-Remaining",
+                        value=response.headers.get("X-RateLimit-Remaining"),
+                    )
+                    remaining = 999  # フォールバック: 残量十分と見なす
                 if remaining < 10:
-                    reset_time = int(response.headers.get("X-RateLimit-Reset", 0))
+                    try:
+                        reset_time = int(response.headers.get("X-RateLimit-Reset", 0))
+                    except ValueError:
+                        self.logger.warning(
+                            "invalid_rate_limit_header",
+                            header="X-RateLimit-Reset",
+                            value=response.headers.get("X-RateLimit-Reset"),
+                        )
+                        reset_time = 0  # フォールバック: リセット時刻不明
                     reset_dt = datetime.fromtimestamp(reset_time, tz=UTC)
                     self.logger.warning(
                         "rate_limit_low",
@@ -311,10 +327,26 @@ class AsyncGitHubClient:
 
                 if response.status_code == 403:
                     # 403判定: Rate Limit超過 vs その他のアクセス禁止
-                    rate_remaining = int(response.headers.get("X-RateLimit-Remaining", -1))
+                    try:
+                        rate_remaining = int(response.headers.get("X-RateLimit-Remaining", -1))
+                    except ValueError:
+                        self.logger.warning(
+                            "invalid_rate_limit_header",
+                            header="X-RateLimit-Remaining",
+                            value=response.headers.get("X-RateLimit-Remaining"),
+                        )
+                        rate_remaining = -1  # フォールバック: rate limit起因でないと見なす
                     if rate_remaining == 0:
                         # Rate Limit超過確定
-                        reset_time = int(response.headers.get("X-RateLimit-Reset", 0))
+                        try:
+                            reset_time = int(response.headers.get("X-RateLimit-Reset", 0))
+                        except ValueError:
+                            self.logger.warning(
+                                "invalid_rate_limit_header",
+                                header="X-RateLimit-Reset",
+                                value=response.headers.get("X-RateLimit-Reset"),
+                            )
+                            reset_time = 0  # フォールバック: リセット時刻不明
                         raise RateLimitError(reset_time)
                     # その他の403エラー（IPブロック、アクセス権限不足等）
                     error_message = "Access forbidden"
@@ -392,7 +424,7 @@ class AsyncGitHubClient:
                 self.logger.warning("request_timeout", endpoint=endpoint, method=method)
                 raise GitHubAPIError(f"Request timeout: {e}") from e
 
-            except (KeyboardInterrupt, SystemExit, MemoryError, asyncio.CancelledError):
+            except KeyboardInterrupt, SystemExit, MemoryError, asyncio.CancelledError:
                 # システム例外は再発生
                 # - KeyboardInterrupt/SystemExit: graceful shutdown対応
                 # - MemoryError: K8s OOMKilled等のリソース枯渇検知

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -232,23 +232,17 @@ class AsyncGitHubClient:
         return result
 
     def _parse_rate_limit_header(self, headers: httpx.Headers, name: str, default: int) -> int:
-        """Rate Limitヘッダーを安全にパースする。
-
-        Args:
-            headers: HTTPレスポンスヘッダー
-            name: ヘッダー名（例: "X-RateLimit-Remaining"）
-            default: パース失敗時のフォールバック値
-
-        Returns:
-            パース済み整数値、またはデフォルト値
-        """
+        """Rate Limitヘッダーを安全にパースする。失敗時は default を返す。"""
+        raw = headers.get(name)
+        if raw is None:
+            return default
         try:
-            return int(headers.get(name, default))
-        except ValueError:
+            return int(raw)
+        except ValueError, TypeError:
             self.logger.warning(
                 "invalid_rate_limit_header",
                 header=name,
-                value=headers.get(name),
+                value=raw,
             )
             return default
 
@@ -338,7 +332,7 @@ class AsyncGitHubClient:
                     # 403判定: Rate Limit超過 vs その他のアクセス禁止
                     rate_remaining = self._parse_rate_limit_header(
                         response.headers, "X-RateLimit-Remaining", -1
-                    )  # フォールバック: rate limit起因でないと見なす
+                    )  # フォールバック -1（不正値時はRateLimitError未発生リスクあり）
                     if rate_remaining == 0:
                         # Rate Limit超過確定
                         reset_time = self._parse_rate_limit_header(


### PR DESCRIPTION
## 概要
Rate Limitヘッダー（X-RateLimit-Remaining, X-RateLimit-Reset）のパース時に不正な値が返された場合、`int()`変換で`ValueError`が発生し、Root Causeが不明なエラーとして伝播する問題を修正。

**前PR**: #268（ブランチ名の`#`文字によるCI問題のためClose → 本PRで再作成。レビュー履歴は #268 参照）

## 変更内容
- `utils/github_client.py`: `_parse_rate_limit_header`ヘルパーメソッド追加（4箇所の重複パースロジックを統合）
- `tests/unit/test_github_client.py`: ValueError回帰テスト4件追加（remaining不正値、reset不正値×2パス、403+不正値）

## 変更規模
```
tests/unit/test_github_client.py | 152 +++
utils/github_client.py           |  39 +-
2 files changed, 186 insertions(+), 5 deletions(-)
```

## テスト
- [x] pytest 559件合格 / カバレッジ 93.56%
- [x] ruff 0 errors
- [x] mypy 0 errors

## 関連Issue/PR
Closes #230 (Issue)
Supersedes #268 (旧PR — レビュー履歴参照)

---
このPRは /push-pr スキルで自動生成されました。

## Review Response (2026-03-20)

| 分類 | 件数 | 対応 |
|------|------|------|
| NEEDS-DECISION（修正） | 3件 | 修正済み |
| NEEDS-DECISION（保留） | 2件 | 次回対応（#3: docstring行番号、#5: docstring削減） |

コミット: `58a9c99`


## Review Response (2026-03-20)

| 分類 | 件数 | 対応 |
|------|------|------|
| AUTO-FIX | 3件 | 修正済み (#1 docstring, #4 assert==2, #5 assert==2) |
| SKIP | 2件 | pushback返信済み (#2 インラインコメント維持, #3 PEP 758有効構文) |

コミット: `3aebbe1`


## Review Response (2026-03-20)

| 分類 | 件数 | 対応 |
|------|------|------|
| AUTO-FIX | 3件 | ログ注入対策(repr)・フォールバック0・テスト更新 |
| SKIP | 2件 | PEP 758 (Python 3.14有効構文) - pushback返信済み |
| 対応なし | 1件 | docstring冗長化指摘 (#4) |

コミット: `49b0334`


## Review Response (2026-03-20) — Round 2

| 分類 | 件数 | 対応 |
|------|------|------|
| NEEDS-DECISION（修正） | 7件 | D1:フォールバック-1復元, D2:docstring追記, D3:except簡素化, D6:設計コメント, D7:テストコメント, D8:API契約docstring, D9:reset_time検証 |
| SKIP（対応済み） | 3件 | ログ件数assert強化済み, docstring行番号修正済み, ログインジェクション対策済み |
| SKIP（pushback） | 1件 | repr(raw)[:100]は防御的プログラミングとして維持 |
| D4:@pytest.mark.unit | SKIP | pytestmarkモジュールレベル設定済み（15/16ファイル一貫） |

**設計判断**: フォールバック値を0→-1に復元。GitHub APIはRate Limit超過時に必ずX-RateLimit-Remaining:0を返すため、ヘッダー不正値時はRate Limit超過以外の403（IPブロック・権限不足等）と推定し、GitHubAPIErrorを発生させる設計に回帰。

コミット: `a81875b`


## Review Response (2026-03-20 #2)

| 分類 | 件数 | 対応 |
|------|------|------|
| AUTO-FIX | 1件 | docstring Note修正済み |
| NEEDS-DECISION | 0件 | - |
| SKIP | 14件 | 対応済み8件 + 設計意図5件 + pytestmark設計1件 |

コミット: `4a15a03`
