### PR TITLE
fix(ci,test): setup-uvアクション化・PII防御・テスト強化 (PR #340 review)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Install dependencies
         run: uv sync --dev
@@ -301,9 +299,7 @@ jobs:
           python-version: '3.14'
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Install dependencies
         run: uv sync --dev
@@ -431,9 +427,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Install dependencies
         run: uv sync --dev

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -357,7 +357,8 @@ def reset_sentry_warning_state(
 ) -> Iterator[None]:
     """utils.logger の sentry warning throttle 状態をテスト前後でリセット
 
-    4 つの permanent throttle マーカー ("settings"/"sdk"/"bug"/"outside_except") を
+    6 つの permanent throttle マーカー
+    ("settings"/"sdk"/"bug"/"outside_except"/"invalid_exc_info"/"safe_error_summary") を
     保持する `_sentry_warnings_emitted: set[str]` を空集合に、
     `_sentry_send_error_last_warned` timestamp を float("-inf") にリセットする。
     `_is_sentry_debug_enabled` は lru_cache 削除済みのためリアルタイム取得。
@@ -384,10 +385,7 @@ def reset_sentry_warning_state(
     monkeypatch.setattr("utils.logger._sentry_send_error_last_warned", float("-inf"))
     # SENTRY_DEBUG は環境変数をリアルタイム取得するため cache_clear() 不要
     # (lru_cache削除済みversion: logger.py _is_sentry_debug_enabled)
-    try:
-        yield
-    finally:
-        pass  # teardown: SENTRY_DEBUG クリア不要（環境変数リアルタイム取得）
+    yield
 
 
 # =============================================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,17 +360,16 @@ def reset_sentry_warning_state(
     4 つの permanent throttle マーカー ("settings"/"sdk"/"bug"/"outside_except") を
     保持する `_sentry_warnings_emitted: set[str]` を空集合に、
     `_sentry_send_error_last_warned` timestamp を float("-inf") にリセットする。
-    `_is_sentry_debug_enabled` の lru_cache も合わせてクリアし monkeypatch.setenv/
-    delenv との整合性を保つ。
+    `_is_sentry_debug_enabled` は lru_cache 削除済みのためリアルタイム取得。
+    monkeypatch.setenv/delenv との整合性は自動的に保たれる。
 
     `_sentry_warning_lock` (threading.Lock) はリセット対象外:
     Lock インスタンス自体を差し替えるとモジュール内の他参照と整合しなくなり、また
     ロック状態は test 間で leak しない (各テスト内でロック取得・解放が完結する) ため
     リセット不要。
 
-    monkeypatch.setattr は test 終了時に自動復元されるが、`lru_cache` は monkeypatch
-    管轄外のため teardown でも明示的に cache_clear() を実行し、teardown フック介入
-    (pytest plugin 等) によるキャッシュ汚染残留リスクを排除する。
+    monkeypatch.setattr は test 終了時に自動復元され、環境変数変更も即時反映される。
+    lru_cache 削除済みのため teardown での cache_clear() は不要。
 
     autouse=True により全テストで自動適用し、TestSentryProcessor 以外のクラスでも
     モジュールレベル throttle 状態の汚染を防止する (同一プロセス内の逐次テスト間
@@ -380,19 +379,15 @@ def reset_sentry_warning_state(
     グローバル変数はプロセス間で共有されない。本 fixture の主目的は同一プロセス内
     の逐次テスト間の汚染防止であり、xdist による並列実行は副次的な恩恵。
     """
-    from utils.logger import _is_sentry_debug_enabled
 
     monkeypatch.setattr("utils.logger._sentry_warnings_emitted", set())
     monkeypatch.setattr("utils.logger._sentry_send_error_last_warned", float("-inf"))
-    # SENTRY_DEBUG の lru_cache を test 開始前にクリア。
-    # monkeypatch.setenv/delenv との整合性確保のため必須。
-    _is_sentry_debug_enabled.cache_clear()
+    # SENTRY_DEBUG は環境変数をリアルタイム取得するため cache_clear() 不要
+    # (lru_cache削除済みversion: logger.py _is_sentry_debug_enabled)
     try:
         yield
     finally:
-        # teardown でも明示的にクリア。lru_cache は monkeypatch 管轄外のため、
-        # test 内でキャッシュが更新されると次テストの setUp 前まで残留する。
-        _is_sentry_debug_enabled.cache_clear()
+        pass  # teardown: SENTRY_DEBUG クリア不要（環境変数リアルタイム取得）
 
 
 # =============================================================================

--- a/tests/unit/test_api_client_shared.py
+++ b/tests/unit/test_api_client_shared.py
@@ -452,7 +452,6 @@ def test_sync_client_headers_empty_dict_preserves_defaults(mock_base_url: str) -
         assert client.default_headers["Content-Type"] == "application/json"
 
 
-@pytest.mark.asyncio
 async def test_async_client_headers_empty_dict_preserves_defaults(mock_base_url: str) -> None:
     """AsyncAPIClient: headers={} でデフォルトヘッダーが保持される
 

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -15,12 +15,14 @@ from config.settings import (
     SecurityConfig,
     SentryConfig,
     Settings,
-    TestConfig,
     _resolve_hostname,
     _resolve_hostname_cached,
     get_settings,
     is_private_ip,
     reload_settings,
+)
+from config.settings import (
+    TestConfig as ConfigForTestingEnv,
 )
 
 # Module-level marker: All tests in this file are unit tests
@@ -569,7 +571,7 @@ class TestNestedConfigDefaults:
         [
             pytest.param("api", APIConfig, id="api_config"),
             pytest.param("log", LogConfig, id="log_config"),
-            pytest.param("test", TestConfig, id="test_config"),
+            pytest.param("test", ConfigForTestingEnv, id="test_config"),
             pytest.param("security", SecurityConfig, id="security_config"),
         ],
     )

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -7,7 +7,6 @@ from typing import Any
 import pytest
 from pydantic import SecretStr, ValidationError
 
-# isort: off
 from config.settings import (
     APIConfig,
     Environment,
@@ -16,14 +15,15 @@ from config.settings import (
     SecurityConfig,
     SentryConfig,
     Settings,
-    TestConfig as ConfigForTestingEnv,
     _resolve_hostname,
     _resolve_hostname_cached,
     get_settings,
     is_private_ip,
     reload_settings,
 )
-# isort: on
+from config.settings import (
+    TestConfig as ConfigForTestingEnv,
+)
 
 # Module-level marker: All tests in this file are unit tests
 pytestmark = pytest.mark.unit

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 from pydantic import SecretStr, ValidationError
 
+# isort: off
 from config.settings import (
     APIConfig,
     Environment,
@@ -15,15 +16,14 @@ from config.settings import (
     SecurityConfig,
     SentryConfig,
     Settings,
+    TestConfig as ConfigForTestingEnv,
     _resolve_hostname,
     _resolve_hostname_cached,
     get_settings,
     is_private_ip,
     reload_settings,
 )
-from config.settings import (
-    TestConfig as ConfigForTestingEnv,
-)
+# isort: on
 
 # Module-level marker: All tests in this file are unit tests
 pytestmark = pytest.mark.unit

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -22,7 +22,7 @@ from config.settings import (
     reload_settings,
 )
 from config.settings import (
-    TestConfig as ConfigForTestingEnv,
+    TestConfig as SettingsTestConfig,
 )
 
 # Module-level marker: All tests in this file are unit tests
@@ -571,7 +571,7 @@ class TestNestedConfigDefaults:
         [
             pytest.param("api", APIConfig, id="api_config"),
             pytest.param("log", LogConfig, id="log_config"),
-            pytest.param("test", ConfigForTestingEnv, id="test_config"),
+            pytest.param("test", SettingsTestConfig, id="test_config"),
             pytest.param("security", SecurityConfig, id="security_config"),
         ],
     )

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -255,6 +255,7 @@ async def test_timeout_handling(
     assert route.call_count == MAX_RETRIES  # timeout は max_retries 回まで再試行
     assert mock_backoff.call_count == MAX_RETRIES - 1
     assert mock_sleep.await_count == MAX_RETRIES - 1
+    mock_sleep.assert_has_awaits([call(0.0)] * (MAX_RETRIES - 1))
     timeout_logs = [log for log in log_output if log.get("event") == "request_timeout"]
     assert len(timeout_logs) == MAX_RETRIES
     for timeout_log in timeout_logs:
@@ -312,6 +313,70 @@ async def test_timeout_logging_no_pii_leak():
     assert route.call_count == MAX_RETRIES
     assert mock_backoff.call_count == MAX_RETRIES - 1
     assert mock_sleep.await_count == MAX_RETRIES - 1
+
+
+@pytest.mark.parametrize(
+    ("network_exception", "expected_message"),
+    [
+        pytest.param(
+            httpx.ConnectError("Connection refused"),
+            "Network error: ConnectError",
+            id="connect_error",
+        ),
+        pytest.param(
+            httpx.ReadError("Read failed"),
+            "Network error: ReadError",
+            id="read_error",
+        ),
+        pytest.param(
+            httpx.RemoteProtocolError("Server disconnected"),
+            "Network error: RemoteProtocolError",
+            id="remote_protocol_error",
+        ),
+    ],
+)
+@respx.mock
+async def test_network_error_retry_handling(
+    network_exception: httpx.NetworkError,
+    expected_message: str,
+) -> None:
+    """NetworkError系をretry後、GitHubAPIErrorへ安全に変換する。"""
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=network_exception)
+
+    with patch(
+        "utils.github_client.exponential_backoff_with_jitter",
+        return_value=0.0,
+    ) as mock_backoff:
+        with patch("utils.github_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            with capture_logs() as log_output:
+                async with AsyncGitHubClient() as client:
+                    with pytest.raises(GitHubAPIError) as exc_info:
+                        await client.get_user("octocat")
+
+    assert str(exc_info.value) == expected_message
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+    assert route.call_count == MAX_RETRIES
+    assert mock_backoff.call_count == MAX_RETRIES - 1
+    assert mock_sleep.await_count == MAX_RETRIES - 1
+    mock_sleep.assert_has_awaits([call(0.0)] * (MAX_RETRIES - 1))
+    network_logs = [log for log in log_output if log.get("event") == "request_network_error"]
+    assert len(network_logs) == MAX_RETRIES
+    for network_log in network_logs:
+        assert network_log["error_type"] == type(network_exception).__qualname__
+        assert network_log["error_module"] == type(network_exception).__module__
+        assert network_log["error_context"] == "network"
+        assert set(network_log) == {
+            "endpoint",
+            "method",
+            "error_type",
+            "error_module",
+            "error_context",
+            "event",
+            "log_level",
+        }
+        assert "error_detail" not in network_log
+        assert "error" not in network_log
 
 
 # =============================================================================

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -194,11 +194,31 @@ async def test_retry_on_server_error(mock_sleep: AsyncMock, mock_backoff: Mock) 
 @pytest.mark.parametrize(
     ("timeout_exception", "expected_message"),
     [
-        (httpx.TimeoutException("Request timeout"), "Request timeout: TimeoutException"),
-        (httpx.ConnectTimeout("Connect timeout"), "Request timeout: ConnectTimeout"),
-        (httpx.ReadTimeout("Read timeout"), "Request timeout: ReadTimeout"),
-        (httpx.WriteTimeout("Write timeout"), "Request timeout: WriteTimeout"),
-        (httpx.PoolTimeout("Pool timeout"), "Request timeout: PoolTimeout"),
+        pytest.param(
+            httpx.TimeoutException("Request timeout"),
+            "Request timeout: TimeoutException",
+            id="timeout_exception",
+        ),
+        pytest.param(
+            httpx.ConnectTimeout("Connect timeout"),
+            "Request timeout: ConnectTimeout",
+            id="connect_timeout",
+        ),
+        pytest.param(
+            httpx.ReadTimeout("Read timeout"),
+            "Request timeout: ReadTimeout",
+            id="read_timeout",
+        ),
+        pytest.param(
+            httpx.WriteTimeout("Write timeout"),
+            "Request timeout: WriteTimeout",
+            id="write_timeout",
+        ),
+        pytest.param(
+            httpx.PoolTimeout("Pool timeout"),
+            "Request timeout: PoolTimeout",
+            id="pool_timeout",
+        ),
     ],
 )
 @respx.mock
@@ -228,6 +248,7 @@ async def test_timeout_handling(
     assert len(timeout_logs) == 1
     assert timeout_logs[0]["error_type"] == type(timeout_exception).__qualname__
     assert timeout_logs[0]["error_module"] == type(timeout_exception).__module__
+    assert timeout_logs[0]["error_context"] == "timeout"
     # PII漏洩防止: error_detailフィールド除去 (unexpected_errorパスと同方針)
     assert "error_detail" not in timeout_logs[0]
     assert "error" not in timeout_logs[0]
@@ -614,6 +635,7 @@ async def test_unexpected_exception():
     assert "error" not in error_logs[0]
     assert error_logs[0]["error_type"] == "ValueError"
     assert error_logs[0]["error_module"] == "builtins"
+    assert error_logs[0]["error_context"] == "unexpected"
     # PII値レベル検証: 全 log フィールド値に sensitive_detail が漏洩していないこと
     for value in error_logs[0].values():
         assert sensitive_detail not in str(value), (

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -10,7 +10,7 @@ GitHub API非同期クライアントのUnit Tests
 import asyncio
 import json
 from datetime import UTC, datetime
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import httpx
 import pytest
@@ -163,7 +163,8 @@ async def test_rate_limit_exceeded():
 
 @respx.mock
 @patch("utils.github_client.exponential_backoff_with_jitter", return_value=0.0)
-async def test_retry_on_server_error(mock_backoff: Mock) -> None:
+@patch("utils.github_client.asyncio.sleep", new_callable=AsyncMock)
+async def test_retry_on_server_error(mock_sleep: AsyncMock, mock_backoff: Mock) -> None:
     """5xxエラーで3回リトライ後、GitHubServerError発生
 
     検証項目:
@@ -186,6 +187,8 @@ async def test_retry_on_server_error(mock_backoff: Mock) -> None:
     assert "Server error: 500" in str(exc_info.value)
     assert f"after {MAX_RETRIES} attempts" in str(exc_info.value)
     assert mock_backoff.call_count == MAX_RETRIES - 1  # MAX_RETRIES試行 → 最終試行以外でバックオフ
+    assert mock_sleep.await_count == MAX_RETRIES - 1
+    mock_sleep.assert_awaited_with(0.0)
 
 
 @respx.mock
@@ -206,6 +209,7 @@ async def test_timeout_handling():
             await client.get_user("octocat")
 
     assert "timeout" in str(exc_info.value).lower()
+    assert str(exc_info.value) == "Request timeout: TimeoutException"
     # 例外チェーン確認
     assert exc_info.value.__cause__ is not None
     assert isinstance(exc_info.value.__cause__, httpx.TimeoutException)
@@ -335,6 +339,7 @@ async def test_httpx_timeout_exception():
             await client.get_user("octocat")
 
     assert "timeout" in str(exc_info.value).lower()
+    assert str(exc_info.value) == "Request timeout: TimeoutException"
     assert exc_info.value.__cause__ is not None
     assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
 
@@ -555,13 +560,18 @@ async def test_unexpected_exception():
         side_effect=ValueError("Unexpected error")
     )
 
-    async with AsyncGitHubClient() as client:
-        with pytest.raises(GitHubAPIError) as exc_info:
-            await client.get_user("octocat")
+    with capture_logs() as log_output:
+        async with AsyncGitHubClient() as client:
+            with pytest.raises(GitHubAPIError) as exc_info:
+                await client.get_user("octocat")
 
     assert "Unexpected error" in str(exc_info.value)
     assert isinstance(exc_info.value.__cause__, ValueError)
     assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
+    error_logs = [log for log in log_output if log.get("event") == "unexpected_error"]
+    assert len(error_logs) == 1
+    assert "error" not in error_logs[0]
+    assert error_logs[0]["error_type"] == "ValueError"
 
 
 # =============================================================================
@@ -745,6 +755,21 @@ async def test_invalid_rate_limit_header_remaining():
     assert warning_logs[0]["value"] == repr("N/A")
 
 
+def test_missing_rate_limit_header_returns_default_without_warning() -> None:
+    """Rate Limitヘッダー未設定時はwarningなしでdefaultを返す。"""
+    client = AsyncGitHubClient()
+
+    with capture_logs() as log_output:
+        result = client._parse_rate_limit_header(
+            httpx.Headers(),
+            "X-RateLimit-Remaining",
+            999,
+        )
+
+    assert result == 999
+    assert not [log for log in log_output if log.get("event") == "invalid_rate_limit_header"]
+
+
 @respx.mock
 async def test_invalid_rate_limit_header_403():
     """403応答時にX-RateLimit-Remainingが不正値の場合、warningログ後 GitHubAPIError 発生
@@ -881,6 +906,7 @@ async def test_invalid_rate_limit_reset_header_rate_limit_exceeded():
         pytest.param("a" * 100, id="max_length"),  # 上限（100文字）
         pytest.param("my_repo", id="underscore"),
         pytest.param("my.repo", id="dot"),
+        pytest.param(".github", id="github_special_repository"),
         pytest.param("123", id="digits_only"),
     ],
 )
@@ -1217,11 +1243,12 @@ def test_handle_403_response_no_json_log() -> None:
     )
     with capture_logs() as logs:
         # _handle_403_response は NoReturn のため pytest.raises は必須（ログ検証が目的）
-        with pytest.raises(GitHubAPIError, match="Access forbidden"):
+        with pytest.raises(GitHubAPIError, match="Access forbidden") as exc_info:
             client._handle_403_response(response)
         warning_logs = [log for log in logs if log.get("event") == "failed_to_parse_403_message"]
         assert len(warning_logs) == 1
         assert warning_logs[0]["log_level"] == "warning"
+        assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -9,6 +9,7 @@ GitHub API非同期クライアントのUnit Tests
 
 import asyncio
 import json
+import re
 from datetime import UTC, datetime
 from unittest.mock import ANY, AsyncMock, Mock, call, patch
 
@@ -23,6 +24,7 @@ from utils.github_client import (
     GitHubServerError,
     NotFoundError,
     RateLimitError,
+    _redact_body_preview,
     validate_github_repo,
 )
 
@@ -243,6 +245,7 @@ async def test_timeout_handling(
     assert str(exc_info.value) == expected_message
     # 例外チェーン切断確認（from None による PII 漏洩防止）
     assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None  # except外raiseパターン検証
     assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
     timeout_logs = [log for log in log_output if log.get("event") == "request_timeout"]
     assert len(timeout_logs) == 1
@@ -275,6 +278,7 @@ async def test_timeout_logging_no_pii_leak():
     assert sensitive_detail not in str(exc_info.value)
     # __cause__ 切断検証: from None により Sentry/traceback 経由の PII 漏洩を防止
     assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None  # except外raiseパターン検証
     timeout_logs = [log for log in log_output if log.get("event") == "request_timeout"]
     assert len(timeout_logs) == 1
     # PII値レベル検証: 全logフィールド値にsensitive_detailが漏洩していないこと
@@ -415,6 +419,8 @@ async def test_httpx_status_error_4xx():
     assert isinstance(exc_info.value.__cause__, Exception)
     # __cause__がhttpx.HTTPStatusErrorそのものでないことを型レベルで確認
     assert not isinstance(exc_info.value.__cause__, httpx.HTTPStatusError)
+    # except外raiseパターン: HTTPStatusErrorが__context__に残存しないこと（PII漏洩防止）
+    assert exc_info.value.__context__ is None
     assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
     # メッセージ形式検証: ボディ除去後の正確なフォーマット確認
     assert str(exc_info.value) == "HTTP 401 error"
@@ -551,6 +557,7 @@ async def test_httpx_status_error_403_defensive_path() -> None:
         with pytest.raises(RateLimitError) as exc_info:
             await client.get_user("octocat")
 
+    assert exc_info.value.__context__ is None  # sentinel pattern: except外raiseパターン検証
     assert exc_info.value.reset_time == 1640000000
     assert "Rate limit exceeded" in str(exc_info.value)
     assert route.call_count == 1
@@ -576,9 +583,10 @@ async def test_httpx_status_error_403_auth_error_defensive_path() -> None:
     route.side_effect = [error_403]
 
     async with AsyncGitHubClient() as client:
-        with pytest.raises(GitHubAPIError, match="Access forbidden"):
+        with pytest.raises(GitHubAPIError, match="Access forbidden") as exc_info:
             await client.get_user("octocat")
 
+    assert exc_info.value.__context__ is None  # sentinel pattern: except外raiseパターン検証
     assert route.call_count == 1
 
 
@@ -629,6 +637,7 @@ async def test_unexpected_exception():
     assert sensitive_detail not in str(exc_info.value)
     # 例外チェーンは切断し、元例外メッセージは露出しない
     assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
     assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
     error_logs = [log for log in log_output if log.get("event") == "unexpected_error"]
     assert len(error_logs) == 1
@@ -1097,25 +1106,38 @@ def test_handle_403_response(
         assert rate_limit_error.reset_time == int(reset_header)
 
 
+def test_redact_body_preview_returns_fixed_format() -> None:
+    """_redact_body_preview: [redacted:SHA256_12chars]形式を返す"""
+    result = _redact_body_preview("any content here")
+    assert re.fullmatch(r"\[redacted:[0-9a-f]{12}\]", result)
+
+
+def test_redact_body_preview_empty_string() -> None:
+    """_redact_body_preview: 空文字列→確定的ハッシュ"""
+    assert _redact_body_preview("") == "[redacted:e3b0c44298fc]"
+
+
+def test_redact_body_preview_deterministic() -> None:
+    """_redact_body_preview: 同一入力→同一ハッシュ（冪等性）"""
+    body = "A" * 200
+    assert _redact_body_preview(body) == _redact_body_preview(body)
+    assert _redact_body_preview(body) == "[redacted:70d3bf8b0b9d]"
+
+
 def test_handle_http_status_error_uses_debug_for_other_4xx() -> None:
     """_handle_http_status_error: 401以外の4xxでは debug ログを使う"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
     mock_request = httpx.Request("GET", "https://api.github.com/test")
     mock_response = httpx.Response(404, request=mock_request)
-    error = httpx.HTTPStatusError(
-        "HTTP 404",
-        request=mock_request,
-        response=mock_response,
-    )
     with patch.object(client, "logger") as mock_logger:
         with pytest.raises(GitHubAPIError, match=r"^HTTP 404 error$"):
-            client._handle_http_status_error(error)
+            client._handle_http_status_error(mock_response, "/test", "GET")
         mock_logger.debug.assert_called_once_with(
             "http_status_error",
             status_code=404,
             endpoint="/test",
             method="GET",
-            body_preview="",
+            body_preview="[redacted:e3b0c44298fc]",
         )
         mock_logger.warning.assert_not_called()
 
@@ -1125,21 +1147,16 @@ def test_handle_http_status_error_uses_warning_for_401() -> None:
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
     mock_request = httpx.Request("GET", "https://api.github.com/test")
     mock_response = httpx.Response(401, request=mock_request)
-    error = httpx.HTTPStatusError(
-        "HTTP 401",
-        request=mock_request,
-        response=mock_response,
-    )
 
     with patch.object(client, "logger") as mock_logger:
         with pytest.raises(GitHubAPIError, match=r"^HTTP 401 error$"):
-            client._handle_http_status_error(error)
+            client._handle_http_status_error(mock_response, "/test", "GET")
         mock_logger.warning.assert_called_once_with(
             "http_status_error",
             status_code=401,
             endpoint="/test",
             method="GET",
-            body_preview="",
+            body_preview="[redacted:e3b0c44298fc]",
         )
         mock_logger.debug.assert_not_called()
 
@@ -1149,21 +1166,16 @@ def test_handle_http_status_error_warning_truncates_body_preview_for_401() -> No
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
     mock_request = httpx.Request("GET", "https://api.github.com/test")
     mock_response = httpx.Response(401, content=b"A" * 201, request=mock_request)
-    error = httpx.HTTPStatusError(
-        "HTTP 401",
-        request=mock_request,
-        response=mock_response,
-    )
 
     with patch.object(client, "logger") as mock_logger:
         with pytest.raises(GitHubAPIError, match=r"^HTTP 401 error$"):
-            client._handle_http_status_error(error)
+            client._handle_http_status_error(mock_response, "/test", "GET")
         mock_logger.warning.assert_called_once_with(
             "http_status_error",
             status_code=401,
             endpoint="/test",
             method="GET",
-            body_preview="A" * 200,
+            body_preview="[redacted:70d3bf8b0b9d]",
         )
         mock_logger.debug.assert_not_called()
 
@@ -1173,10 +1185,9 @@ def test_handle_http_status_error_with_5xx_raises_github_api_error() -> None:
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
     request = httpx.Request("GET", "https://api.github.com/test")
     response = httpx.Response(503, request=request)
-    error = httpx.HTTPStatusError("HTTP 503", request=request, response=response)
 
     with pytest.raises(GitHubAPIError, match=r"^HTTP 503 error$"):
-        client._handle_http_status_error(error)
+        client._handle_http_status_error(response, "/test", "GET")
 
 
 def test_handle_304_response_cache_miss() -> None:
@@ -1459,12 +1470,11 @@ def test_handle_http_status_error_truncates_long_body() -> None:
     long_body = "x" * 201
     request = httpx.Request("GET", "https://api.github.com/test")
     response = httpx.Response(422, request=request, content=long_body.encode())
-    error = httpx.HTTPStatusError("422", request=request, response=response)
 
     with patch.object(client, "logger") as mock_logger:
         with pytest.raises(GitHubAPIError) as exc_info:
-            client._handle_http_status_error(error)
-        assert mock_logger.debug.call_args.kwargs["body_preview"] == "x" * 200
+            client._handle_http_status_error(response, "/test", "GET")
+        assert mock_logger.debug.call_args.kwargs["body_preview"] == "[redacted:aa20c23e3201]"
 
     # エラーメッセージにボディが含まれないこと
     assert "x" not in str(exc_info.value)
@@ -1476,12 +1486,11 @@ def test_handle_http_status_error_no_truncation_at_boundary() -> None:
     exact_body = "y" * 200  # ちょうど200文字（[:200]スライスで切り詰めが発生しない境界値）
     request = httpx.Request("GET", "https://api.github.com/test")
     response = httpx.Response(422, request=request, content=exact_body.encode())
-    error = httpx.HTTPStatusError("422", request=request, response=response)
 
     with patch.object(client, "logger") as mock_logger:
         with pytest.raises(GitHubAPIError) as exc_info:
-            client._handle_http_status_error(error)
-        assert mock_logger.debug.call_args.kwargs["body_preview"] == exact_body
+            client._handle_http_status_error(response, "/test", "GET")
+        assert mock_logger.debug.call_args.kwargs["body_preview"] == "[redacted:8ca9bfd43d61]"
 
     # エラーメッセージにボディが含まれないこと
     assert exact_body not in str(exc_info.value)
@@ -1495,12 +1504,11 @@ def test_handle_http_status_error_truncates_multibyte_body_to_200_bytes() -> Non
     multibyte_body = "あ" * 201
     request = httpx.Request("GET", "https://api.github.com/test")
     response = httpx.Response(422, request=request, content=multibyte_body.encode("utf-8"))
-    error = httpx.HTTPStatusError("422", request=request, response=response)
 
     with patch.object(client, "logger") as mock_logger:
         with pytest.raises(GitHubAPIError) as exc_info:
-            client._handle_http_status_error(error)
-        assert mock_logger.debug.call_args.kwargs["body_preview"] == "あ" * 66 + "\ufffd"
+            client._handle_http_status_error(response, "/test", "GET")
+        assert mock_logger.debug.call_args.kwargs["body_preview"] == "[redacted:5e93700d5564]"
 
     assert multibyte_body not in str(exc_info.value)
 
@@ -1511,10 +1519,9 @@ def test_handle_http_status_error_with_invalid_bytes() -> None:
     request = httpx.Request("GET", "https://api.github.com/test")
     # encoding=None をシミュレート: content に不正バイト列を設定
     response = httpx.Response(400, request=request, content=b"\xff\xfe invalid bytes \x80\x81")
-    error = httpx.HTTPStatusError("HTTP 400", request=request, response=response)
 
     with pytest.raises(GitHubAPIError, match=r"^HTTP 400 error$"):
-        client._handle_http_status_error(error)
+        client._handle_http_status_error(response, "/test", "GET")
 
 
 def test_429_handled_as_github_api_error_not_rate_limit_error() -> None:
@@ -1526,10 +1533,9 @@ def test_429_handled_as_github_api_error_not_rate_limit_error() -> None:
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
     request = httpx.Request("GET", "https://api.github.com/test")
     response = httpx.Response(429, request=request)
-    error = httpx.HTTPStatusError("HTTP 429", request=request, response=response)
 
     with pytest.raises(GitHubAPIError, match=r"^HTTP 429 error$") as exc_info:
-        client._handle_http_status_error(error)
+        client._handle_http_status_error(response, "/test", "GET")
 
     assert not isinstance(exc_info.value, RateLimitError)
 
@@ -1578,6 +1584,7 @@ async def test_httpx_status_error_429_defensive_path() -> None:
         with pytest.raises(RateLimitError) as exc_info:
             await client.get_user("octocat")
 
+    assert exc_info.value.__context__ is None  # sentinel pattern: except外raiseパターン検証
     assert exc_info.value.reset_time == 1640000000
     assert "Rate limit exceeded" in str(exc_info.value)
     assert route.call_count == 1
@@ -1626,13 +1633,17 @@ def test_handle_http_status_error_cause_excludes_response_body() -> None:
     sensitive_body = "token=SUPER_SECRET_API_KEY_12345"
     request = httpx.Request("GET", "https://api.github.com/repos/test")
     response = httpx.Response(422, request=request, text=sensitive_body)
-    error = httpx.HTTPStatusError("422", request=request, response=response)
 
     with patch.object(client, "logger") as mock_logger:
         with pytest.raises(GitHubAPIError) as exc_info:
-            client._handle_http_status_error(error)
+            client._handle_http_status_error(response, "/repos/test", "GET")
         # logger.debugでbody_previewにセンシティブデータが記録されること（デバッグ用途）
-        assert sensitive_body in mock_logger.debug.call_args.kwargs["body_preview"]
+        # logger.debugでbody_previewはリダクション済み（[redacted:hash]形式）であること
+        body_preview_logged = mock_logger.debug.call_args.kwargs["body_preview"]
+        assert body_preview_logged.startswith("[redacted:")
+        assert "]" in body_preview_logged
+        # センシティブデータはログに含まれないこと
+        assert sensitive_body not in body_preview_logged
 
     cause_str = str(exc_info.value.__cause__)
     # __cause__はURL+ステータスのみ保持し、response bodyを含まない

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -249,12 +249,21 @@ async def test_timeout_handling(
     assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
     timeout_logs = [log for log in log_output if log.get("event") == "request_timeout"]
     assert len(timeout_logs) == 1
-    assert timeout_logs[0]["error_type"] == type(timeout_exception).__qualname__
-    assert timeout_logs[0]["error_module"] == type(timeout_exception).__module__
-    assert timeout_logs[0]["error_context"] == "timeout"
-    # PII漏洩防止: error_detailフィールド除去 (unexpected_errorパスと同方針)
-    assert "error_detail" not in timeout_logs[0]
-    assert "error" not in timeout_logs[0]
+    timeout_log = timeout_logs[0]
+    assert timeout_log["error_type"] == type(timeout_exception).__qualname__
+    assert timeout_log["error_module"] == type(timeout_exception).__module__
+    assert timeout_log["error_context"] == "timeout"
+    assert set(timeout_log) == {
+        "endpoint",
+        "method",
+        "error_type",
+        "error_module",
+        "error_context",
+        "event",
+        "log_level",
+    }
+    assert "error_detail" not in timeout_log
+    assert "error" not in timeout_log
 
 
 @respx.mock
@@ -415,10 +424,8 @@ async def test_httpx_status_error_4xx():
 
     # GitHubAPIError であり、httpx.HTTPStatusError ではないことを明示検証
     assert not isinstance(exc_info.value, httpx.HTTPStatusError)
-    # 例外チェーンが保持され、cause が例外オブジェクトであることを確認
-    assert isinstance(exc_info.value.__cause__, Exception)
-    # __cause__がhttpx.HTTPStatusErrorそのものでないことを型レベルで確認
-    assert not isinstance(exc_info.value.__cause__, httpx.HTTPStatusError)
+    # from None による完全PII遮断: __cause__ は None
+    assert exc_info.value.__cause__ is None
     # except外raiseパターン: HTTPStatusErrorが__context__に残存しないこと（PII漏洩防止）
     assert exc_info.value.__context__ is None
     assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
@@ -1118,10 +1125,9 @@ def test_redact_body_preview_empty_string() -> None:
 
 
 def test_redact_body_preview_deterministic() -> None:
-    """_redact_body_preview: 同一入力→同一ハッシュ（冪等性）"""
+    """_redact_body_preview: 同一入力→同一出力（冪等性）"""
     body = "A" * 200
     assert _redact_body_preview(body) == _redact_body_preview(body)
-    assert _redact_body_preview(body) == "[redacted:70d3bf8b0b9d]"
 
 
 def test_handle_http_status_error_uses_debug_for_other_4xx() -> None:
@@ -1130,14 +1136,16 @@ def test_handle_http_status_error_uses_debug_for_other_4xx() -> None:
     mock_request = httpx.Request("GET", "https://api.github.com/test")
     mock_response = httpx.Response(404, request=mock_request)
     with patch.object(client, "logger") as mock_logger:
-        with pytest.raises(GitHubAPIError, match=r"^HTTP 404 error$"):
+        with pytest.raises(GitHubAPIError, match=r"^HTTP 404 error$") as exc_info:
             client._handle_http_status_error(mock_response, "/test", "GET")
+        assert exc_info.value.__cause__ is None
+        assert exc_info.value.__context__ is None
         mock_logger.debug.assert_called_once_with(
             "http_status_error",
             status_code=404,
             endpoint="/test",
             method="GET",
-            body_preview="[redacted:e3b0c44298fc]",
+            body_preview=_redact_body_preview(""),
         )
         mock_logger.warning.assert_not_called()
 
@@ -1149,14 +1157,16 @@ def test_handle_http_status_error_uses_warning_for_401() -> None:
     mock_response = httpx.Response(401, request=mock_request)
 
     with patch.object(client, "logger") as mock_logger:
-        with pytest.raises(GitHubAPIError, match=r"^HTTP 401 error$"):
+        with pytest.raises(GitHubAPIError, match=r"^HTTP 401 error$") as exc_info:
             client._handle_http_status_error(mock_response, "/test", "GET")
+        assert exc_info.value.__cause__ is None
+        assert exc_info.value.__context__ is None
         mock_logger.warning.assert_called_once_with(
             "http_status_error",
             status_code=401,
             endpoint="/test",
             method="GET",
-            body_preview="[redacted:e3b0c44298fc]",
+            body_preview=_redact_body_preview(""),
         )
         mock_logger.debug.assert_not_called()
 
@@ -1175,7 +1185,7 @@ def test_handle_http_status_error_warning_truncates_body_preview_for_401() -> No
             status_code=401,
             endpoint="/test",
             method="GET",
-            body_preview="[redacted:70d3bf8b0b9d]",
+            body_preview=_redact_body_preview("A" * 200),
         )
         mock_logger.debug.assert_not_called()
 
@@ -1474,7 +1484,7 @@ def test_handle_http_status_error_truncates_long_body() -> None:
     with patch.object(client, "logger") as mock_logger:
         with pytest.raises(GitHubAPIError) as exc_info:
             client._handle_http_status_error(response, "/test", "GET")
-        assert mock_logger.debug.call_args.kwargs["body_preview"] == "[redacted:aa20c23e3201]"
+        assert mock_logger.debug.call_args.kwargs["body_preview"] == _redact_body_preview("x" * 200)
 
     # エラーメッセージにボディが含まれないこと
     assert "x" not in str(exc_info.value)
@@ -1490,7 +1500,7 @@ def test_handle_http_status_error_no_truncation_at_boundary() -> None:
     with patch.object(client, "logger") as mock_logger:
         with pytest.raises(GitHubAPIError) as exc_info:
             client._handle_http_status_error(response, "/test", "GET")
-        assert mock_logger.debug.call_args.kwargs["body_preview"] == "[redacted:8ca9bfd43d61]"
+        assert mock_logger.debug.call_args.kwargs["body_preview"] == _redact_body_preview("y" * 200)
 
     # エラーメッセージにボディが含まれないこと
     assert exact_body not in str(exc_info.value)
@@ -1508,7 +1518,9 @@ def test_handle_http_status_error_truncates_multibyte_body_to_200_bytes() -> Non
     with patch.object(client, "logger") as mock_logger:
         with pytest.raises(GitHubAPIError) as exc_info:
             client._handle_http_status_error(response, "/test", "GET")
-        assert mock_logger.debug.call_args.kwargs["body_preview"] == "[redacted:5e93700d5564]"
+        assert mock_logger.debug.call_args.kwargs["body_preview"] == _redact_body_preview(
+            ("あ" * 201).encode("utf-8")[:200].decode("utf-8", errors="replace")
+        )
 
     assert multibyte_body not in str(exc_info.value)
 
@@ -1623,10 +1635,29 @@ async def test_httpx_status_error_429_missing_reset_header_falls_back_to_zero() 
     assert route.call_count == 1
 
 
-def test_handle_http_status_error_cause_excludes_response_body() -> None:
-    """__cause__およびGitHubAPIError本体の両方にセンシティブデータが含まれないことを確認
+@respx.mock
+async def test_httpx_status_error_404_defensive_path_raises_not_found_error() -> None:
+    """404の防御的パスでも NotFoundError に揃うことを確認する"""
+    request = httpx.Request("GET", f"{GITHUB_API_BASE_URL}/users/octocat")
+    response_404 = httpx.Response(404, request=request)
+    error_404 = httpx.HTTPStatusError("404 Not Found", request=request, response=response_404)
 
-    from e → from _cause 変更の核心プロパティ: センシティブなresponse bodyが
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat")
+    route.side_effect = [error_404]
+
+    async with AsyncGitHubClient() as client:
+        with pytest.raises(NotFoundError) as exc_info:
+            await client.get_user("octocat")
+
+    assert "Resource not found" in str(exc_info.value)
+    assert "/users/octocat" in str(exc_info.value)
+    assert route.call_count == 1
+
+
+def test_handle_http_status_error_cause_excludes_response_body() -> None:
+    """from None による完全PII遮断を確認
+
+    __cause__ is None であるため、センシティブなresponse bodyが
     Sentry等の例外チェーン解析ツールに露出しないことを保証する。
     """
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1637,7 +1668,6 @@ def test_handle_http_status_error_cause_excludes_response_body() -> None:
     with patch.object(client, "logger") as mock_logger:
         with pytest.raises(GitHubAPIError) as exc_info:
             client._handle_http_status_error(response, "/repos/test", "GET")
-        # logger.debugでbody_previewにセンシティブデータが記録されること（デバッグ用途）
         # logger.debugでbody_previewはリダクション済み（[redacted:hash]形式）であること
         body_preview_logged = mock_logger.debug.call_args.kwargs["body_preview"]
         assert body_preview_logged.startswith("[redacted:")
@@ -1645,10 +1675,7 @@ def test_handle_http_status_error_cause_excludes_response_body() -> None:
         # センシティブデータはログに含まれないこと
         assert sensitive_body not in body_preview_logged
 
-    cause_str = str(exc_info.value.__cause__)
-    # __cause__はURL+ステータスのみ保持し、response bodyを含まない
-    assert sensitive_body not in cause_str
-    # __cause__がhttpx.HTTPStatusErrorそのものではないことを確認
-    assert not isinstance(exc_info.value.__cause__, httpx.HTTPStatusError)
+    # from None により __cause__ は None（完全PII遮断）
+    assert exc_info.value.__cause__ is None
     # GitHubAPIError本体にもセンシティブデータが含まれないこと
     assert sensitive_body not in str(exc_info.value)

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -10,7 +10,7 @@ GitHub API非同期クライアントのUnit Tests
 import asyncio
 import json
 from datetime import UTC, datetime
-from unittest.mock import ANY, AsyncMock, Mock, patch
+from unittest.mock import ANY, AsyncMock, Mock, call, patch
 
 import httpx
 import pytest
@@ -188,7 +188,7 @@ async def test_retry_on_server_error(mock_sleep: AsyncMock, mock_backoff: Mock) 
     assert f"after {MAX_RETRIES} attempts" in str(exc_info.value)
     assert mock_backoff.call_count == MAX_RETRIES - 1  # MAX_RETRIES試行 → 最終試行以外でバックオフ
     assert mock_sleep.await_count == MAX_RETRIES - 1
-    mock_sleep.assert_awaited_with(0.0)
+    mock_sleep.assert_has_awaits([call(0.0)] * (MAX_RETRIES - 1))
 
 
 @pytest.mark.parametrize(
@@ -210,7 +210,7 @@ async def test_timeout_handling(
 
     検証項目:
     - httpx.TimeoutException系 → GitHubAPIError変換
-    - 例外チェーン維持（from e）
+    - 例外チェーン切断（from None）: PII漏洩防止のため __cause__ を抑制
     - 警告ログ出力
     """
     route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=timeout_exception)
@@ -221,13 +221,46 @@ async def test_timeout_handling(
                 await client.get_user("octocat")
 
     assert str(exc_info.value) == expected_message
-    # 例外チェーン確認
-    assert exc_info.value.__cause__ is timeout_exception
+    # 例外チェーン切断確認（from None による PII 漏洩防止）
+    assert exc_info.value.__cause__ is None
     assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
     timeout_logs = [log for log in log_output if log.get("event") == "request_timeout"]
     assert len(timeout_logs) == 1
     assert timeout_logs[0]["error_type"] == type(timeout_exception).__qualname__
     assert timeout_logs[0]["error_module"] == type(timeout_exception).__module__
+    # PII漏洩防止: error_detailフィールド除去 (unexpected_errorパスと同方針)
+    assert "error_detail" not in timeout_logs[0]
+    assert "error" not in timeout_logs[0]
+
+
+@respx.mock
+async def test_timeout_logging_no_pii_leak():
+    """タイムアウト例外メッセージがログフィールド値・例外チェーンに漏洩しないこと検証
+
+    検証項目:
+    - httpx.TimeoutException msg内のsensitive文字列(token/URL等)がログ全フィールドに含まれない
+    - GitHubAPIError msgにもsensitive文字列が漏洩しない
+    - __cause__ chain切断（from None）で Sentry/traceback walker 経由の PII 漏洩を防止
+    """
+    sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"
+    timeout_exception = httpx.ConnectTimeout(sensitive_detail)
+    respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=timeout_exception)
+
+    with capture_logs() as log_output:
+        async with AsyncGitHubClient() as client:
+            with pytest.raises(GitHubAPIError) as exc_info:
+                await client.get_user("octocat")
+
+    assert sensitive_detail not in str(exc_info.value)
+    # __cause__ 切断検証: from None により Sentry/traceback 経由の PII 漏洩を防止
+    assert exc_info.value.__cause__ is None
+    timeout_logs = [log for log in log_output if log.get("event") == "request_timeout"]
+    assert len(timeout_logs) == 1
+    # PII値レベル検証: 全logフィールド値にsensitive_detailが漏洩していないこと
+    for value in timeout_logs[0].values():
+        assert sensitive_detail not in str(value), (
+            f"sensitive_detail leaked in log field value: {value!r}"
+        )
 
 
 # =============================================================================
@@ -572,7 +605,8 @@ async def test_unexpected_exception():
 
     assert str(exc_info.value) == "Unexpected error: ValueError"
     assert sensitive_detail not in str(exc_info.value)
-    assert isinstance(exc_info.value.__cause__, ValueError)
+    # 例外チェーン切断確認（from None による PII 漏洩防止）
+    assert exc_info.value.__cause__ is None
     assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
     error_logs = [log for log in log_output if log.get("event") == "unexpected_error"]
     assert len(error_logs) == 1
@@ -658,6 +692,8 @@ async def test_json_decode_error():
     assert "error" not in decode_logs[0]
     assert decode_logs[0]["error_type"] == json.JSONDecodeError.__qualname__
     assert decode_logs[0]["error_module"] == json.JSONDecodeError.__module__
+    assert isinstance(decode_logs[0]["error_pos"], int)
+    assert isinstance(decode_logs[0]["error_lineno"], int)
 
 
 @pytest.mark.unit
@@ -1337,6 +1373,8 @@ def test_parse_json_response_invalid_json_raises() -> None:
     assert "error" not in decode_logs[0]
     assert decode_logs[0]["error_type"] == json.JSONDecodeError.__qualname__
     assert decode_logs[0]["error_module"] == json.JSONDecodeError.__module__
+    assert isinstance(decode_logs[0]["error_pos"], int)
+    assert isinstance(decode_logs[0]["error_lineno"], int)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -427,7 +427,7 @@ async def test_httpx_status_error_5xx(mock_sleep: AsyncMock, mock_backoff: Mock)
     assert "Server error: 503" in str(exc_info.value)
     assert route.call_count == MAX_RETRIES
     assert mock_backoff.call_count == MAX_RETRIES - 1  # MAX_RETRIES試行 → 最終試行以外でバックオフ
-    assert mock_sleep.call_count == MAX_RETRIES - 1
+    assert mock_sleep.await_count == MAX_RETRIES - 1
 
     # リトライ中間試行のログ出力検証（Issue #229）
     retry_logs = [log for log in log_output if log.get("event") == "retrying_server_error"]
@@ -481,7 +481,7 @@ async def test_httpx_status_error_5xx_defensive_path(
     assert "Server error: 503" in str(exc_info.value)
     assert route.call_count == MAX_RETRIES
     assert mock_backoff.call_count == MAX_RETRIES - 1
-    assert mock_sleep.call_count == MAX_RETRIES - 1
+    assert mock_sleep.await_count == MAX_RETRIES - 1
 
     retry_logs = [log for log in log_output if log.get("event") == "retrying_server_error"]
     assert len(retry_logs) == MAX_RETRIES - 1, (
@@ -605,8 +605,9 @@ async def test_unexpected_exception():
 
     assert str(exc_info.value) == "Unexpected error: ValueError"
     assert sensitive_detail not in str(exc_info.value)
-    # 例外チェーン切断確認（from None による PII 漏洩防止）
-    assert exc_info.value.__cause__ is None
+    # 例外チェーンは sanitized cause のみ保持し、元例外メッセージは露出しない
+    assert str(exc_info.value.__cause__) == "builtins.ValueError"
+    assert sensitive_detail not in str(exc_info.value.__cause__)
     assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
     error_logs = [log for log in log_output if log.get("event") == "unexpected_error"]
     assert len(error_logs) == 1
@@ -696,7 +697,6 @@ async def test_json_decode_error():
     assert isinstance(decode_logs[0]["error_lineno"], int)
 
 
-@pytest.mark.unit
 @respx.mock
 async def test_get_user_type_guard_rejects_non_dict():
     """get_user: APIが非dictレスポンスを返した場合にGitHubAPIErrorを発生"""
@@ -710,7 +710,6 @@ async def test_get_user_type_guard_rejects_non_dict():
             await client.get_user("octocat")
 
 
-@pytest.mark.unit
 @respx.mock
 async def test_get_repos_type_guard_rejects_non_list():
     """get_repos: APIが非listレスポンスを返した場合にGitHubAPIErrorを発生"""
@@ -724,7 +723,6 @@ async def test_get_repos_type_guard_rejects_non_list():
             await client.get_repos("octocat")
 
 
-@pytest.mark.unit
 @respx.mock
 async def test_get_repo_type_guard_rejects_non_dict():
     """get_repo: APIが非dictレスポンスを返した場合にGitHubAPIErrorを発生"""
@@ -990,7 +988,6 @@ def test_repo_validation_invalid(repo: str) -> None:
 # =============================================================================
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize(
     ("remaining_header", "reset_header", "json_body", "expected_exc", "match"),
     [
@@ -1078,7 +1075,6 @@ def test_handle_403_response(
         assert rate_limit_error.reset_time == int(reset_header)
 
 
-@pytest.mark.unit
 def test_handle_http_status_error_uses_debug_for_other_4xx() -> None:
     """_handle_http_status_error: 401以外の4xxでは debug ログを使う"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1102,7 +1098,6 @@ def test_handle_http_status_error_uses_debug_for_other_4xx() -> None:
         mock_logger.warning.assert_not_called()
 
 
-@pytest.mark.unit
 def test_handle_http_status_error_uses_warning_for_401() -> None:
     """_handle_http_status_error: 401ステータスでは warning ログを使う"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1127,7 +1122,6 @@ def test_handle_http_status_error_uses_warning_for_401() -> None:
         mock_logger.debug.assert_not_called()
 
 
-@pytest.mark.unit
 def test_handle_http_status_error_warning_truncates_body_preview_for_401() -> None:
     """_handle_http_status_error: 401レスポンスで body_preview が200バイトに切り詰められる"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1152,7 +1146,6 @@ def test_handle_http_status_error_warning_truncates_body_preview_for_401() -> No
         mock_logger.debug.assert_not_called()
 
 
-@pytest.mark.unit
 def test_handle_http_status_error_with_5xx_raises_github_api_error() -> None:
     """_handle_http_status_error: 5xxでもGitHubAPIErrorをraiseする（防御的安全網）"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1164,7 +1157,6 @@ def test_handle_http_status_error_with_5xx_raises_github_api_error() -> None:
         client._handle_http_status_error(error)
 
 
-@pytest.mark.unit
 def test_handle_304_response_cache_miss() -> None:
     """キャッシュミス時にGitHubAPIErrorを発生させる（防御的コードパス D-07）"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1184,7 +1176,6 @@ def test_handle_304_response_cache_miss() -> None:
     assert "hint" in error_logs[0]
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize(
     ("status_code", "attempt", "max_retries_val", "expected_exc"),
     [
@@ -1253,7 +1244,6 @@ async def test_handle_5xx_response(
 # ── D-07 追加: _prepare_headers / _handle_304 / _handle_403 / _update_etag_cache ──
 
 
-@pytest.mark.unit
 def test_prepare_headers_with_etag() -> None:
     """ETagキャッシュ存在時にIf-None-Matchヘッダーが設定される"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1262,14 +1252,12 @@ def test_prepare_headers_with_etag() -> None:
     assert headers == {"If-None-Match": "etag-abc"}
 
 
-@pytest.mark.unit
 def test_prepare_headers_without_etag() -> None:
     """ETagキャッシュ不在時に空dictを返す"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
     assert client._prepare_headers("/repos/test") == {}
 
 
-@pytest.mark.unit
 def test_handle_304_response_cache_hit() -> None:
     """_data_cacheヒット時にキャッシュデータを返す（D-07正常系）"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1279,7 +1267,6 @@ def test_handle_304_response_cache_hit() -> None:
     assert result == cached
 
 
-@pytest.mark.unit
 def test_handle_403_response_no_json_log() -> None:
     """非JSONボディ時にfailed_to_parse_403_messageログ（warning）が出力される"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1306,7 +1293,6 @@ def test_handle_403_response_no_json_log() -> None:
         assert exc_info.value.__cause__ is None
 
 
-@pytest.mark.unit
 def test_handle_403_response_truncates_message_to_200_chars() -> None:
     """403 JSON message は 200 文字で切り詰められる"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1325,7 +1311,6 @@ def test_handle_403_response_truncates_message_to_200_chars() -> None:
         client._handle_403_response(response)
 
 
-@pytest.mark.unit
 def test_handle_403_response_no_truncation_at_boundary() -> None:
     """403 JSON messageが200文字ちょうどの場合は切り詰めない"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1344,7 +1329,6 @@ def test_handle_403_response_no_truncation_at_boundary() -> None:
         client._handle_403_response(response)
 
 
-@pytest.mark.unit
 def test_parse_json_response_valid_json() -> None:
     """_parse_json_response: 有効なJSONレスポンスをパースして返す"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1353,7 +1337,6 @@ def test_parse_json_response_valid_json() -> None:
     assert result == {"id": 1, "login": "user"}
 
 
-@pytest.mark.unit
 def test_parse_json_response_invalid_json_raises() -> None:
     """_parse_json_response: 破損JSONでGitHubAPIError + json_decode_errorログ"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1364,9 +1347,11 @@ def test_parse_json_response_invalid_json_raises() -> None:
         headers={"Content-Type": "application/json"},
     )
     with capture_logs() as log_output:
-        with pytest.raises(GitHubAPIError, match="Invalid JSON response"):
+        with pytest.raises(GitHubAPIError, match="Invalid JSON response") as exc_info:
             client._parse_json_response(response, "/test-endpoint")
 
+    assert exc_info.value.__cause__ is None
+    assert "not-valid-json" not in str(exc_info.value)
     decode_logs = [log for log in log_output if log.get("event") == "json_decode_error"]
     assert len(decode_logs) == 1
     assert decode_logs[0]["endpoint"] == "/test-endpoint"
@@ -1377,7 +1362,6 @@ def test_parse_json_response_invalid_json_raises() -> None:
     assert isinstance(decode_logs[0]["error_lineno"], int)
 
 
-@pytest.mark.unit
 def test_update_etag_cache_no_etag_header() -> None:
     """ETagヘッダー不在時にキャッシュを更新しない"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1388,7 +1372,6 @@ def test_update_etag_cache_no_etag_header() -> None:
     assert "/test" not in client._data_cache
 
 
-@pytest.mark.unit
 def test_update_etag_cache_with_etag_header() -> None:
     """ETagヘッダー存在時に _etag_cache と _data_cache を同時更新する"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1399,7 +1382,6 @@ def test_update_etag_cache_with_etag_header() -> None:
     assert client._data_cache["/repos/test"] == result
 
 
-@pytest.mark.unit
 def test_update_etag_cache_clears_stale_cache_when_etag_missing() -> None:
     """ETagが消失した場合は古いキャッシュを削除する"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1416,7 +1398,6 @@ def test_update_etag_cache_clears_stale_cache_when_etag_missing() -> None:
     assert endpoint not in client._data_cache
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize(
     "remaining",
     [
@@ -1436,7 +1417,6 @@ def test_check_rate_limit_warning_triggers(remaining: int) -> None:
     assert warning_logs[0]["reset_time"] == datetime.fromtimestamp(1700000000, tz=UTC).isoformat()
 
 
-@pytest.mark.unit
 def test_check_rate_limit_warning_no_warning_at_boundary() -> None:
     """remaining=10 (== _RATE_LIMIT_WARNING_THRESHOLD) で警告ログを出力しない"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1449,7 +1429,6 @@ def test_check_rate_limit_warning_no_warning_at_boundary() -> None:
         assert "remaining" not in log  # threshold以上では remaining フィールドを出力しない
 
 
-@pytest.mark.unit
 def test_handle_http_status_error_truncates_long_body() -> None:
     """レスポンスボディはエラーメッセージに含まれない（Sentryセキュリティ対応）"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1467,7 +1446,6 @@ def test_handle_http_status_error_truncates_long_body() -> None:
     assert "x" not in str(exc_info.value)
 
 
-@pytest.mark.unit
 def test_handle_http_status_error_no_truncation_at_boundary() -> None:
     """境界値(200字)でもレスポンスボディはエラーメッセージに含まれない（Sentryセキュリティ対応）"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1485,7 +1463,6 @@ def test_handle_http_status_error_no_truncation_at_boundary() -> None:
     assert exact_body not in str(exc_info.value)
 
 
-@pytest.mark.unit
 def test_handle_http_status_error_truncates_multibyte_body_to_200_bytes() -> None:
     """多バイト文字のbody_previewも200バイトで切り詰める（境界はerrors='replace'で補完）"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1504,7 +1481,6 @@ def test_handle_http_status_error_truncates_multibyte_body_to_200_bytes() -> Non
     assert multibyte_body not in str(exc_info.value)
 
 
-@pytest.mark.unit
 def test_handle_http_status_error_with_invalid_bytes() -> None:
     """不正UTF-8バイト列でもUnicodeDecodeErrorが発生しない（errors='replace'検証）"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1517,7 +1493,6 @@ def test_handle_http_status_error_with_invalid_bytes() -> None:
         client._handle_http_status_error(error)
 
 
-@pytest.mark.unit
 def test_429_handled_as_github_api_error_not_rate_limit_error() -> None:
     """_handle_http_status_error単体では429をGitHubAPIErrorとして扱う（メソッド直接呼び出し確認）
 
@@ -1536,7 +1511,6 @@ def test_429_handled_as_github_api_error_not_rate_limit_error() -> None:
 
 
 @respx.mock
-@pytest.mark.unit
 async def test_429_response_raises_rate_limit_error() -> None:
     """429 Too Many RequestsはRateLimitErrorに変換される（_requestレベル・通常パス）
 
@@ -1557,7 +1531,6 @@ async def test_429_response_raises_rate_limit_error() -> None:
 
 
 @respx.mock
-@pytest.mark.unit
 async def test_httpx_status_error_429_defensive_path() -> None:
     """httpx.HTTPStatusError（429）防御的コードパスの検証
 
@@ -1587,7 +1560,6 @@ async def test_httpx_status_error_429_defensive_path() -> None:
 
 
 @respx.mock
-@pytest.mark.unit
 async def test_429_response_missing_reset_header_falls_back_to_zero() -> None:
     """X-RateLimit-Resetヘッダー欠損時は reset_time=0 にフォールバックする（通常パス）"""
     route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(429)
@@ -1601,7 +1573,6 @@ async def test_429_response_missing_reset_header_falls_back_to_zero() -> None:
 
 
 @respx.mock
-@pytest.mark.unit
 async def test_httpx_status_error_429_missing_reset_header_falls_back_to_zero() -> None:
     """X-RateLimit-Resetヘッダー欠損時は reset_time=0 にフォールバックする（防御的パス）"""
     request = httpx.Request("GET", f"{GITHUB_API_BASE_URL}/users/octocat")
@@ -1621,7 +1592,6 @@ async def test_httpx_status_error_429_missing_reset_header_falls_back_to_zero() 
     assert route.call_count == 1
 
 
-@pytest.mark.unit
 def test_handle_http_status_error_cause_excludes_response_body() -> None:
     """__cause__およびGitHubAPIError本体の両方にセンシティブデータが含まれないことを確認
 

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -228,42 +228,50 @@ async def test_timeout_handling(
     timeout_exception: httpx.TimeoutException,
     expected_message: str,
 ):
-    """タイムアウト時にGitHubAPIError発生
+    """タイムアウト時に再試行後、GitHubAPIError発生
 
     検証項目:
-    - httpx.TimeoutException系 → GitHubAPIError変換
+    - httpx.TimeoutException系 → retry 後に GitHubAPIError 変換
+    - retry 回数が max_retries に一致すること
     - 例外チェーン切断（from None）: PII漏洩防止のため __cause__ を抑制
     - 警告ログ出力
     """
     route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=timeout_exception)
 
-    with capture_logs() as log_output:
-        async with AsyncGitHubClient() as client:
-            with pytest.raises(GitHubAPIError) as exc_info:
-                await client.get_user("octocat")
+    with patch(
+        "utils.github_client.exponential_backoff_with_jitter",
+        return_value=0.0,
+    ) as mock_backoff:
+        with patch("utils.github_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            with capture_logs() as log_output:
+                async with AsyncGitHubClient() as client:
+                    with pytest.raises(GitHubAPIError) as exc_info:
+                        await client.get_user("octocat")
 
     assert str(exc_info.value) == expected_message
     # 例外チェーン切断確認（from None による PII 漏洩防止）
     assert exc_info.value.__cause__ is None
     assert exc_info.value.__context__ is None  # except外raiseパターン検証
-    assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
+    assert route.call_count == MAX_RETRIES  # timeout は max_retries 回まで再試行
+    assert mock_backoff.call_count == MAX_RETRIES - 1
+    assert mock_sleep.await_count == MAX_RETRIES - 1
     timeout_logs = [log for log in log_output if log.get("event") == "request_timeout"]
-    assert len(timeout_logs) == 1
-    timeout_log = timeout_logs[0]
-    assert timeout_log["error_type"] == type(timeout_exception).__qualname__
-    assert timeout_log["error_module"] == type(timeout_exception).__module__
-    assert timeout_log["error_context"] == "timeout"
-    assert set(timeout_log) == {
-        "endpoint",
-        "method",
-        "error_type",
-        "error_module",
-        "error_context",
-        "event",
-        "log_level",
-    }
-    assert "error_detail" not in timeout_log
-    assert "error" not in timeout_log
+    assert len(timeout_logs) == MAX_RETRIES
+    for timeout_log in timeout_logs:
+        assert timeout_log["error_type"] == type(timeout_exception).__qualname__
+        assert timeout_log["error_module"] == type(timeout_exception).__module__
+        assert timeout_log["error_context"] == "timeout"
+        assert set(timeout_log) == {
+            "endpoint",
+            "method",
+            "error_type",
+            "error_module",
+            "error_context",
+            "event",
+            "log_level",
+        }
+        assert "error_detail" not in timeout_log
+        assert "error" not in timeout_log
 
 
 @respx.mock
@@ -279,23 +287,31 @@ async def test_timeout_logging_no_pii_leak():
     timeout_exception = httpx.ConnectTimeout(sensitive_detail)
     route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=timeout_exception)
 
-    with capture_logs() as log_output:
-        async with AsyncGitHubClient() as client:
-            with pytest.raises(GitHubAPIError) as exc_info:
-                await client.get_user("octocat")
+    with patch(
+        "utils.github_client.exponential_backoff_with_jitter",
+        return_value=0.0,
+    ) as mock_backoff:
+        with patch("utils.github_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            with capture_logs() as log_output:
+                async with AsyncGitHubClient() as client:
+                    with pytest.raises(GitHubAPIError) as exc_info:
+                        await client.get_user("octocat")
 
     assert sensitive_detail not in str(exc_info.value)
     # __cause__ 切断検証: from None により Sentry/traceback 経由の PII 漏洩を防止
     assert exc_info.value.__cause__ is None
     assert exc_info.value.__context__ is None  # except外raiseパターン検証
     timeout_logs = [log for log in log_output if log.get("event") == "request_timeout"]
-    assert len(timeout_logs) == 1
+    assert len(timeout_logs) == MAX_RETRIES
     # PII値レベル検証: 全logフィールド値にsensitive_detailが漏洩していないこと
-    for value in timeout_logs[0].values():
-        assert sensitive_detail not in str(value), (
-            f"sensitive_detail leaked in log field value: {value!r}"
-        )
-    assert route.call_count == 1
+    for timeout_log in timeout_logs:
+        for value in timeout_log.values():
+            assert sensitive_detail not in str(value), (
+                f"sensitive_detail leaked in log field value: {value!r}"
+            )
+    assert route.call_count == MAX_RETRIES
+    assert mock_backoff.call_count == MAX_RETRIES - 1
+    assert mock_sleep.await_count == MAX_RETRIES - 1
 
 
 # =============================================================================
@@ -657,6 +673,15 @@ async def test_unexpected_exception():
         assert sensitive_detail not in str(value), (
             f"sensitive_detail leaked in log field value: {value!r}"
         )
+
+
+@respx.mock
+async def test_response_not_read_propagates_without_unexpected_wrapper():
+    """ResponseNotRead は unexpected_error に包まずそのまま伝播する"""
+    async with AsyncGitHubClient() as client:
+        with patch.object(client._client, "request", side_effect=httpx.ResponseNotRead()):
+            with pytest.raises(httpx.ResponseNotRead):
+                await client.get_user("octocat")
 
 
 # =============================================================================
@@ -1114,14 +1139,14 @@ def test_handle_403_response(
 
 
 def test_redact_body_preview_returns_fixed_format() -> None:
-    """_redact_body_preview: [redacted:SHA256_12chars]形式を返す"""
+    """_redact_body_preview: [redacted:SHA256_16chars]形式を返す"""
     result = _redact_body_preview("any content here")
-    assert re.fullmatch(r"\[redacted:[0-9a-f]{12}\]", result)
+    assert re.fullmatch(r"\[redacted:[0-9a-f]{16}\]", result)
 
 
 def test_redact_body_preview_empty_string() -> None:
     """_redact_body_preview: 空文字列→確定的ハッシュ"""
-    assert _redact_body_preview("") == "[redacted:e3b0c44298fc]"
+    assert _redact_body_preview("") == "[redacted:e3b0c44298fc1c14]"
 
 
 def test_redact_body_preview_deterministic() -> None:

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -356,8 +356,8 @@ async def test_httpx_status_error_4xx():
 
     # GitHubAPIError であり、httpx.HTTPStatusError ではないことを明示検証
     assert not isinstance(exc_info.value, httpx.HTTPStatusError)
-    # 例外チェーンが保持されていることを確認（HTTPStatusError 情報を保持した cause に再ラップ）
-    assert exc_info.value.__cause__ is not None
+    # 例外チェーンが保持され、cause が例外オブジェクトであることを確認
+    assert isinstance(exc_info.value.__cause__, Exception)
     # __cause__がhttpx.HTTPStatusErrorそのものでないことを型レベルで確認
     assert not isinstance(exc_info.value.__cause__, httpx.HTTPStatusError)
     assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
@@ -367,7 +367,8 @@ async def test_httpx_status_error_4xx():
 
 @respx.mock
 @patch("utils.github_client.exponential_backoff_with_jitter", return_value=0.0)
-async def test_httpx_status_error_5xx(mock_backoff: Mock) -> None:
+@patch("utils.github_client.asyncio.sleep", new_callable=AsyncMock)
+async def test_httpx_status_error_5xx(mock_sleep: AsyncMock, mock_backoff: Mock) -> None:
     """5xxステータスコード（response.status_code >= 500）リトライパスの検証
 
     リトライ動作に加え、retrying_server_error ログ出力を検証する（Issue #229）。
@@ -393,6 +394,7 @@ async def test_httpx_status_error_5xx(mock_backoff: Mock) -> None:
     assert "Server error: 503" in str(exc_info.value)
     assert route.call_count == MAX_RETRIES
     assert mock_backoff.call_count == MAX_RETRIES - 1  # MAX_RETRIES試行 → 最終試行以外でバックオフ
+    assert mock_sleep.call_count == MAX_RETRIES - 1
 
     # リトライ中間試行のログ出力検証（Issue #229）
     retry_logs = [log for log in log_output if log.get("event") == "retrying_server_error"]
@@ -416,7 +418,11 @@ async def test_httpx_status_error_5xx(mock_backoff: Mock) -> None:
 
 @respx.mock
 @patch("utils.github_client.exponential_backoff_with_jitter", return_value=0.0)
-async def test_httpx_status_error_5xx_defensive_path(mock_backoff: Mock) -> None:
+@patch("utils.github_client.asyncio.sleep", new_callable=AsyncMock)
+async def test_httpx_status_error_5xx_defensive_path(
+    mock_sleep: AsyncMock,
+    mock_backoff: Mock,
+) -> None:
     """httpx.HTTPStatusError（5xx）防御的コードパスの検証
 
     C2修正後: httpx.HTTPStatusError として直接 5xx が発生した場合も
@@ -442,6 +448,7 @@ async def test_httpx_status_error_5xx_defensive_path(mock_backoff: Mock) -> None
     assert "Server error: 503" in str(exc_info.value)
     assert route.call_count == MAX_RETRIES
     assert mock_backoff.call_count == MAX_RETRIES - 1
+    assert mock_sleep.call_count == MAX_RETRIES - 1
 
     retry_logs = [log for log in log_output if log.get("event") == "retrying_server_error"]
     assert len(retry_logs) == MAX_RETRIES - 1, (
@@ -639,15 +646,21 @@ async def test_json_decode_error():
         },
     )
 
-    async with AsyncGitHubClient() as client:
-        with pytest.raises(GitHubAPIError, match="Invalid JSON"):
-            await client.get_user("octocat")
+    with capture_logs() as logs:
+        async with AsyncGitHubClient() as client:
+            with pytest.raises(GitHubAPIError, match="Invalid JSON"):
+                await client.get_user("octocat")
 
     assert route.call_count == 1  # GETリクエストが1回発行されたことを確認
+    decode_logs = [log for log in logs if log.get("event") == "json_decode_error"]
+    assert len(decode_logs) == 1
+    assert decode_logs[0]["endpoint"] == "/users/octocat"
+    assert "error" not in decode_logs[0]
+    assert decode_logs[0]["error_type"] == json.JSONDecodeError.__qualname__
+    assert decode_logs[0]["error_module"] == json.JSONDecodeError.__module__
 
 
 @pytest.mark.unit
-@pytest.mark.asyncio
 @respx.mock
 async def test_get_user_type_guard_rejects_non_dict():
     """get_user: APIが非dictレスポンスを返した場合にGitHubAPIErrorを発生"""
@@ -662,7 +675,6 @@ async def test_get_user_type_guard_rejects_non_dict():
 
 
 @pytest.mark.unit
-@pytest.mark.asyncio
 @respx.mock
 async def test_get_repos_type_guard_rejects_non_list():
     """get_repos: APIが非listレスポンスを返した場合にGitHubAPIErrorを発生"""
@@ -677,7 +689,6 @@ async def test_get_repos_type_guard_rejects_non_list():
 
 
 @pytest.mark.unit
-@pytest.mark.asyncio
 @respx.mock
 async def test_get_repo_type_guard_rejects_non_dict():
     """get_repo: APIが非dictレスポンスを返した場合にGitHubAPIErrorを発生"""
@@ -1138,7 +1149,6 @@ def test_handle_304_response_cache_miss() -> None:
 
 
 @pytest.mark.unit
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("status_code", "attempt", "max_retries_val", "expected_exc"),
     [
@@ -1324,7 +1334,9 @@ def test_parse_json_response_invalid_json_raises() -> None:
     decode_logs = [log for log in log_output if log.get("event") == "json_decode_error"]
     assert len(decode_logs) == 1
     assert decode_logs[0]["endpoint"] == "/test-endpoint"
-    assert "error" in decode_logs[0]
+    assert "error" not in decode_logs[0]
+    assert decode_logs[0]["error_type"] == json.JSONDecodeError.__qualname__
+    assert decode_logs[0]["error_module"] == json.JSONDecodeError.__module__
 
 
 @pytest.mark.unit

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -170,7 +170,7 @@ async def test_retry_on_server_error(mock_sleep: AsyncMock, mock_backoff: Mock) 
     検証項目:
     - 500エラー発生時に指数バックオフでリトライ
     - 3回失敗後にGitHubServerError例外
-    - 例外チェーン維持（from e）
+    - 最終試行後にサーバーエラー情報を保持
     """
     route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat")
     route.side_effect = [
@@ -244,7 +244,7 @@ async def test_timeout_logging_no_pii_leak():
     """
     sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"
     timeout_exception = httpx.ConnectTimeout(sensitive_detail)
-    respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=timeout_exception)
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=timeout_exception)
 
     with capture_logs() as log_output:
         async with AsyncGitHubClient() as client:
@@ -261,6 +261,7 @@ async def test_timeout_logging_no_pii_leak():
         assert sensitive_detail not in str(value), (
             f"sensitive_detail leaked in log field value: {value!r}"
         )
+    assert route.call_count == 1
 
 
 # =============================================================================
@@ -605,9 +606,8 @@ async def test_unexpected_exception():
 
     assert str(exc_info.value) == "Unexpected error: ValueError"
     assert sensitive_detail not in str(exc_info.value)
-    # 例外チェーンは sanitized cause のみ保持し、元例外メッセージは露出しない
-    assert str(exc_info.value.__cause__) == "builtins.ValueError"
-    assert sensitive_detail not in str(exc_info.value.__cause__)
+    # 例外チェーンは切断し、元例外メッセージは露出しない
+    assert exc_info.value.__cause__ is None
     assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
     error_logs = [log for log in log_output if log.get("event") == "unexpected_error"]
     assert len(error_logs) == 1
@@ -1351,6 +1351,8 @@ def test_parse_json_response_invalid_json_raises() -> None:
             client._parse_json_response(response, "/test-endpoint")
 
     assert exc_info.value.__cause__ is None
+    # except外raiseパターンで__context__も完全切断されていること（PII隔離保証）
+    assert exc_info.value.__context__ is None
     assert "not-valid-json" not in str(exc_info.value)
     decode_logs = [log for log in log_output if log.get("event") == "json_decode_error"]
     assert len(decode_logs) == 1

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -329,9 +329,14 @@ async def test_timeout_logging_no_pii_leak():
             id="read_error",
         ),
         pytest.param(
-            httpx.RemoteProtocolError("Server disconnected"),
-            "Network error: RemoteProtocolError",
-            id="remote_protocol_error",
+            httpx.WriteError("Write failed"),
+            "Network error: WriteError",
+            id="write_error",
+        ),
+        pytest.param(
+            httpx.CloseError("Close failed"),
+            "Network error: CloseError",
+            id="close_error",
         ),
     ],
 )
@@ -743,10 +748,12 @@ async def test_unexpected_exception():
 @respx.mock
 async def test_response_not_read_propagates_without_unexpected_wrapper():
     """ResponseNotRead は unexpected_error に包まずそのまま伝播する"""
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat")
+    route.side_effect = [httpx.ResponseNotRead()]
     async with AsyncGitHubClient() as client:
-        with patch.object(client._client, "request", side_effect=httpx.ResponseNotRead()):
-            with pytest.raises(httpx.ResponseNotRead):
-                await client.get_user("octocat")
+        with pytest.raises(httpx.ResponseNotRead):
+            await client.get_user("octocat")
+    assert route.call_count == 1
 
 
 # =============================================================================
@@ -1741,6 +1748,7 @@ async def test_httpx_status_error_404_defensive_path_raises_not_found_error() ->
 
     assert "Resource not found" in str(exc_info.value)
     assert "/users/octocat" in str(exc_info.value)
+    assert exc_info.value.__context__ is None  # from None による PII 遮断の確認
     assert route.call_count == 1
 
 

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -215,15 +215,19 @@ async def test_timeout_handling(
     """
     route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=timeout_exception)
 
-    async with AsyncGitHubClient() as client:
-        with pytest.raises(GitHubAPIError) as exc_info:
-            await client.get_user("octocat")
+    with capture_logs() as log_output:
+        async with AsyncGitHubClient() as client:
+            with pytest.raises(GitHubAPIError) as exc_info:
+                await client.get_user("octocat")
 
     assert str(exc_info.value) == expected_message
     # 例外チェーン確認
-    assert exc_info.value.__cause__ is not None
     assert exc_info.value.__cause__ is timeout_exception
     assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
+    timeout_logs = [log for log in log_output if log.get("event") == "request_timeout"]
+    assert len(timeout_logs) == 1
+    assert timeout_logs[0]["error_type"] == type(timeout_exception).__qualname__
+    assert timeout_logs[0]["error_module"] == type(timeout_exception).__module__
 
 
 # =============================================================================
@@ -567,6 +571,7 @@ async def test_unexpected_exception():
     assert len(error_logs) == 1
     assert "error" not in error_logs[0]
     assert error_logs[0]["error_type"] == "ValueError"
+    assert error_logs[0]["error_module"] == "builtins"
     # PII値レベル検証: 全 log フィールド値に sensitive_detail が漏洩していないこと
     for value in error_logs[0].values():
         assert sensitive_detail not in str(value), (
@@ -1250,6 +1255,7 @@ def test_handle_403_response_no_json_log() -> None:
         assert warning_logs[0]["log_level"] == "warning"
         assert "error" not in warning_logs[0]
         assert warning_logs[0].get("error_type") == "JSONDecodeError"
+        assert warning_logs[0].get("error_module") == "json.decoder"
         # __cause__ なし（from None で保護）
         assert exc_info.value.__cause__ is None
 

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -191,28 +191,39 @@ async def test_retry_on_server_error(mock_sleep: AsyncMock, mock_backoff: Mock) 
     mock_sleep.assert_awaited_with(0.0)
 
 
+@pytest.mark.parametrize(
+    ("timeout_exception", "expected_message"),
+    [
+        (httpx.TimeoutException("Request timeout"), "Request timeout: TimeoutException"),
+        (httpx.ConnectTimeout("Connect timeout"), "Request timeout: ConnectTimeout"),
+        (httpx.ReadTimeout("Read timeout"), "Request timeout: ReadTimeout"),
+        (httpx.WriteTimeout("Write timeout"), "Request timeout: WriteTimeout"),
+        (httpx.PoolTimeout("Pool timeout"), "Request timeout: PoolTimeout"),
+    ],
+)
 @respx.mock
-async def test_timeout_handling():
+async def test_timeout_handling(
+    timeout_exception: httpx.TimeoutException,
+    expected_message: str,
+):
     """タイムアウト時にGitHubAPIError発生
 
     検証項目:
-    - httpx.TimeoutException → GitHubAPIError変換
+    - httpx.TimeoutException系 → GitHubAPIError変換
     - 例外チェーン維持（from e）
     - 警告ログ出力
     """
-    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(
-        side_effect=httpx.TimeoutException("Request timeout")
-    )
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=timeout_exception)
 
     async with AsyncGitHubClient() as client:
         with pytest.raises(GitHubAPIError) as exc_info:
             await client.get_user("octocat")
 
     assert "timeout" in str(exc_info.value).lower()
-    assert str(exc_info.value) == "Request timeout: TimeoutException"
+    assert str(exc_info.value) == expected_message
     # 例外チェーン確認
     assert exc_info.value.__cause__ is not None
-    assert isinstance(exc_info.value.__cause__, httpx.TimeoutException)
+    assert exc_info.value.__cause__ is timeout_exception
     assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
 
 
@@ -325,23 +336,6 @@ async def test_request_without_context_manager():
 
     assert "Client not initialized" in str(exc_info.value)
     assert "async with" in str(exc_info.value)
-
-
-@respx.mock
-async def test_httpx_timeout_exception():
-    """httpx.TimeoutException処理の検証"""
-    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(
-        side_effect=httpx.TimeoutException("Connection timeout")
-    )
-
-    async with AsyncGitHubClient() as client:
-        with pytest.raises(GitHubAPIError) as exc_info:
-            await client.get_user("octocat")
-
-    assert "timeout" in str(exc_info.value).lower()
-    assert str(exc_info.value) == "Request timeout: TimeoutException"
-    assert exc_info.value.__cause__ is not None
-    assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
 
 
 @respx.mock
@@ -556,8 +550,9 @@ async def test_httpx_status_error_403_auth_error_with_message() -> None:
 @respx.mock
 async def test_unexpected_exception():
     """予期しない例外処理の検証"""
+    sensitive_detail = "secret connection string"
     route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(
-        side_effect=ValueError("Unexpected error")
+        side_effect=ValueError(sensitive_detail)
     )
 
     with capture_logs() as log_output:
@@ -565,7 +560,8 @@ async def test_unexpected_exception():
             with pytest.raises(GitHubAPIError) as exc_info:
                 await client.get_user("octocat")
 
-    assert "Unexpected error" in str(exc_info.value)
+    assert str(exc_info.value) == "Unexpected error: ValueError"
+    assert sensitive_detail not in str(exc_info.value)
     assert isinstance(exc_info.value.__cause__, ValueError)
     assert route.call_count == 1  # エラー時はリトライなし（1回のみ実行）
     error_logs = [log for log in log_output if log.get("event") == "unexpected_error"]
@@ -1248,7 +1244,10 @@ def test_handle_403_response_no_json_log() -> None:
         warning_logs = [log for log in logs if log.get("event") == "failed_to_parse_403_message"]
         assert len(warning_logs) == 1
         assert warning_logs[0]["log_level"] == "warning"
-        assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)
+        assert "error" not in warning_logs[0]
+        assert warning_logs[0].get("error_type") == "JSONDecodeError"
+        # __cause__ なし（from None で保護）
+        assert exc_info.value.__cause__ is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -219,7 +219,6 @@ async def test_timeout_handling(
         with pytest.raises(GitHubAPIError) as exc_info:
             await client.get_user("octocat")
 
-    assert "timeout" in str(exc_info.value).lower()
     assert str(exc_info.value) == expected_message
     # 例外チェーン確認
     assert exc_info.value.__cause__ is not None
@@ -568,6 +567,11 @@ async def test_unexpected_exception():
     assert len(error_logs) == 1
     assert "error" not in error_logs[0]
     assert error_logs[0]["error_type"] == "ValueError"
+    # PII値レベル検証: 全 log フィールド値に sensitive_detail が漏洩していないこと
+    for value in error_logs[0].values():
+        assert sensitive_detail not in str(value), (
+            f"sensitive_detail leaked in log field value: {value!r}"
+        )
 
 
 # =============================================================================

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -226,12 +226,9 @@ class TestSentryProcessor:
     4. 例外情報なし → capture_message()
     5. ImportError/Exception → エラー処理
 
-    **注意 (lru_cache)**: `_is_sentry_debug_enabled` は `@lru_cache(maxsize=1)` で
-    プロセスライフタイムキャッシュされる。conftest の `reset_sentry_warning_state`
-    autouse fixture が各テスト前に `cache_clear()` を実行するため、テスト間の汚染は
-    防止済み。テスト本体内で `monkeypatch.setenv("SENTRY_DEBUG", ...)` を呼んだ後に
-    `_is_sentry_debug_enabled` の戻り値を期待する場合は、setenv 直後に
-    `_is_sentry_debug_enabled.cache_clear()` を明示的に呼ぶこと。
+    **注意 (SENTRY_DEBUG)**: `_is_sentry_debug_enabled` は lru_cache 削除済みで
+    環境変数をリアルタイム取得する。`monkeypatch.setenv/delenv` の変更は
+    即時反映されるため、`cache_clear()` の呼び出しは不要。
     """
 
     # ダミーのWrappedLoggerとmethod_name（未使用だが引数として必要）
@@ -1512,10 +1509,8 @@ class TestSafeErrorSummary:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """SENTRY_DEBUG 無効時は詳細文字列を返さない"""
-        from utils import logger as logger_module
 
         monkeypatch.delenv("SENTRY_DEBUG", raising=False)
-        logger_module._is_sentry_debug_enabled.cache_clear()
 
         assert _sentry_debug_detail(RuntimeError("secret")) == ""
 
@@ -1533,10 +1528,8 @@ class TestSafeErrorSummary:
         expected: str,
     ) -> None:
         """SENTRY_DEBUG 有効時は詳細を 100 文字まで返す"""
-        from utils import logger as logger_module
 
         monkeypatch.setenv("SENTRY_DEBUG", "true")
-        logger_module._is_sentry_debug_enabled.cache_clear()
 
         assert _sentry_debug_detail(RuntimeError(message)) == expected
 

--- a/tests/unit/test_sync_client.py
+++ b/tests/unit/test_sync_client.py
@@ -1084,7 +1084,6 @@ def test_main_non_api_client_error_propagates_without_http_or_print_side_effects
     client.get_posts.side_effect = RuntimeError("unexpected failure")
     client_context = MagicMock()
     client_context.__enter__.return_value = client
-    client_context.__exit__.return_value = False
 
     with (
         patch.object(

--- a/tests/unit/test_sync_client.py
+++ b/tests/unit/test_sync_client.py
@@ -13,7 +13,7 @@ Note:
 
 import json
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import httpx
 import pytest
@@ -1099,6 +1099,6 @@ def test_main_propagates_non_api_client_error() -> None:
     create_client_mock.assert_called_once_with()
     client.get_posts.assert_called_once_with(limit=5)
     # context manager cleanup 検証 (例外伝播時も __exit__ が呼ばれる)
-    client_context.__exit__.assert_called_once()
+    client_context.__exit__.assert_called_once_with(RuntimeError, ANY, ANY)
     # Demo completed が呼ばれていない (途中エラーで Demo 完了出力されないこと) 意味的検証のみ保持
     assert not any(call.args == ("\n=== Demo completed ===",) for call in print_mock.call_args_list)

--- a/tests/unit/test_sync_client.py
+++ b/tests/unit/test_sync_client.py
@@ -13,7 +13,7 @@ Note:
 
 import json
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -21,6 +21,7 @@ import respx
 
 from tests.constants import BASE_URL, INVALID_BASE_URLS
 from tests.unit.helpers import mock_get_route
+from utils import api_client
 from utils.api_client import SyncAPIClient, SyncJSONPlaceholderClient
 
 pytestmark = pytest.mark.unit
@@ -1075,3 +1076,29 @@ def test_sync_health_check_system_exception_propagates(
         with patch.object(client, "get", side_effect=exception_class(*exception_args)):
             with pytest.raises(exception_class):
                 client.health_check()
+
+
+def test_main_non_api_client_error_propagates_without_http_or_print_side_effects() -> None:
+    """main() は APIClientError 以外を捕捉せず呼び出し元へ伝播する"""
+    client = MagicMock()
+    client.get_posts.side_effect = RuntimeError("unexpected failure")
+    client_context = MagicMock()
+    client_context.__enter__.return_value = client
+    client_context.__exit__.return_value = False
+
+    with (
+        patch.object(
+            api_client,
+            "create_client",
+            return_value=client_context,
+        ) as create_client_mock,
+        patch("builtins.print") as print_mock,
+        pytest.raises(RuntimeError, match="unexpected failure"),
+    ):
+        api_client.main()
+
+    create_client_mock.assert_called_once_with()
+    client.get_posts.assert_called_once_with(limit=5)
+    print_mock.assert_any_call("=== JSONPlaceholder API Client Demo ===")
+    print_mock.assert_any_call("\n1. 投稿一覧取得（5件）:")
+    assert not any(call.args == ("\n=== Demo completed ===",) for call in print_mock.call_args_list)

--- a/tests/unit/test_sync_client.py
+++ b/tests/unit/test_sync_client.py
@@ -1099,6 +1099,7 @@ def test_main_non_api_client_error_propagates_without_http_or_print_side_effects
 
     create_client_mock.assert_called_once_with()
     client.get_posts.assert_called_once_with(limit=5)
-    print_mock.assert_any_call("=== JSONPlaceholder API Client Demo ===")
-    print_mock.assert_any_call("\n1. 投稿一覧取得（5件）:")
+    # context manager cleanup 検証 (例外伝播時も __exit__ が呼ばれる)
+    client_context.__exit__.assert_called_once()
+    # Demo completed が呼ばれていない (途中エラーで Demo 完了出力されないこと) 意味的検証のみ保持
     assert not any(call.args == ("\n=== Demo completed ===",) for call in print_mock.call_args_list)

--- a/tests/unit/test_sync_client.py
+++ b/tests/unit/test_sync_client.py
@@ -1078,7 +1078,7 @@ def test_sync_health_check_system_exception_propagates(
                 client.health_check()
 
 
-def test_main_non_api_client_error_propagates_without_http_or_print_side_effects() -> None:
+def test_main_propagates_non_api_client_error() -> None:
     """main() は APIClientError 以外を捕捉せず呼び出し元へ伝播する"""
     client = MagicMock()
     client.get_posts.side_effect = RuntimeError("unexpected failure")

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -343,7 +343,7 @@ class SyncAPIClient:
         headers: 追加HTTPヘッダー
 
         Raises:
-            ValueError: base_urlが空文字列の場合
+            ValueError: base_urlが空文字列またはスペースのみの文字列の場合
 
         """
         # 設定解決・バリデーション（Sync/Async共通ロジック）
@@ -789,7 +789,7 @@ class AsyncAPIClient:
         headers: 追加HTTPヘッダー
 
         Raises:
-            ValueError: base_urlが空文字列の場合
+            ValueError: base_urlが空文字列またはスペースのみの文字列の場合
 
         """
         # 設定解決・バリデーション（Sync/Async共通ロジック）

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -354,8 +354,8 @@ class AsyncGitHubClient:
                     error_message = raw_message[:_MAX_403_ERROR_MESSAGE_CHARS]
         except json.JSONDecodeError as parse_err:
             # JSONパース失敗は想定内（GitHub APIが非JSON形式で403を返す場合がある）
-            # PII漏洩防止: parse_err.docはレスポンスbody全体を保持するため
-            # 例外オブジェクトを例外メッセージ・ログから除外（"Access forbidden"のみで再raise）
+            # PII漏洩防止: parse_err.doc はレスポンスbody全体を保持するため、
+            # ログのみ記録し active exception context の外で raise して __context__ を None に保つ。
             self.logger.warning(
                 "failed_to_parse_403_message",
                 error_type=type(parse_err).__qualname__,
@@ -363,8 +363,10 @@ class AsyncGitHubClient:
                 error_pos=parse_err.pos,
                 error_lineno=parse_err.lineno,
             )
-            raise GitHubAPIError("Access forbidden") from None
 
+        # JSONDecodeError.doc はレスポンスbody全体を保持する。
+        # except 外で raise して __context__ を None に保つ（_parse_json_response と同方針）。
+        # JSONDecodeError パス（error_message=""）も正常パスも同一の raise で処理。
         raise GitHubAPIError(
             f"Access forbidden: {error_message}" if error_message else "Access forbidden"
         ) from None
@@ -412,7 +414,7 @@ class AsyncGitHubClient:
                 response.json(),
             )
         except json.JSONDecodeError as e:
-            self.logger.warning(
+            self.logger.error(
                 "json_decode_error",
                 endpoint=endpoint,
                 error_type=type(e).__qualname__,
@@ -421,8 +423,9 @@ class AsyncGitHubClient:
                 error_lineno=e.lineno,
             )
 
-        # JSONDecodeError.doc はレスポンスbody全体を保持するため、
-        # active exception context の外で再raiseして cause/context に残さない。
+        # JSONDecodeError.doc はレスポンスbody全体を保持する。
+        # except 内で raise すると __context__ に JSONDecodeError が残存し .doc 経由で露出するため、
+        # active exception context の外で raise して __context__ を None に保つ。
         raise GitHubAPIError("Invalid JSON response") from None
 
     def _handle_http_status_error(
@@ -625,10 +628,8 @@ class AsyncGitHubClient:
                     error_module=error_module,
                 )
                 # PII漏洩防止 (__cause__): catch-all例外はURL/host:port等のPIIを含む可能性があるため
-                # `from Exception(...)` で chain 切断し最小限の診断情報を保持 (L461-463 と同方針)
-                raise GitHubAPIError(f"Unexpected error: {error_type}") from Exception(
-                    f"{error_module}.{error_type}"
-                )
+                # 例外チェーンを切断し、診断情報は非PIIのログフィールドに限定する。
+                raise GitHubAPIError(f"Unexpected error: {error_type}") from None
 
         # リトライ上限到達（ここに到達することはないはずだが、型チェッカー対策）
         raise GitHubServerError(f"Failed after {self.max_retries} attempts")

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -461,9 +461,11 @@ class AsyncGitHubClient:
         通常はこのメソッドへ 5xx は到達しない。ただし実装は status_code に依存しないため、
         5xx が直接渡された場合も安全に GitHubAPIError へ変換する（防御的安全網）。
 
-        設計上の制約: `from e` でなく新規 Exception を __cause__ に使用する。
-        理由: httpx.HTTPStatusError の response body が Sentry 経由で漏洩するリスクを回避。
-        コーディング規約 Section 5「from e でチェーン維持」の意図的例外。
+        設計上の制約: `from None` を使用し __cause__ を None に設定する。
+        理由: 全 PII 回避パス（timeout/unexpected/NotFound/RateLimit/JSONDecode）と統一し、
+        呼び出し元が __cause__ を参照する際の分岐を不要とするため。
+        診断情報は構造化ログの endpoint フィールドで取得可能なため __cause__ への記録は不要。
+        コーディング規約 Section 5「from e でチェーン維持」の意図的例外（PII漏洩防止優先）。
 
         response/endpoint/method を直接受け取る理由: 呼び出し元が except 外で呼ぶことで
         __context__ に PII含有オブジェクトが残存しないよう設計（PII漏洩防止）。
@@ -486,9 +488,7 @@ class AsyncGitHubClient:
             method=method,
             body_preview=_redact_body_preview(body_preview_raw),
         )
-        raise GitHubAPIError(f"HTTP {response.status_code} error") from Exception(
-            f"httpx.HTTPStatusError: HTTP {response.status_code} {endpoint}"
-        )
+        raise GitHubAPIError(f"HTTP {response.status_code} error") from None
 
     def _update_etag_cache(
         self,
@@ -653,6 +653,9 @@ class AsyncGitHubClient:
                     # 防御的パス: 5xxをhttpx.HTTPStatusErrorとして受信した場合、通常パスと同等に処理
                     await self._handle_5xx_response(http_status_response, attempt, endpoint, method)
                     continue
+                if status_code == 404:
+                    # 防御的パス: 404も通常パスと同じ NotFoundError に揃える
+                    raise NotFoundError(f"Resource not found: {endpoint}") from None
                 if status_code == 429:
                     # 防御的パス: 429をhttpx.HTTPStatusErrorとして受信した場合もRateLimitErrorに変換
                     reset_time = self._parse_rate_limit_header(

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -361,7 +361,7 @@ class AsyncGitHubClient:
             raise GitHubAPIError("Access forbidden") from None
         raise GitHubAPIError(
             f"Access forbidden: {error_message}" if error_message else "Access forbidden"
-        )
+        ) from None
 
     async def _handle_5xx_response(
         self,

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -559,6 +559,7 @@ class AsyncGitHubClient:
 
         for attempt in range(self.max_retries):
             timeout_error_type: str | None = None
+            network_error_type: str | None = None
             unexpected_error_type: str | None = None
             http_status_response: httpx.Response | None = None
             try:
@@ -631,6 +632,24 @@ class AsyncGitHubClient:
                     continue
                 # 最終試行は後続の `timeout_error_type` で GitHubAPIError に変換する
 
+            except httpx.TransportError as e:
+                # PII漏洩防止: str(e)はURL/host:port等を含む可能性があるためログから除外
+                network_error_type = type(e).__qualname__
+                error_module = type(e).__module__
+                self.logger.warning(
+                    "request_network_error",
+                    endpoint=endpoint,
+                    method=method,
+                    error_type=network_error_type,
+                    error_module=error_module,
+                    error_context="network",
+                )
+                if attempt < self.max_retries - 1:
+                    delay = exponential_backoff_with_jitter(attempt, base_delay=2.0)
+                    await asyncio.sleep(delay)
+                    continue
+                # 最終試行は後続の `network_error_type` で GitHubAPIError に変換する
+
             except ASYNC_FATAL_EXCEPTIONS:
                 # システム例外は再発生
                 # - KeyboardInterrupt/SystemExit: graceful shutdown対応
@@ -687,6 +706,11 @@ class AsyncGitHubClient:
                 # Sentry/traceback walker 経由で expose されるため、
                 # active exception context の外で raise して __context__ を None に保つ
                 raise GitHubAPIError(f"Request timeout: {timeout_error_type}") from None
+
+            if network_error_type is not None:
+                # PII漏洩防止 (__context__): active exception context の外で raise して
+                # httpx.NetworkError のURL/host:port等を例外チェーンに残さない
+                raise GitHubAPIError(f"Network error: {network_error_type}") from None
 
             if unexpected_error_type is not None:
                 # PII漏洩防止 (__cause__): catch-all例外はURL/host:port等のPIIを含む可能性があるため

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -51,6 +51,9 @@ def validate_github_username(username: str) -> None:
 def validate_github_repo(repo: str) -> None:
     """GitHubリポジトリ名のバリデーション
 
+    "." と ".." は予約名として拒否する。
+    ".github" のようなドット始まりの名前はGitHub上で有効なため許可する。
+
     Args:
         repo: リポジトリ名
 
@@ -351,8 +354,11 @@ class AsyncGitHubClient:
                     error_message = raw_message[:_MAX_403_ERROR_MESSAGE_CHARS]
         except json.JSONDecodeError as parse_err:
             # JSONパース失敗は想定内（GitHub APIが非JSON形式で403を返す場合がある）
-            self.logger.warning("failed_to_parse_403_message", error=str(parse_err))
-            raise GitHubAPIError("Access forbidden") from parse_err
+            self.logger.warning(
+                "failed_to_parse_403_message",
+                error_type=type(parse_err).__qualname__,
+            )
+            raise GitHubAPIError("Access forbidden") from None
         raise GitHubAPIError(
             f"Access forbidden: {error_message}" if error_message else "Access forbidden"
         )
@@ -580,13 +586,14 @@ class AsyncGitHubClient:
                 raise
 
             except Exception as e:
+                error_type = type(e).__qualname__
                 self.logger.error(
                     "unexpected_error",
                     endpoint=endpoint,
                     method=method,
-                    error_type=type(e).__qualname__,
+                    error_type=error_type,
                 )
-                raise GitHubAPIError(f"Unexpected error: {e}") from e
+                raise GitHubAPIError(f"Unexpected error: {error_type}") from e
 
         # リトライ上限到達（ここに到達することはないはずだが、型チェッカー対策）
         raise GitHubServerError(f"Failed after {self.max_retries} attempts")

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -167,33 +167,40 @@ class AsyncGitHubClient:
         self._data_cache: dict[str, dict[str, Any] | list[dict[str, Any]]] = {}
         self.logger = get_logger(__name__)
 
-    async def _handle_retryable_error(
+    async def _log_and_sleep_for_retry(
         self,
         *,
         event: str,
-        prefix: str,
         error_context: str,
         error: httpx.TimeoutException | httpx.NetworkError,
         endpoint: str,
         method: str,
         attempt: int,
-    ) -> tuple[str, bool]:
-        """Retry対象例外をログし、必要なら sleep する。"""
-        error_type = type(error).__qualname__
+    ) -> None:
+        """Retry対象例外をログし、次の試行前に sleep する。
+
+        最終試行（attempt == max_retries - 1）では sleep しない。
+        ループの continue 判断は呼び出し元が担う。
+
+        Args:
+            event: structlog に渡すイベント名（例: "request_timeout"）
+            error_context: ログの error_context フィールド値（例: "timeout"）
+            error: キャッチした例外（TimeoutException または NetworkError）
+            endpoint: リクエスト先エンドポイント（ログ用）
+            method: HTTP メソッド（ログ用）
+            attempt: 現在の試行インデックス（0-based）
+        """
         self.logger.warning(
             event,
             endpoint=endpoint,
             method=method,
-            error_type=error_type,
+            error_type=type(error).__qualname__,
             error_module=type(error).__module__,
             error_context=error_context,
         )
-        retry_error_message = f"{prefix}: {error_type}"
         if attempt < self.max_retries - 1:
             delay = exponential_backoff_with_jitter(attempt, base_delay=2.0)
             await asyncio.sleep(delay)
-            return retry_error_message, True
-        return retry_error_message, False
 
     async def __aenter__(self) -> Self:
         """非同期コンテキストマネージャーのエントリー"""
@@ -644,30 +651,30 @@ class AsyncGitHubClient:
                 # PII漏洩防止: str(e)はURL/host:port等を含む可能性があるためログから除外
                 # (unexpected_errorパスと同じ方針:
                 #  error_type + error_module + error_context で診断情報を提供)
-                retry_error_message, should_continue = await self._handle_retryable_error(
+                retry_error_message = f"Request timeout: {type(e).__qualname__}"
+                await self._log_and_sleep_for_retry(
                     event="request_timeout",
-                    prefix="Request timeout",
                     error_context="timeout",
                     error=e,
                     endpoint=endpoint,
                     method=method,
                     attempt=attempt,
                 )
-                if should_continue:
+                if attempt < self.max_retries - 1:
                     continue
 
             except httpx.NetworkError as e:
                 # PII漏洩防止: str(e)はURL/host:port等を含む可能性があるためログから除外
-                retry_error_message, should_continue = await self._handle_retryable_error(
+                retry_error_message = f"Network error: {type(e).__qualname__}"
+                await self._log_and_sleep_for_retry(
                     event="request_network_error",
-                    prefix="Network error",
                     error_context="network",
                     error=e,
                     endpoint=endpoint,
                     method=method,
                     attempt=attempt,
                 )
-                if should_continue:
+                if attempt < self.max_retries - 1:
                     continue
 
             except ASYNC_FATAL_EXCEPTIONS:

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -94,10 +94,10 @@ def _redact_body_preview(body_preview: str) -> str:
         body_preview: デコード済みの response body (先頭 200バイト)
 
     Returns:
-        リダクション済み文字列 (形式: "[redacted:hash]")
+        リダクション済み文字列 (形式: "[redacted:SHA256_16chars]")
     """
 
-    body_hash = hashlib.sha256(body_preview.encode("utf-8", errors="replace")).hexdigest()[:12]
+    body_hash = hashlib.sha256(body_preview.encode("utf-8", errors="replace")).hexdigest()[:16]
     return f"[redacted:{body_hash}]"
 
 
@@ -153,7 +153,7 @@ class AsyncGitHubClient:
 
         Args:
             timeout: リクエストタイムアウト（秒）
-            max_retries: 最大試行回数（5xxエラーのみ、初回含む）
+            max_retries: 最大試行回数（5xx と timeout の再試行回数、初回含む）
             user_agent: User-Agentヘッダー（GitHub要求事項）
 
         """
@@ -538,9 +538,12 @@ class AsyncGitHubClient:
             NotFoundError: 404エラー
             RateLimitError: 403 Rate Limit超過 または 429 Too Many Requests
             GitHubServerError: 5xxエラー（リトライ上限後）
-            GitHubAPIError: タイムアウト等の予期しないエラー
+            GitHubAPIError: タイムアウトは再試行後の最終失敗、
+                予期しないエラーは即失敗
 
         Note:
+            max_retries は 5xx エラーと timeout の再試行回数を制御する。
+            unexpected エラーは再試行せず、1回目で GitHubAPIError へ変換する。
             X-RateLimit-Remaining ヘッダーが不正値の場合:
             - 監視パス: _RATE_LIMIT_FALLBACK_REMAINING（残量十分と見なし、rate_limit_low警告なし）
             - 403判定パス: _RATE_LIMIT_FORBIDDEN_FALLBACK（Rate Limit超過と判定せず、GitHubAPIError発生）
@@ -622,14 +625,22 @@ class AsyncGitHubClient:
                     error_module=error_module,
                     error_context="timeout",
                 )
-                # except外raiseパターン: HTTPStatusError.response等のPII含有オブジェクトが
-                # __context__に残存するのを防止（_parse_json_responseと同方針）
+                if attempt < self.max_retries - 1:
+                    delay = exponential_backoff_with_jitter(attempt, base_delay=2.0)
+                    await asyncio.sleep(delay)
+                    continue
+                # 最終試行は後続の `timeout_error_type` で GitHubAPIError に変換する
 
             except ASYNC_FATAL_EXCEPTIONS:
                 # システム例外は再発生
                 # - KeyboardInterrupt/SystemExit: graceful shutdown対応
                 # - MemoryError: K8s OOMKilled等のリソース枯渇検知
                 # - CancelledError: asyncioタスクキャンセル伝播
+                raise
+
+            except httpx.ResponseNotRead:
+                # ResponseNotRead は response body 未読の httpx 正常系制御例外。
+                # unexpected_error に包まず、そのまま伝播させる。
                 raise
 
             except Exception as e:

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import re
 from datetime import UTC, datetime
+from types import TracebackType
 from typing import Any, NoReturn, Self, cast
 
 import httpx
@@ -155,7 +156,12 @@ class AsyncGitHubClient:
         )
         return self
 
-    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """非同期コンテキストマネージャーの終了処理"""
         if self._client:
             await self._client.aclose()
@@ -173,7 +179,7 @@ class AsyncGitHubClient:
         Raises:
             ValueError: 無効なユーザー名
             NotFoundError: ユーザーが存在しない
-            RateLimitError: Rate Limit超過
+            RateLimitError: 403 Rate Limit超過 または 429 Too Many Requests
             GitHubServerError: 5xxエラー（リトライ上限後）
             GitHubAPIError: タイムアウト等の予期しないエラー、または不正なレスポンス型
 
@@ -346,9 +352,10 @@ class AsyncGitHubClient:
         except json.JSONDecodeError as parse_err:
             # JSONパース失敗は想定内（GitHub APIが非JSON形式で403を返す場合がある）
             self.logger.warning("failed_to_parse_403_message", error=str(parse_err))
+            raise GitHubAPIError("Access forbidden") from parse_err
         raise GitHubAPIError(
             f"Access forbidden: {error_message}" if error_message else "Access forbidden"
-        ) from None
+        )
 
     async def _handle_5xx_response(
         self,
@@ -563,7 +570,7 @@ class AsyncGitHubClient:
 
             except httpx.TimeoutException as e:
                 self.logger.warning("request_timeout", endpoint=endpoint, method=method)
-                raise GitHubAPIError(f"Request timeout: {e}") from e
+                raise GitHubAPIError(f"Request timeout: {type(e).__qualname__}") from e
 
             except ASYNC_FATAL_EXCEPTIONS:
                 # システム例外は再発生
@@ -577,7 +584,6 @@ class AsyncGitHubClient:
                     "unexpected_error",
                     endpoint=endpoint,
                     method=method,
-                    error=str(e),
                     error_type=type(e).__qualname__,
                 )
                 raise GitHubAPIError(f"Unexpected error: {e}") from e

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -407,8 +407,13 @@ class AsyncGitHubClient:
                 response.json(),
             )
         except json.JSONDecodeError as e:
-            self.logger.error("json_decode_error", endpoint=endpoint, error=str(e))
-            raise GitHubAPIError(f"Invalid JSON response: {e}") from e
+            self.logger.error(
+                "json_decode_error",
+                endpoint=endpoint,
+                error_type=type(e).__qualname__,
+                error_module=type(e).__module__,
+            )
+            raise GitHubAPIError("Invalid JSON response") from e
 
     def _handle_http_status_error(
         self,

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -153,7 +153,8 @@ class AsyncGitHubClient:
 
         Args:
             timeout: リクエストタイムアウト（秒）
-            max_retries: 最大試行回数（5xx と timeout の再試行回数、初回含む）
+            max_retries: 最大試行回数（5xx・timeout・NetworkError の再試行回数、初回含む）。
+                デフォルト設定(timeout=30, max_retries=3)での最悪ケース: 約96秒。
             user_agent: User-Agentヘッダー（GitHub要求事項）
 
         """
@@ -165,6 +166,34 @@ class AsyncGitHubClient:
         # URL -> response data（304レスポンス時のキャッシュ返却用）
         self._data_cache: dict[str, dict[str, Any] | list[dict[str, Any]]] = {}
         self.logger = get_logger(__name__)
+
+    async def _handle_retryable_error(
+        self,
+        *,
+        event: str,
+        prefix: str,
+        error_context: str,
+        error: httpx.TimeoutException | httpx.NetworkError,
+        endpoint: str,
+        method: str,
+        attempt: int,
+    ) -> tuple[str, bool]:
+        """Retry対象例外をログし、必要なら sleep する。"""
+        error_type = type(error).__qualname__
+        self.logger.warning(
+            event,
+            endpoint=endpoint,
+            method=method,
+            error_type=error_type,
+            error_module=type(error).__module__,
+            error_context=error_context,
+        )
+        retry_error_message = f"{prefix}: {error_type}"
+        if attempt < self.max_retries - 1:
+            delay = exponential_backoff_with_jitter(attempt, base_delay=2.0)
+            await asyncio.sleep(delay)
+            return retry_error_message, True
+        return retry_error_message, False
 
     async def __aenter__(self) -> Self:
         """非同期コンテキストマネージャーのエントリー"""
@@ -419,7 +448,7 @@ class AsyncGitHubClient:
             return
         raise GitHubServerError(
             f"Server error: {response.status_code} after {self.max_retries} attempts",
-        )
+        ) from None
 
     def _parse_json_response(
         self,
@@ -521,7 +550,7 @@ class AsyncGitHubClient:
         機能:
         - Rate Limit監視（X-RateLimit-Remaining < _RATE_LIMIT_WARNING_THRESHOLD で警告ログ）
         - Conditional Requests（ETag活用、304 Not Modified対応）
-        - 5xxエラーリトライ（指数バックオフ+ジッター）
+        - 5xx・timeout・NetworkError リトライ（指数バックオフ+ジッター）
         - 4xxエラー即失敗（NotFoundError, RateLimitError例外）
         - 例外情報の安全な保持（HTTPStatusError は URL+ステータスのみ保持した cause に再ラップ、response body 非露出）
 
@@ -538,11 +567,11 @@ class AsyncGitHubClient:
             NotFoundError: 404エラー
             RateLimitError: 403 Rate Limit超過 または 429 Too Many Requests
             GitHubServerError: 5xxエラー（リトライ上限後）
-            GitHubAPIError: タイムアウトは再試行後の最終失敗、
+            GitHubAPIError: タイムアウト・NetworkError は再試行後の最終失敗、
                 予期しないエラーは即失敗
 
         Note:
-            max_retries は 5xx エラーと timeout の再試行回数を制御する。
+            max_retries は 5xx エラーと timeout / NetworkError の再試行回数を制御する。
             unexpected エラーは再試行せず、1回目で GitHubAPIError へ変換する。
             X-RateLimit-Remaining ヘッダーが不正値の場合:
             - 監視パス: _RATE_LIMIT_FALLBACK_REMAINING（残量十分と見なし、rate_limit_low警告なし）
@@ -558,8 +587,7 @@ class AsyncGitHubClient:
         headers = self._prepare_headers(endpoint)
 
         for attempt in range(self.max_retries):
-            timeout_error_type: str | None = None
-            network_error_type: str | None = None
+            retry_error_message: str | None = None
             unexpected_error_type: str | None = None
             http_status_response: httpx.Response | None = None
             try:
@@ -616,39 +644,31 @@ class AsyncGitHubClient:
                 # PII漏洩防止: str(e)はURL/host:port等を含む可能性があるためログから除外
                 # (unexpected_errorパスと同じ方針:
                 #  error_type + error_module + error_context で診断情報を提供)
-                timeout_error_type = type(e).__qualname__
-                error_module = type(e).__module__
-                self.logger.warning(
-                    "request_timeout",
-                    endpoint=endpoint,
-                    method=method,
-                    error_type=timeout_error_type,
-                    error_module=error_module,
+                retry_error_message, should_continue = await self._handle_retryable_error(
+                    event="request_timeout",
+                    prefix="Request timeout",
                     error_context="timeout",
-                )
-                if attempt < self.max_retries - 1:
-                    delay = exponential_backoff_with_jitter(attempt, base_delay=2.0)
-                    await asyncio.sleep(delay)
-                    continue
-                # 最終試行は後続の `timeout_error_type` で GitHubAPIError に変換する
-
-            except httpx.TransportError as e:
-                # PII漏洩防止: str(e)はURL/host:port等を含む可能性があるためログから除外
-                network_error_type = type(e).__qualname__
-                error_module = type(e).__module__
-                self.logger.warning(
-                    "request_network_error",
+                    error=e,
                     endpoint=endpoint,
                     method=method,
-                    error_type=network_error_type,
-                    error_module=error_module,
-                    error_context="network",
+                    attempt=attempt,
                 )
-                if attempt < self.max_retries - 1:
-                    delay = exponential_backoff_with_jitter(attempt, base_delay=2.0)
-                    await asyncio.sleep(delay)
+                if should_continue:
                     continue
-                # 最終試行は後続の `network_error_type` で GitHubAPIError に変換する
+
+            except httpx.NetworkError as e:
+                # PII漏洩防止: str(e)はURL/host:port等を含む可能性があるためログから除外
+                retry_error_message, should_continue = await self._handle_retryable_error(
+                    event="request_network_error",
+                    prefix="Network error",
+                    error_context="network",
+                    error=e,
+                    endpoint=endpoint,
+                    method=method,
+                    attempt=attempt,
+                )
+                if should_continue:
+                    continue
 
             except ASYNC_FATAL_EXCEPTIONS:
                 # システム例外は再発生
@@ -700,17 +720,11 @@ class AsyncGitHubClient:
                 else:
                     self._handle_http_status_error(http_status_response, endpoint, method)
 
-            if timeout_error_type is not None:
-                # PII漏洩防止 (__context__): except 内で raise すると
-                # httpx.TimeoutException が __context__ に残り、
-                # Sentry/traceback walker 経由で expose されるため、
-                # active exception context の外で raise して __context__ を None に保つ
-                raise GitHubAPIError(f"Request timeout: {timeout_error_type}") from None
-
-            if network_error_type is not None:
+            if retry_error_message is not None:
                 # PII漏洩防止 (__context__): active exception context の外で raise して
-                # httpx.NetworkError のURL/host:port等を例外チェーンに残さない
-                raise GitHubAPIError(f"Network error: {network_error_type}") from None
+                # httpx.TimeoutException / httpx.NetworkError の
+                # URL/host:port等を例外チェーンに残さない
+                raise GitHubAPIError(retry_error_message) from None
 
             if unexpected_error_type is not None:
                 # PII漏洩防止 (__cause__): catch-all例外はURL/host:port等のPIIを含む可能性があるため

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -595,7 +595,8 @@ class AsyncGitHubClient:
 
             except httpx.TimeoutException as e:
                 # PII漏洩防止: str(e)はURL/host:port等を含む可能性があるためログから除外
-                # (unexpected_errorパスと同じ方針: error_type + error_moduleのみで診断情報を提供)
+                # (unexpected_errorパスと同じ方針:
+                #  error_type + error_module + error_context で診断情報を提供)
                 error_type = type(e).__qualname__
                 error_module = type(e).__module__
                 self.logger.warning(
@@ -604,6 +605,7 @@ class AsyncGitHubClient:
                     method=method,
                     error_type=error_type,
                     error_module=error_module,
+                    error_context="timeout",
                 )
                 # PII漏洩防止 (__cause__): `from e` では chain 経由で httpx.TimeoutException.args が
                 # Sentry/traceback walker に露出するため `from None` で chain 切断
@@ -626,6 +628,7 @@ class AsyncGitHubClient:
                     method=method,
                     error_type=error_type,
                     error_module=error_module,
+                    error_context="unexpected",
                 )
                 # PII漏洩防止 (__cause__): catch-all例外はURL/host:port等のPIIを含む可能性があるため
                 # 例外チェーンを切断し、診断情報は非PIIのログフィールドに限定する。

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -354,12 +354,15 @@ class AsyncGitHubClient:
                     error_message = raw_message[:_MAX_403_ERROR_MESSAGE_CHARS]
         except json.JSONDecodeError as parse_err:
             # JSONパース失敗は想定内（GitHub APIが非JSON形式で403を返す場合がある）
+            # PII漏洩防止: parse_err.docはレスポンスbody全体を保持するため
+            # 例外オブジェクトを例外メッセージ・ログから除外（"Access forbidden"のみで再raise）
             self.logger.warning(
                 "failed_to_parse_403_message",
                 error_type=type(parse_err).__qualname__,
                 error_module=type(parse_err).__module__,
             )
             raise GitHubAPIError("Access forbidden") from None
+
         raise GitHubAPIError(
             f"Access forbidden: {error_message}" if error_message else "Access forbidden"
         ) from None
@@ -412,7 +415,13 @@ class AsyncGitHubClient:
                 endpoint=endpoint,
                 error_type=type(e).__qualname__,
                 error_module=type(e).__module__,
+                error_pos=e.pos,
+                error_lineno=e.lineno,
             )
+            # `from e` 維持: 200レスポンスのJSONパース失敗は診断に必要なため例外チェーン保持。
+            # JSONDecodeError.doc にbody全体が保持されるが、_handle_403_response (認証コンテキスト
+            # 秘匿) と異なり 200 success path のため `from None` ではなく `from e` を選択。
+            # PII含有可能性は API 応答仕様に依存（GitHub APIは通常 PII を返さない）。
             raise GitHubAPIError("Invalid JSON response") from e
 
     def _handle_http_status_error(
@@ -581,6 +590,8 @@ class AsyncGitHubClient:
                     self._handle_http_status_error(e)
 
             except httpx.TimeoutException as e:
+                # PII漏洩防止: str(e)はURL/host:port等を含む可能性があるためログから除外
+                # (unexpected_errorパスと同じ方針: error_type + error_moduleのみで診断情報を提供)
                 error_type = type(e).__qualname__
                 error_module = type(e).__module__
                 self.logger.warning(
@@ -590,7 +601,10 @@ class AsyncGitHubClient:
                     error_type=error_type,
                     error_module=error_module,
                 )
-                raise GitHubAPIError(f"Request timeout: {error_type}") from e
+                # PII漏洩防止 (__cause__): `from e` では chain 経由で httpx.TimeoutException.args が
+                # Sentry/traceback walker に露出するため `from None` で chain 切断
+                # (_handle_http_status_error L427-438 と同方針)
+                raise GitHubAPIError(f"Request timeout: {error_type}") from None
 
             except ASYNC_FATAL_EXCEPTIONS:
                 # システム例外は再発生
@@ -609,7 +623,9 @@ class AsyncGitHubClient:
                     error_type=error_type,
                     error_module=error_module,
                 )
-                raise GitHubAPIError(f"Unexpected error: {error_type}") from e
+                # PII漏洩防止 (__cause__): catch-all例外はURL/host:port等のPIIを含む可能性があるため
+                # `from None` で chain 切断 (timeout path L600 と同方針)
+                raise GitHubAPIError(f"Unexpected error: {error_type}") from None
 
         # リトライ上限到達（ここに到達することはないはずだが、型チェッカー対策）
         raise GitHubServerError(f"Failed after {self.max_retries} attempts")

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -7,6 +7,7 @@
 """
 
 import asyncio
+import hashlib
 import json
 import re
 from datetime import UTC, datetime
@@ -80,6 +81,24 @@ _MAX_HTTP_ERROR_BODY_PREVIEW_BYTES = 200
 # =============================================================================
 # 例外クラス
 # =============================================================================
+
+
+def _redact_body_preview(body_preview: str) -> str:
+    """HTTP error response body preview をリダクション
+
+    エラー応答がトークン、API キー、private repository 名を含む場合に
+    stdout/debug logs へ機密情報が漏れるのを防止する。
+    内容を完全にマスクし、ハッシュベースの指紋を保持して debug に利用。
+
+    Args:
+        body_preview: デコード済みの response body (先頭 200バイト)
+
+    Returns:
+        リダクション済み文字列 (形式: "[redacted:hash]")
+    """
+
+    body_hash = hashlib.sha256(body_preview.encode("utf-8", errors="replace")).hexdigest()[:12]
+    return f"[redacted:{body_hash}]"
 
 
 class GitHubAPIError(APIClientError):
@@ -430,7 +449,9 @@ class AsyncGitHubClient:
 
     def _handle_http_status_error(
         self,
-        e: httpx.HTTPStatusError,
+        response: httpx.Response,
+        endpoint: str,
+        method: str,
     ) -> NoReturn:
         """4xxエラーを GitHubAPIError に変換して raise する。
 
@@ -443,27 +464,30 @@ class AsyncGitHubClient:
         設計上の制約: `from e` でなく新規 Exception を __cause__ に使用する。
         理由: httpx.HTTPStatusError の response body が Sentry 経由で漏洩するリスクを回避。
         コーディング規約 Section 5「from e でチェーン維持」の意図的例外。
+
+        response/endpoint/method を直接受け取る理由: 呼び出し元が except 外で呼ぶことで
+        __context__ に PII含有オブジェクトが残存しないよう設計（PII漏洩防止）。
         """
         # ログレベル別出力先
         # warning(401) → LOG__LEVEL=ERROR未満の全設定でstdoutに出力（デフォルトINFO含む）
         # debug(404等) → LOG__LEVEL=DEBUGの場合のみstdoutに出力
         # いずれもSentry非送信: make_filtering_bound_logger によりDEBUG/WARNING は
         #   Sentry送信前にフィルタ済み（参照: utils/logger.py L160, _sentry_processor L52-54）
-        body_preview = e.response.content[:_MAX_HTTP_ERROR_BODY_PREVIEW_BYTES].decode(
-            e.response.encoding or "utf-8",
+        body_preview_raw = response.content[:_MAX_HTTP_ERROR_BODY_PREVIEW_BYTES].decode(
+            response.encoding or "utf-8",
             errors="replace",
         )
         # 401 (Unauthorized) は認証エラーのため warning、404/422 等の想定内4xx は debug に抑制
-        log_fn = self.logger.warning if e.response.status_code == 401 else self.logger.debug
+        log_fn = self.logger.warning if response.status_code == 401 else self.logger.debug
         log_fn(
             "http_status_error",
-            status_code=e.response.status_code,
-            endpoint=e.request.url.path,
-            method=e.request.method,
-            body_preview=body_preview,
+            status_code=response.status_code,
+            endpoint=endpoint,
+            method=method,
+            body_preview=_redact_body_preview(body_preview_raw),
         )
-        raise GitHubAPIError(f"HTTP {e.response.status_code} error") from Exception(
-            f"httpx.HTTPStatusError: HTTP {e.response.status_code} {e.request.url.path}"
+        raise GitHubAPIError(f"HTTP {response.status_code} error") from Exception(
+            f"httpx.HTTPStatusError: HTTP {response.status_code} {endpoint}"
         )
 
     def _update_etag_cache(
@@ -531,6 +555,9 @@ class AsyncGitHubClient:
         headers = self._prepare_headers(endpoint)
 
         for attempt in range(self.max_retries):
+            timeout_error_type: str | None = None
+            unexpected_error_type: str | None = None
+            http_status_response: httpx.Response | None = None
             try:
                 response = await self._client.request(
                     method,
@@ -577,40 +604,26 @@ class AsyncGitHubClient:
                 raise
 
             except httpx.HTTPStatusError as e:
-                if e.response.status_code >= 500:
-                    # 防御的パス: 5xxをhttpx.HTTPStatusErrorとして受信した場合、通常パスと同等に処理
-                    await self._handle_5xx_response(e.response, attempt, endpoint, method)
-                    continue
-                if e.response.status_code == 429:
-                    # 防御的パス: 429をhttpx.HTTPStatusErrorとして受信した場合もRateLimitErrorに変換
-                    reset_time = self._parse_rate_limit_header(
-                        e.response.headers, "X-RateLimit-Reset", _RATE_LIMIT_RESET_FALLBACK
-                    )
-                    raise RateLimitError(reset_time) from None
-                if e.response.status_code == 403:
-                    # 防御的パス: 403をhttpx.HTTPStatusErrorとして受信した場合も詳細分析を実施
-                    self._handle_403_response(e.response)
-                else:
-                    self._handle_http_status_error(e)
+                # except外raiseパターン: e.response（PII含有）が __context__ に残存するのを防止
+                # e.response を退避してから except を抜け、except 外で処理・raise する
+                http_status_response = e.response
 
             except httpx.TimeoutException as e:
                 # PII漏洩防止: str(e)はURL/host:port等を含む可能性があるためログから除外
                 # (unexpected_errorパスと同じ方針:
                 #  error_type + error_module + error_context で診断情報を提供)
-                error_type = type(e).__qualname__
+                timeout_error_type = type(e).__qualname__
                 error_module = type(e).__module__
                 self.logger.warning(
                     "request_timeout",
                     endpoint=endpoint,
                     method=method,
-                    error_type=error_type,
+                    error_type=timeout_error_type,
                     error_module=error_module,
                     error_context="timeout",
                 )
-                # PII漏洩防止 (__cause__): `from e` では chain 経由で httpx.TimeoutException.args が
-                # Sentry/traceback walker に露出するため `from None` で chain 切断
-                # (_handle_http_status_error L427-438 と同方針)
-                raise GitHubAPIError(f"Request timeout: {error_type}") from None
+                # except外raiseパターン: HTTPStatusError.response等のPII含有オブジェクトが
+                # __context__に残存するのを防止（_parse_json_responseと同方針）
 
             except ASYNC_FATAL_EXCEPTIONS:
                 # システム例外は再発生
@@ -620,19 +633,51 @@ class AsyncGitHubClient:
                 raise
 
             except Exception as e:
-                error_type = type(e).__qualname__
+                unexpected_error_type = type(e).__qualname__
                 error_module = type(e).__module__
                 self.logger.error(
                     "unexpected_error",
                     endpoint=endpoint,
                     method=method,
-                    error_type=error_type,
+                    error_type=unexpected_error_type,
                     error_module=error_module,
                     error_context="unexpected",
                 )
+                # except外raiseパターン: 予期しない例外が__context__に残存するのを防止
+
+            if http_status_response is not None:
+                # PII漏洩防止: __context__ を None に保つため except 外で処理・raise
+                # (httpx.HTTPStatusError.response は response body + request URL を保持するため)
+                status_code = http_status_response.status_code
+                if status_code >= 500:
+                    # 防御的パス: 5xxをhttpx.HTTPStatusErrorとして受信した場合、通常パスと同等に処理
+                    await self._handle_5xx_response(http_status_response, attempt, endpoint, method)
+                    continue
+                if status_code == 429:
+                    # 防御的パス: 429をhttpx.HTTPStatusErrorとして受信した場合もRateLimitErrorに変換
+                    reset_time = self._parse_rate_limit_header(
+                        http_status_response.headers,
+                        "X-RateLimit-Reset",
+                        _RATE_LIMIT_RESET_FALLBACK,
+                    )
+                    raise RateLimitError(reset_time) from None
+                if status_code == 403:
+                    # 防御的パス: 403をhttpx.HTTPStatusErrorとして受信した場合も詳細分析を実施
+                    self._handle_403_response(http_status_response)
+                else:
+                    self._handle_http_status_error(http_status_response, endpoint, method)
+
+            if timeout_error_type is not None:
+                # PII漏洩防止 (__context__): except 内で raise すると
+                # httpx.TimeoutException が __context__ に残り、
+                # Sentry/traceback walker 経由で expose されるため、
+                # active exception context の外で raise して __context__ を None に保つ
+                raise GitHubAPIError(f"Request timeout: {timeout_error_type}") from None
+
+            if unexpected_error_type is not None:
                 # PII漏洩防止 (__cause__): catch-all例外はURL/host:port等のPIIを含む可能性があるため
                 # 例外チェーンを切断し、診断情報は非PIIのログフィールドに限定する。
-                raise GitHubAPIError(f"Unexpected error: {error_type}") from None
+                raise GitHubAPIError(f"Unexpected error: {unexpected_error_type}") from None
 
         # リトライ上限到達（ここに到達することはないはずだが、型チェッカー対策）
         raise GitHubServerError(f"Failed after {self.max_retries} attempts")

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -360,6 +360,8 @@ class AsyncGitHubClient:
                 "failed_to_parse_403_message",
                 error_type=type(parse_err).__qualname__,
                 error_module=type(parse_err).__module__,
+                error_pos=parse_err.pos,
+                error_lineno=parse_err.lineno,
             )
             raise GitHubAPIError("Access forbidden") from None
 
@@ -410,7 +412,7 @@ class AsyncGitHubClient:
                 response.json(),
             )
         except json.JSONDecodeError as e:
-            self.logger.error(
+            self.logger.warning(
                 "json_decode_error",
                 endpoint=endpoint,
                 error_type=type(e).__qualname__,
@@ -418,11 +420,10 @@ class AsyncGitHubClient:
                 error_pos=e.pos,
                 error_lineno=e.lineno,
             )
-            # `from e` 維持: 200レスポンスのJSONパース失敗は診断に必要なため例外チェーン保持。
-            # JSONDecodeError.doc にbody全体が保持されるが、_handle_403_response (認証コンテキスト
-            # 秘匿) と異なり 200 success path のため `from None` ではなく `from e` を選択。
-            # PII含有可能性は API 応答仕様に依存（GitHub APIは通常 PII を返さない）。
-            raise GitHubAPIError("Invalid JSON response") from e
+
+        # JSONDecodeError.doc はレスポンスbody全体を保持するため、
+        # active exception context の外で再raiseして cause/context に残さない。
+        raise GitHubAPIError("Invalid JSON response") from None
 
     def _handle_http_status_error(
         self,
@@ -624,8 +625,10 @@ class AsyncGitHubClient:
                     error_module=error_module,
                 )
                 # PII漏洩防止 (__cause__): catch-all例外はURL/host:port等のPIIを含む可能性があるため
-                # `from None` で chain 切断 (timeout path L600 と同方針)
-                raise GitHubAPIError(f"Unexpected error: {error_type}") from None
+                # `from Exception(...)` で chain 切断し最小限の診断情報を保持 (L461-463 と同方針)
+                raise GitHubAPIError(f"Unexpected error: {error_type}") from Exception(
+                    f"{error_module}.{error_type}"
+                )
 
         # リトライ上限到達（ここに到達することはないはずだが、型チェッカー対策）
         raise GitHubServerError(f"Failed after {self.max_retries} attempts")

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -357,6 +357,7 @@ class AsyncGitHubClient:
             self.logger.warning(
                 "failed_to_parse_403_message",
                 error_type=type(parse_err).__qualname__,
+                error_module=type(parse_err).__module__,
             )
             raise GitHubAPIError("Access forbidden") from None
         raise GitHubAPIError(
@@ -575,8 +576,16 @@ class AsyncGitHubClient:
                     self._handle_http_status_error(e)
 
             except httpx.TimeoutException as e:
-                self.logger.warning("request_timeout", endpoint=endpoint, method=method)
-                raise GitHubAPIError(f"Request timeout: {type(e).__qualname__}") from e
+                error_type = type(e).__qualname__
+                error_module = type(e).__module__
+                self.logger.warning(
+                    "request_timeout",
+                    endpoint=endpoint,
+                    method=method,
+                    error_type=error_type,
+                    error_module=error_module,
+                )
+                raise GitHubAPIError(f"Request timeout: {error_type}") from e
 
             except ASYNC_FATAL_EXCEPTIONS:
                 # システム例外は再発生
@@ -587,11 +596,13 @@ class AsyncGitHubClient:
 
             except Exception as e:
                 error_type = type(e).__qualname__
+                error_module = type(e).__module__
                 self.logger.error(
                     "unexpected_error",
                     endpoint=endpoint,
                     method=method,
                     error_type=error_type,
+                    error_module=error_module,
                 )
                 raise GitHubAPIError(f"Unexpected error: {error_type}") from e
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -18,7 +18,6 @@ import os
 import sys
 import threading
 import time
-from functools import lru_cache
 from types import TracebackType
 from typing import Any, Literal, cast
 
@@ -63,13 +62,12 @@ _SENTRY_LEVEL_MAP: dict[str, Literal["error", "critical"]] = {
 _SENTRY_DEBUG_DETAIL_MAX_LEN: int = 100
 
 
-@lru_cache(maxsize=1)
 def _is_sentry_debug_enabled() -> bool:
     """SENTRY_DEBUG 環境変数が有効か判定
 
-    結果はプロセスライフタイムでキャッシュされる (lru_cache)。
-    SENTRY_DEBUG の変更を反映するにはプロセス再起動が必要。
-    テストで動的に変更する場合は `_is_sentry_debug_enabled.cache_clear()` を呼ぶこと。
+    環境変数の変更はリアルタイムに反映される（キャッシュなし）。
+    デプロイ後のSENTRY_DEBUG有効化に対応し、プロセス再起動不要。
+    os.environ.get() はO(1)で軽量なため、呼び出しごとのチェックにオーバーヘッドなし。
     """
     return os.environ.get("SENTRY_DEBUG", "").lower() in ("true", "1", "yes")
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -322,6 +322,7 @@ def _sentry_processor(  # noqa: C901
             # システム例外は再発生させ OOMKilled / 無限再帰検知を妨げない
             raise
         except Exception as warn_err:  # noqa: BLE001
+            # import warning の失敗は診断補助に限定し、本体のログ処理は止めない
             print(
                 f"[SENTRY_WARN] Failed to emit import warning: {type(warn_err).__name__}",
                 file=sys.stderr,
@@ -364,7 +365,7 @@ def _sentry_processor(  # noqa: C901
                     scope.set_extra(key, value)
                 except AttributeError, TypeError:  # noqa: PERF203
                     # user-data serialization failure (e.g. broken __repr__ on Pydantic model)
-                    # → 該当キーのみスキップし [SENTRY_BUG] には昇格させない
+                    # → 該当キーのみスキップし、追加ログは出さない（PII再露出/再帰防止）
                     continue
             if exc_info is True:
                 # except ブロック外では sys.exc_info()[1] が None → capture_exception 不可

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -67,7 +67,8 @@ def _is_sentry_debug_enabled() -> bool:
 
     環境変数の変更はリアルタイムに反映される（キャッシュなし）。
     デプロイ後のSENTRY_DEBUG有効化に対応し、プロセス再起動不要。
-    os.environ.get() はO(1)で軽量なため、呼び出しごとのチェックにオーバーヘッドなし。
+    os.environ.get() はO(1)で軽量なため、呼び出しごとのチェックでも
+    通常のホットパスへの影響は小さい。
     """
     return os.environ.get("SENTRY_DEBUG", "").lower() in ("true", "1", "yes")
 


### PR DESCRIPTION
## 概要
PR #340 のレビュー指摘対応。CI安全性・型精度・PII防御・テスト品質の4点を改善。

## 変更内容
- **ci**: setup-uvアクション(pinned SHA)への移行でsupply chain attack対策（3ジョブ）
- **security**: timeout/unexpected_errorログからstr(e)を除去→qualname化でPII漏洩防止
- **test**: asyncio.sleepをAsyncMockでモック化しリトライテストを高速・決定論化
- **type**: `__aexit__`型注釈を`Any→BaseException|None`に強化、TracebackType導入
- **test**: edge caseテスト追加（.github repo名、missing headerデフォルト、main()RuntimeError伝播、timeout/unexpected_errorの例外チェーン切断検証）
- **docs**: api_client.pyのdocstringをwhitespace-only検証実装と一致させる

## テスト
- [x] ローカルテスト完了（961 passed / 95.50% coverage）
- [x] ruff 0 errors（staged files）
- [x] mypy 0 errors
- [x] CI/CDパイプライン確認予定

## 関連PR
Refs #340 (PR)

---

## ⚠️ Behavior Change Note

### Commit 5ea09ac: NetworkError retry & PII防止

**変更対象**: `utils/github_client.py` + `tests/unit/test_github_client.py`

| 項目 | 旧仕様 | 新仕様 | 影響度 |
|-----|--------|--------|--------|
| **NetworkError処理** | 即失敗 (ConnectError/ReadError等) | TimeoutExceptionと同等のretry戦略を適用 | 🟡 Medium |
| **retry回数** | timeout: 5回まで | Network error: 5回まで | 🟡 Medium |
| **backoff戦略** | timeout専用 | timeout+network共通: exponential_backoff_with_jitter | 🟢 Low |
| **外部API側の見え方** | 同じ (GitHubAPIError) | 同じ (GitHubAPIError) | 🟢 Low |
| **PII漏洩防止** | except内raise（__context__に例外残存） | except外raise + from None（チェーン完全切断） | ✅ Security |
| **ログフィールド** | 既存: request_timeout | 新規: request_network_error（同一フォーマット） | 🟡 Medium |

**移行手順**: 
- 既存コード: ConnectError/ReadError/RemoteProtocolErrorはGitHubAPIError即失敗 → 即座にリトライを止める実装あれば影響あり。ただし、httpx.TransportError + retryは標準パターンのため、大半のコード（retry条件がない限り）は挙動変わらず。
- 新仕様: 自動retry → エラー率低減。ログには `request_network_error` イベントが追加される（既存監視ダッシュボードは変更不要、新rule追加で `request_network_error` を集計可能）。

**リスク要因**: なし（例外チェーン切断はセキュリティ向上、retry上限は既存と同じ）。

---

このPRは `/push-pr` スキルで自動生成されました。