### PR TITLE
refactor(test): BASE_URL定数を共通モジュールに集約

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ import pytest
 import pytest_asyncio
 
 from config.settings import _resolve_hostname_cached, reload_settings
+from tests.constants import BASE_URL
 from utils.api_client import AsyncAPIClient
 
 # =============================================================================
@@ -92,7 +93,7 @@ def test_config() -> dict[str, Any]:
     """テスト用設定データ"""
     return {
         "api": {
-            "base_url": "https://jsonplaceholder.typicode.com",
+            "base_url": BASE_URL,
             "timeout": 10,
             "retry_count": 1,
             "retry_delay": 0.5,

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,3 @@
+"""テスト共通定数."""
+
+BASE_URL = "https://jsonplaceholder.typicode.com"

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,3 +1,3 @@
 """テスト共通定数."""
 
-BASE_URL = "https://jsonplaceholder.typicode.com"
+BASE_URL: str = "https://jsonplaceholder.typicode.com"

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -13,6 +13,8 @@ from typing import Any
 import httpx
 import pytest
 
+from tests.constants import BASE_URL
+
 # Module-level marker: All tests in this file are integration tests
 pytestmark = pytest.mark.integration
 
@@ -24,7 +26,7 @@ pytestmark = pytest.mark.integration
 def test_jsonplaceholder_api_accessible():
     """JSONPlaceholder APIへの基本的な接続確認"""
     # Given: JSONPlaceholder APIのエンドポイント
-    url = "https://jsonplaceholder.typicode.com/todos/1"
+    url = f"{BASE_URL}/todos/1"
 
     # When: 同期HTTPクライアントでリクエスト実行
     with httpx.Client() as client:
@@ -51,7 +53,7 @@ def test_jsonplaceholder_api_accessible():
 def test_todos_endpoint_returns_list():
     """TODOsエンドポイントが配列を返すことを確認"""
     # Given: TODOsリストのエンドポイント
-    url = "https://jsonplaceholder.typicode.com/todos"
+    url = f"{BASE_URL}/todos"
 
     # When: リクエスト実行（上限5件で制限）
     with httpx.Client() as client:
@@ -74,7 +76,7 @@ def test_todos_endpoint_returns_list():
 def test_users_endpoint_response_structure():
     """ユーザーエンドポイントのレスポンス構造確認"""
     # Given: 特定ユーザーのエンドポイント
-    url = "https://jsonplaceholder.typicode.com/users/1"
+    url = f"{BASE_URL}/users/1"
 
     # When: リクエスト実行
     with httpx.Client() as client:
@@ -161,7 +163,7 @@ async def test_concurrent_requests(async_client):
 def test_todo_user_mapping(todo_id: int, expected_user_id: int) -> None:
     """TODOとユーザーIDのマッピング確認（パラメータ化テスト）"""
     # Given: 特定のTODO ID
-    url = f"https://jsonplaceholder.typicode.com/todos/{todo_id}"
+    url = f"{BASE_URL}/todos/{todo_id}"
 
     # When: TODO情報を取得
     with httpx.Client() as client:
@@ -180,7 +182,7 @@ def test_todo_user_mapping(todo_id: int, expected_user_id: int) -> None:
 def test_all_endpoints_accessible(endpoint: str) -> None:
     """全エンドポイントのアクセス確認"""
     # Given: 各種エンドポイント
-    url = f"https://jsonplaceholder.typicode.com{endpoint}"
+    url = f"{BASE_URL}{endpoint}"
 
     # When: リクエスト実行（件数制限付き）
     with httpx.Client() as client:
@@ -201,7 +203,7 @@ def test_all_endpoints_accessible(endpoint: str) -> None:
 def test_nonexistent_resource_returns_404():
     """存在しないリソースで404エラーを確認"""
     # Given: 存在しないリソースのURL
-    url = "https://jsonplaceholder.typicode.com/todos/99999"
+    url = f"{BASE_URL}/todos/99999"
 
     # When: リクエスト実行
     with httpx.Client() as client:
@@ -214,7 +216,7 @@ def test_nonexistent_resource_returns_404():
 def test_invalid_endpoint_returns_404():
     """無効なエンドポイントで404エラーを確認"""
     # Given: 無効なエンドポイント
-    url = "https://jsonplaceholder.typicode.com/invalid-endpoint"
+    url = f"{BASE_URL}/invalid-endpoint"
 
     # When: リクエスト実行
     with httpx.Client() as client:

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 
+from tests.constants import BASE_URL
 from utils.api_client import (
     SyncAPIClient,
 )
@@ -14,7 +15,7 @@ pytestmark = pytest.mark.unit
 # Mock settings for testing purposes, as the actual SyncAPIClient uses config.settings
 class MockAPISettings:
     def __init__(self):
-        self.base_url = "https://jsonplaceholder.typicode.com"
+        self.base_url = BASE_URL
         self.timeout = 30.0
         self.retry_count = 3
         self.retry_delay = 0.1
@@ -60,7 +61,7 @@ def test_context_manager_basic():
 def test_base_client_uses_default_settings_if_not_provided():
     """引数がない場合にデフォルト設定が使用されることを確認"""
     client = SyncAPIClient()  # Uses mock_settings_instance
-    assert client.base_url == "https://jsonplaceholder.typicode.com"
+    assert client.base_url == BASE_URL
     assert client.timeout == 30.0
     assert client.retry_count == 3
 

--- a/tests/unit/test_async_client.py
+++ b/tests/unit/test_async_client.py
@@ -2198,7 +2198,7 @@ async def test_async_client_falsy_values_not_overridden() -> None:
     - retry_count=0 の用途: リトライを行わず即座に失敗させたい場合に使用
     """
     async with AsyncAPIClient(
-        base_url="https://jsonplaceholder.typicode.com",
+        base_url=BASE_URL,
         retry_count=0,
         timeout=0.0,
         retry_delay=0.0,

--- a/tests/unit/test_async_client.py
+++ b/tests/unit/test_async_client.py
@@ -30,6 +30,7 @@ from httpx import Response
 from structlog.testing import capture_logs
 
 # テストヘルパー
+from tests.constants import BASE_URL
 from tests.unit.helpers import assert_warning_log_count
 
 # プロジェクト内モジュール
@@ -42,9 +43,6 @@ from utils.api_client import (
 
 # Module-level marker: All tests in this file are unit tests
 pytestmark = pytest.mark.unit
-
-# Constants
-BASE_URL = "https://jsonplaceholder.typicode.com"
 
 # ===============================================================================
 # テスト用フィクスチャ・設定

--- a/tests/unit/test_async_client_error_handling.py
+++ b/tests/unit/test_async_client_error_handling.py
@@ -22,6 +22,7 @@ import httpx
 import pytest
 import respx
 
+from tests.constants import BASE_URL
 from utils.api_client import (
     APIConnectionError,
     APIHTTPError,
@@ -32,8 +33,6 @@ from utils.api_client import (
 
 # Module-level marker: All tests in this file are unit tests
 pytestmark = pytest.mark.unit
-
-BASE_URL = "https://jsonplaceholder.typicode.com"
 
 
 # =============================================================================

--- a/tests/unit/test_async_crud.py
+++ b/tests/unit/test_async_crud.py
@@ -22,11 +22,10 @@ from unittest.mock import Mock, patch
 import pytest
 import respx
 
+from tests.constants import BASE_URL
 from utils.api_client import APIHTTPError, APIRetryError, AsyncJSONPlaceholderClient
 
 pytestmark = pytest.mark.unit
-
-BASE_URL = "https://jsonplaceholder.typicode.com"
 
 # ===============================================================================
 # テスト用フィクスチャ

--- a/tests/unit/test_sync_client.py
+++ b/tests/unit/test_sync_client.py
@@ -19,12 +19,11 @@ import httpx
 import pytest
 import respx
 
+from tests.constants import BASE_URL
 from tests.unit.helpers import mock_get_route
 from utils.api_client import SyncAPIClient, SyncJSONPlaceholderClient
 
 pytestmark = pytest.mark.unit
-
-BASE_URL = "https://jsonplaceholder.typicode.com"
 
 
 # =============================================================================

--- a/tests/unit/test_sync_client.py
+++ b/tests/unit/test_sync_client.py
@@ -859,7 +859,7 @@ def test_sync_client_falsy_values_not_overridden() -> None:
     - retry_count=0 の用途: リトライを行わず即座に失敗させたい場合に使用
     """
     with SyncAPIClient(
-        base_url="https://jsonplaceholder.typicode.com",
+        base_url=BASE_URL,
         retry_count=0,
         timeout=0.0,
         retry_delay=0.0,

--- a/tests/unit/test_sync_client_error_handling.py
+++ b/tests/unit/test_sync_client_error_handling.py
@@ -22,6 +22,7 @@ import httpx
 import pytest
 import respx
 
+from tests.constants import BASE_URL
 from utils.api_client import (
     APIConnectionError,
     APIHTTPError,
@@ -31,8 +32,6 @@ from utils.api_client import (
 )
 
 pytestmark = pytest.mark.unit
-
-BASE_URL = "https://jsonplaceholder.typicode.com"
 
 # =============================================================================
 # Retry Logic Tests（条件2: エラーパス）


### PR DESCRIPTION
## 概要
5テストファイルで重複定義されていた`BASE_URL`定数を`tests/constants.py`に集約。DRY原則に基づくリファクタリング。

## 変更内容
- `tests/constants.py`: 新規作成（共通定数モジュール）
- 5テストファイル: ローカル`BASE_URL`定義を`from tests.constants import BASE_URL`に置換

## 背景
- respx移行（PR #195）でURL参照箇所が増加し、変更時の修正漏れリスクが顕在化
- conftest fixture化やsettings importは循環結合リスクのため非採用（Issue #196で設計判断済み）

## テスト
- [x] 569 tests passed / 93.50% coverage
- [x] ruff 0 errors / mypy 0 errors
- [x] `grep -r "^BASE_URL\s*=" tests/unit/` で残存ゼロ確認

Closes #196 (Issue)

---
このPRは /push-pr スキルで自動生成されました。