### PR TITLE
docs(config): Staging環境のシークレット・HTTPS必須化をドキュメント化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,7 @@ TEST__EXTERNAL_API_ENABLED="true"                     # Enable/disable integrati
 #   1. Visit: https://www.morphllm.com/
 #   2. Create account and get API key from dashboard
 # Documentation: https://docs.morphllm.com/mcpquickstart
-MORPH_API_KEY=your-morph-api-key-here
+# MORPH_API_KEY=your-morph-api-key-here
 
 # mgrep (Semantic Code Search - CLI Tool)
 # Used by: Claude Code local + CI via Bash(mgrep:*)
@@ -53,4 +53,4 @@ MORPH_API_KEY=your-morph-api-key-here
 #   - For local testing (optional): Copy this file to .env and set your key
 #   - For CI/CD: Add MXBAI_API_KEY to GitHub Secrets (Settings → Secrets)
 # Documentation: https://github.com/mixedbread-ai/mgrep
-MXBAI_API_KEY=your_api_key_here
+# MXBAI_API_KEY=your_api_key_here

--- a/.env.example
+++ b/.env.example
@@ -20,8 +20,8 @@ SENTRY__SEND_DEFAULT_PII="false"                      # Send personally identifi
 SENTRY__DSN=""                                          # Required when SENTRY__ENABLED=true. Example: https://xxx@xxx.ingest.us.sentry.io/xxx
 
 # Security Configuration
-# SECURITY__API_KEY=""                                  # API authentication key (optional in dev, required in production)
-# SECURITY__JWT_SECRET=""                               # JWT signing secret (optional in dev, required in production)
+# SECURITY__API_KEY=""                                  # API authentication key (optional in dev, required in production/staging)
+# SECURITY__JWT_SECRET=""                               # JWT signing secret (optional in dev, required in production/staging)
 
 # Test Configuration
 TEST__EXTERNAL_API_ENABLED="true"                     # Enable/disable integration tests that access external APIs (JSONPlaceholder)

--- a/docs/guides/staging_environment_guide.md
+++ b/docs/guides/staging_environment_guide.md
@@ -45,7 +45,9 @@ SENTRY__ENVIRONMENT=staging
 1. `.env` の `ENVIRONMENT` を `staging` に変更
 2. `SECURITY__API_KEY` または `SECURITY__JWT_SECRET` を設定
 3. `API__BASE_URL` を `https://` URLに変更
-4. `uv run python -c "from config.settings import settings; print(settings.environment)"` で検証
+4. `uv run python -c "from config.settings import settings; print(f'環境: {settings.environment}')"` で検証
+   - `環境: staging` → 成功
+   - `環境: development` → `.env` の `ENVIRONMENT=staging` 設定を確認（プロジェクトルートで実行すること）
 
 ## エラーメッセージと対処法
 

--- a/docs/guides/staging_environment_guide.md
+++ b/docs/guides/staging_environment_guide.md
@@ -34,7 +34,7 @@ API__BASE_URL=https://<REPLACE_WITH_STAGING_API_URL>  # https:// 必須
 ENVIRONMENT=staging
 DEBUG=false
 API__BASE_URL=https://<REPLACE_WITH_STAGING_API_URL>
-ALLOWED_DOMAINS=<REPLACE_WITH_STAGING_API_DOMAIN>
+ALLOWED_DOMAINS=<REPLACE_WITH_STAGING_API_DOMAIN>  # デフォルトリストを上書き（置換）。複数ドメイン必要な場合はカンマ区切りで全て列挙
 SECURITY__API_KEY=<REPLACE_WITH_STAGING_API_KEY>
 LOG__LEVEL=INFO
 SENTRY__ENABLED=true
@@ -47,7 +47,7 @@ SENTRY__DSN=<REPLACE_WITH_SENTRY_DSN>
 1. `.env` の `ENVIRONMENT` を `staging` に変更
 2. `SECURITY__API_KEY` または `SECURITY__JWT_SECRET` を設定
 3. `API__BASE_URL` を `https://` URLに変更
-4. アプリ起動時にValidationErrorが発生しなければ設定は正常です。
+4. アプリ起動時（Pydantic Settingsインスタンス化）にValidationErrorが発生しなければ設定は正常である。
 
 ## エラーメッセージと対処法
 

--- a/docs/guides/staging_environment_guide.md
+++ b/docs/guides/staging_environment_guide.md
@@ -4,11 +4,7 @@
 
 ## 概要
 
-Staging環境はproduction同等のセキュリティポリシーが適用されます。
-`config/settings.py` の `_PRODUCTION_LIKE_ENVIRONMENTS` により、
-staging と production は同一のバリデーションを受けます。
-
-**影響範囲**: シークレット必須化 + HTTPS強制
+Staging環境はproduction同等のセキュリティポリシー（シークレット必須化・HTTPS強制）が適用されます。
 
 ## 必須環境変数
 
@@ -17,28 +13,28 @@ Staging環境（`ENVIRONMENT=staging`）では以下が必須です。
 ### シークレット（いずれか1つ以上）
 
 ```bash
-SECURITY__API_KEY="your-api-key"       # API認証キー
-SECURITY__JWT_SECRET="your-jwt-secret" # JWT署名シークレット
+SECURITY__API_KEY=<REPLACE_WITH_API_KEY>        # API認証キー
+SECURITY__JWT_SECRET=<REPLACE_WITH_JWT_SECRET>  # JWT署名シークレット
 ```
 
 `api_key` と `jwt_secret` の少なくとも一方を設定してください。
-両方未設定の場合、アプリケーション起動時に `ValueError` が発生します。
+両方未設定の場合、アプリケーション起動時に `ValidationError` が発生します。
 
 ### HTTPS必須
 
 ```bash
-API__BASE_URL=https://staging-api.example.com  # https:// 必須
+API__BASE_URL=https://<REPLACE_WITH_STAGING_API_URL>  # https:// 必須
 ```
 
-`http://` を指定すると `ValueError` が発生します。
+`http://` を指定すると `ValidationError` が発生します。
 
 ## .envファイル例（staging用）
 
 ```bash
 ENVIRONMENT=staging
 DEBUG=false
-API__BASE_URL=https://staging-api.example.com
-SECURITY__API_KEY="your-staging-key"  # placeholder example
+API__BASE_URL=https://<REPLACE_WITH_STAGING_API_URL>
+SECURITY__API_KEY=<REPLACE_WITH_STAGING_API_KEY>
 LOG__LEVEL=INFO
 SENTRY__ENABLED=true
 SENTRY__ENVIRONMENT=staging
@@ -56,7 +52,8 @@ SENTRY__ENVIRONMENT=staging
 ### シークレット未設定
 
 ```text
-ValueError: Staging environment requires at least one of: SECURITY__API_KEY or SECURITY__JWT_SECRET
+pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
+  Value error, Staging environment requires at least one of: SECURITY__API_KEY or SECURITY__JWT_SECRET [type=value_error, ...]
 ```
 
 **対処**: `SECURITY__API_KEY` または `SECURITY__JWT_SECRET` を `.env` に追加してください。
@@ -64,26 +61,14 @@ ValueError: Staging environment requires at least one of: SECURITY__API_KEY or S
 ### HTTP URL使用
 
 ```text
-ValueError: Staging environment requires HTTPS. Set API__BASE_URL to an https:// URL.
+pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
+  Value error, Staging environment requires HTTPS. Set API__BASE_URL to an https:// URL. [type=value_error, ...]
 ```
 
 **対処**: `API__BASE_URL` を `https://` で始まるURLに変更してください。
 
-## 技術的背景
-
-バリデーションは `config/settings.py` の以下のバリデータで実行されます。
-
-- `validate_production_secrets`（model_validator）: シークレット存在チェック
-- `validate_production_https`（model_validator）: HTTPS強制チェック
-
-対象環境の定義:
-
-```python
-_PRODUCTION_LIKE_ENVIRONMENTS = frozenset({Environment.PRODUCTION, Environment.STAGING})
-```
-
 ## 参考
 
-- `config/settings.py` L424-532: バリデータ実装
+- `config/settings.py` L492-532: バリデータ実装（`validate_production_secrets` / `validate_production_https`）
 - `.env.example`: 環境変数テンプレート
 - [Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)

--- a/docs/guides/staging_environment_guide.md
+++ b/docs/guides/staging_environment_guide.md
@@ -1,0 +1,89 @@
+# Staging環境セットアップガイド
+
+*最終更新: 2026年03月20日*
+
+## 概要
+
+Staging環境はproduction同等のセキュリティポリシーが適用されます。
+`config/settings.py` の `_PRODUCTION_LIKE_ENVIRONMENTS` により、
+staging と production は同一のバリデーションを受けます。
+
+**影響範囲**: シークレット必須化 + HTTPS強制
+
+## 必須環境変数
+
+Staging環境（`ENVIRONMENT=staging`）では以下が必須です。
+
+### シークレット（いずれか1つ以上）
+
+```bash
+SECURITY__API_KEY="your-api-key"       # API認証キー
+SECURITY__JWT_SECRET="your-jwt-secret" # JWT署名シークレット
+```
+
+`api_key` と `jwt_secret` の少なくとも一方を設定してください。
+両方未設定の場合、アプリケーション起動時に `ValueError` が発生します。
+
+### HTTPS必須
+
+```bash
+API__BASE_URL=https://staging-api.example.com  # https:// 必須
+```
+
+`http://` を指定すると `ValueError` が発生します。
+
+## .envファイル例（staging用）
+
+```bash
+ENVIRONMENT=staging
+DEBUG=false
+API__BASE_URL=https://staging-api.example.com
+SECURITY__API_KEY="your-staging-key"  # placeholder example
+LOG__LEVEL=INFO
+SENTRY__ENABLED=true
+SENTRY__ENVIRONMENT=staging
+```
+
+## 移行手順（development → staging）
+
+1. `.env` の `ENVIRONMENT` を `staging` に変更
+2. `SECURITY__API_KEY` または `SECURITY__JWT_SECRET` を設定
+3. `API__BASE_URL` を `https://` URLに変更
+4. `uv run python -c "from config.settings import settings; print(settings.environment)"` で検証
+
+## エラーメッセージと対処法
+
+### シークレット未設定
+
+```text
+ValueError: Staging environment requires at least one of: SECURITY__API_KEY or SECURITY__JWT_SECRET
+```
+
+**対処**: `SECURITY__API_KEY` または `SECURITY__JWT_SECRET` を `.env` に追加してください。
+
+### HTTP URL使用
+
+```text
+ValueError: Staging environment requires HTTPS. Set API__BASE_URL to an https:// URL.
+```
+
+**対処**: `API__BASE_URL` を `https://` で始まるURLに変更してください。
+
+## 技術的背景
+
+バリデーションは `config/settings.py` の以下のバリデータで実行されます。
+
+- `validate_production_secrets`（model_validator）: シークレット存在チェック
+- `validate_production_https`（model_validator）: HTTPS強制チェック
+
+対象環境の定義:
+
+```python
+_PRODUCTION_LIKE_ENVIRONMENTS = frozenset({Environment.PRODUCTION, Environment.STAGING})
+```
+
+## 参考
+
+- `config/settings.py` L424-532: バリデータ実装
+- `.env.example`: 環境変数テンプレート
+- [Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)

--- a/docs/guides/staging_environment_guide.md
+++ b/docs/guides/staging_environment_guide.md
@@ -71,6 +71,6 @@ pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
 
 ## 参考
 
-- `config/settings.py` L491-532: バリデータ実装（`validate_production_secrets` / `validate_production_https`）
+- `config/settings.py`: バリデータ実装（`validate_production_secrets` / `validate_production_https`）
 - `.env.example`: 環境変数テンプレート
 - [Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)

--- a/docs/guides/staging_environment_guide.md
+++ b/docs/guides/staging_environment_guide.md
@@ -1,6 +1,6 @@
 # Staging環境セットアップガイド
 
-*最終更新: 2026年03月20日*
+*最終更新: 2026年03月21日*
 
 ## 概要
 
@@ -34,10 +34,12 @@ API__BASE_URL=https://<REPLACE_WITH_STAGING_API_URL>  # https:// 必須
 ENVIRONMENT=staging
 DEBUG=false
 API__BASE_URL=https://<REPLACE_WITH_STAGING_API_URL>
+ALLOWED_DOMAINS=<REPLACE_WITH_STAGING_API_DOMAIN>
 SECURITY__API_KEY=<REPLACE_WITH_STAGING_API_KEY>
 LOG__LEVEL=INFO
 SENTRY__ENABLED=true
 SENTRY__ENVIRONMENT=staging
+SENTRY__DSN=<REPLACE_WITH_SENTRY_DSN>
 ```
 
 ## 移行手順（development → staging）
@@ -45,9 +47,7 @@ SENTRY__ENVIRONMENT=staging
 1. `.env` の `ENVIRONMENT` を `staging` に変更
 2. `SECURITY__API_KEY` または `SECURITY__JWT_SECRET` を設定
 3. `API__BASE_URL` を `https://` URLに変更
-4. `uv run python -c "from config.settings import settings; print(f'環境: {settings.environment}')"` で検証
-   - `環境: staging` → 成功
-   - `環境: development` → `.env` の `ENVIRONMENT=staging` 設定を確認（プロジェクトルートで実行すること）
+4. アプリ起動時にValidationErrorが発生しなければ設定は正常です。
 
 ## エラーメッセージと対処法
 
@@ -69,8 +69,16 @@ pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
 
 **対処**: `API__BASE_URL` を `https://` で始まるURLに変更してください。
 
+### Domain not in allowlist
+
+```text
+pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
+  Value error, SSRF Prevention: Domain not in allowlist: <staging-domain>. Allowed domains count: N [type=value_error, ...]
+```
+
+**対処**: `ALLOWED_DOMAINS=<staging-domain>` を `.env` に追加してください。
+
 ## 参考
 
 - `config/settings.py`: バリデータ実装（`validate_production_secrets` / `validate_production_https`）
 - `.env.example`: 環境変数テンプレート
-- [Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)

--- a/docs/guides/staging_environment_guide.md
+++ b/docs/guides/staging_environment_guide.md
@@ -17,7 +17,7 @@ SECURITY__API_KEY=<REPLACE_WITH_API_KEY>        # API認証キー
 SECURITY__JWT_SECRET=<REPLACE_WITH_JWT_SECRET>  # JWT署名シークレット
 ```
 
-`api_key` と `jwt_secret` の少なくとも一方を設定してください。
+`SECURITY__API_KEY` と `SECURITY__JWT_SECRET` の少なくとも一方を設定してください。
 両方未設定の場合、アプリケーション起動時に `ValidationError` が発生します。
 
 ### HTTPS必須
@@ -69,6 +69,6 @@ pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
 
 ## 参考
 
-- `config/settings.py` L492-532: バリデータ実装（`validate_production_secrets` / `validate_production_https`）
+- `config/settings.py` L491-532: バリデータ実装（`validate_production_secrets` / `validate_production_https`）
 - `.env.example`: 環境変数テンプレート
 - [Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -356,6 +356,17 @@ class TestProductionSecretValidation:
         )
         assert settings.environment == Environment.STAGING
 
+    def test_staging_with_jwt_secret_valid(self):
+        """ステージング環境でjwt_secret設定時は有効"""
+        settings = Settings(
+            environment=Environment.STAGING,
+            security=SecurityConfig(jwt_secret=SecretStr("test-secret")),
+            api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),
+        )
+        assert settings.environment == Environment.STAGING
+        assert settings.security.jwt_secret is not None
+        assert settings.security.api_key is None
+
 
 class TestProductionHTTPSValidation:
     """本番環境でのHTTPS強制テスト"""

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -179,7 +179,7 @@ class TestSettingsEnvironmentValidation:
             settings = Settings(
                 environment=env_input,  # type: ignore[arg-type]
                 security=SecurityConfig(api_key=SecretStr("test-key")),
-                api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),  # https required
+                api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),  # https:// 必須
             )
         else:
             settings = Settings(environment=env_input)  # type: ignore[arg-type]
@@ -340,12 +340,11 @@ class TestProductionSecretValidation:
 
     def test_staging_without_secrets_raises_error(self):
         """ステージング環境でシークレット未設定時にエラー (STAGING=本番同等ポリシー)"""
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ValidationError, match="Staging environment requires"):
             Settings(
                 environment=Environment.STAGING,
                 api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),
             )
-        assert "SECURITY__API_KEY or SECURITY__JWT_SECRET" in str(exc_info.value)
 
     def test_staging_with_api_key_valid(self):
         """ステージング環境でapi_key設定時は有効"""
@@ -365,6 +364,7 @@ class TestProductionSecretValidation:
             api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),
         )
         assert settings.environment == Environment.STAGING
+        assert settings.security.jwt_secret is not None
 
 
 class TestProductionHTTPSValidation:

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -179,7 +179,7 @@ class TestSettingsEnvironmentValidation:
             settings = Settings(
                 environment=env_input,  # type: ignore[arg-type]
                 security=SecurityConfig(api_key=SecretStr("test-key")),
-                api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),
+                api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),  # https required
             )
         else:
             settings = Settings(environment=env_input)  # type: ignore[arg-type]
@@ -361,7 +361,7 @@ class TestProductionSecretValidation:
         settings = Settings(
             environment=Environment.STAGING,
             security=SecurityConfig(jwt_secret=SecretStr("test-secret")),
-            api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),  # HTTPS必須
+            api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),  # https required
         )
         assert settings.environment == Environment.STAGING
 

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -364,8 +364,6 @@ class TestProductionSecretValidation:
             api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),
         )
         assert settings.environment == Environment.STAGING
-        assert settings.security.jwt_secret is not None
-        assert settings.security.api_key is None
 
 
 class TestProductionHTTPSValidation:

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -340,7 +340,7 @@ class TestProductionSecretValidation:
 
     def test_staging_without_secrets_raises_error(self):
         """ステージング環境でシークレット未設定時にエラー (STAGING=本番同等ポリシー)"""
-        with pytest.raises(ValidationError, match="Staging environment requires"):
+        with pytest.raises(ValidationError, match="SECURITY__API_KEY or SECURITY__JWT_SECRET"):
             Settings(
                 environment=Environment.STAGING,
                 api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -361,7 +361,8 @@ class TestProductionSecretValidation:
         settings = Settings(
             environment=Environment.STAGING,
             security=SecurityConfig(jwt_secret=SecretStr("test-secret")),
-            api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),  # https required
+            # validate_production_https のためHTTPS必須
+            api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),
         )
         assert settings.environment == Environment.STAGING
 

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -364,7 +364,6 @@ class TestProductionSecretValidation:
             api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),
         )
         assert settings.environment == Environment.STAGING
-        assert settings.security.jwt_secret is not None
 
 
 class TestProductionHTTPSValidation:

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -361,7 +361,7 @@ class TestProductionSecretValidation:
         settings = Settings(
             environment=Environment.STAGING,
             security=SecurityConfig(jwt_secret=SecretStr("test-secret")),
-            api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),
+            api=APIConfig(base_url="https://jsonplaceholder.typicode.com"),  # HTTPS必須
         )
         assert settings.environment == Environment.STAGING
 


### PR DESCRIPTION
## 概要
config/settings.pyでstaging環境にproduction同等のバリデーション（シークレット必須+HTTPS強制）が実装済みだが、マイグレーションガイドが不在だったため追加。

## 変更内容
- .env.example: SECURITY__API_KEY/JWT_SECRETのコメントを「required in production/staging」に更新
- docs/guides/staging_environment_guide.md: 新規作成（必須変数、移行手順、エラー対処法）

## テスト
- [x] markdownlint: 0 errors
- [x] gitleaks: Passed

## 関連Issue/PR
Closes #223 (Issue)

---
このPRは /push-pr スキルで自動生成されました。

## Review Response (2026-03-21)

| 分類 | 件数 | 対応 |
|------|------|------|
| AUTO-FIX | 5件 | 修正済み（エラーメッセージ完全形式・URLプレースホルダー化・行番号修正） |
| NEEDS-DECISION | 1件 | 技術的背景セクション削除（YAGNI）・品質改善推奨6項目全対応 |
| SKIP | 1件 | PRサマリーコメント（情報提供のみ） |

コミット: `55a9c9e`


## Review Response (2026-03-21)

| 分類 | 件数 | 対応 |
|------|------|------|
| NEEDS-DECISION（修正あり） | 2件 | 修正済み |
| SKIP | 0件 | - |

コミット: `a925567`

**対応内容**: ALLOWED_DOMAINS欠落修正（マージブロッカー）+ 品質改善items 1,3,4,6,7,8対応


## Review Response (2026-03-21)

| 分類 | 件数 | 対応 |
|------|------|------|
| AUTO-FIX | 0件 | - |
| NEEDS-DECISION | 3件 | matchパターン強化・ALLOWED_DOMAINS注記追加・ステップ4文言修正+textlint解消 |
| SKIP | 1件 | jwt_secret アサーション（YAGNI判断・pushback返信済み） |

コミット: `5090715`
