### PR TITLE
docs(security): safety check → safety scanへ移行

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -148,7 +148,7 @@ uv run mypy utils/ config/ models/  # 型チェック
 
 # セキュリティ（週次）
 uv run bandit -r utils/ config/ models/
-uv run safety check
+uv run safety scan
 ```
 
 ### pre-commit（軽量版）

--- a/docs/main/6週プラン/6週プラン.md
+++ b/docs/main/6週プラン/6週プラン.md
@@ -2210,7 +2210,7 @@ trivy fs --scanners vuln .
 
    ```yaml
    - name: Run safety scan
-     run: uv run safety scan --output json
+     run: uv run safety scan --output json > reports/safety-report.json
    ```
 
 2. CodeQL統合実装（GitHub Security設定）

--- a/docs/main/6週プラン/6週プラン.md
+++ b/docs/main/6週プラン/6週プラン.md
@@ -2209,8 +2209,8 @@ trivy fs --scanners vuln .
 1. safety統合実装（依存関係脆弱性スキャン）
 
    ```yaml
-   - name: Run safety check
-     run: uv run safety check --json
+   - name: Run safety scan
+     run: uv run safety scan --output json
    ```
 
 2. CodeQL統合実装（GitHub Security設定）
@@ -2227,7 +2227,7 @@ trivy fs --scanners vuln .
 
 3. セキュリティスキャン動作確認
    - GitHubへpush → security job実行 → 結果確認
-   - [ ] safety check合格（脆弱性0件、またはFalse positive判定済み）
+   - [ ] safety scan合格（脆弱性0件、またはFalse positive判定済み）
    - [ ] CodeQL Analysis合格（Critical脆弱性0件）
 
 4. セキュリティポリシー設定（任意）
@@ -3934,7 +3934,7 @@ jobs:
         run: uv run bandit -r utils/ config/
 
       - name: Run safety
-        run: uv run safety check
+        run: uv run safety scan
 ```
 
 **AI依頼プロンプト例**:

--- a/docs/main/api/api_documentation.md
+++ b/docs/main/api/api_documentation.md
@@ -486,7 +486,7 @@ jobs:
     - name: Security Testing (CI/CD品質ゲート)
       run: |
         uv run bandit -r . -ll
-        uv run safety check
+        uv run safety scan
         uv run pip-audit
 
     - name: Performance Testing


### PR DESCRIPTION
## 概要
safety 3.xで非推奨化された`safety check`コマンドを`safety scan`に移行。ドキュメント3ファイル内の残存箇所を統一。

## 変更内容
- `.claude/CLAUDE.md`: `uv run safety check` → `uv run safety scan`
- `docs/main/6週プラン/6週プラン.md`: 4箇所置換（`--json` → `--output json` オプション変更含む）
- `docs/main/api/api_documentation.md`: 1箇所置換

## 背景
- safety v3では`safety check`のメンテナンスサポートが2024年6月に終了
- `docs/guides/daily_commands.md`は既に`safety scan`を使用しており、不整合が生じていた
- CI/CDには現時点でsafetyスキャン未実装のため、CI破壊リスクはゼロ

## テスト
- [x] `grep -r "safety check" docs/ .claude/` で残存ゼロ確認
- [x] ruff通過
- [x] markdownlint通過

Closes #242 (Issue)

---
このPRは /push-pr スキルで自動生成されました。