### PR TITLE
fix(client): RemoteProtocolError対応・リトライSRP化 (PR #341 review)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -383,8 +383,7 @@ def reset_sentry_warning_state(
 
     monkeypatch.setattr("utils.logger._sentry_warnings_emitted", set())
     monkeypatch.setattr("utils.logger._sentry_send_error_last_warned", float("-inf"))
-    # SENTRY_DEBUG は環境変数をリアルタイム取得するため cache_clear() 不要
-    # (lru_cache削除済みversion: logger.py _is_sentry_debug_enabled)
+    # SENTRY_DEBUG は環境変数をリアルタイム取得するため、キャッシュリセット不要
     yield
 
 

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -403,13 +403,13 @@ async def test_network_and_protocol_error_logging_no_pii_leak(
     """NetworkError/RemoteProtocolError例外メッセージがログフィールド値へ漏洩しないこと検証"""
     sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"
     transport_exception = exception_class(sensitive_detail)
-    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=transport_exception)
+    respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=transport_exception)
 
     with patch(
         "utils.github_client.exponential_backoff_with_jitter",
         return_value=0.0,
-    ) as mock_backoff:
-        with patch("utils.github_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+    ):
+        with patch("utils.github_client.asyncio.sleep", new_callable=AsyncMock):
             with capture_logs() as log_output:
                 async with AsyncGitHubClient() as client:
                     with pytest.raises(GitHubAPIError) as exc_info:
@@ -428,9 +428,6 @@ async def test_network_and_protocol_error_logging_no_pii_leak(
             assert sensitive_detail not in str(value), (
                 f"sensitive_detail leaked in log field value: {value!r}"
             )
-    assert route.call_count == MAX_RETRIES
-    assert mock_backoff.call_count == MAX_RETRIES - 1
-    assert mock_sleep.await_count == MAX_RETRIES - 1
 
 
 @respx.mock

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -188,6 +188,8 @@ async def test_retry_on_server_error(mock_sleep: AsyncMock, mock_backoff: Mock) 
     assert route.call_count == MAX_RETRIES
     assert "Server error: 500" in str(exc_info.value)
     assert f"after {MAX_RETRIES} attempts" in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
     assert mock_backoff.call_count == MAX_RETRIES - 1  # MAX_RETRIES試行 → 最終試行以外でバックオフ
     assert mock_sleep.await_count == MAX_RETRIES - 1
     mock_sleep.assert_has_awaits([call(0.0)] * (MAX_RETRIES - 1))
@@ -403,13 +405,13 @@ async def test_network_and_protocol_error_logging_no_pii_leak(
     """NetworkError/RemoteProtocolError例外メッセージがログフィールド値へ漏洩しないこと検証"""
     sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"
     transport_exception = exception_class(sensitive_detail)
-    respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=transport_exception)
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=transport_exception)
 
     with patch(
         "utils.github_client.exponential_backoff_with_jitter",
         return_value=0.0,
-    ):
-        with patch("utils.github_client.asyncio.sleep", new_callable=AsyncMock):
+    ) as mock_backoff:
+        with patch("utils.github_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             with capture_logs() as log_output:
                 async with AsyncGitHubClient() as client:
                     with pytest.raises(GitHubAPIError) as exc_info:
@@ -418,6 +420,10 @@ async def test_network_and_protocol_error_logging_no_pii_leak(
     assert sensitive_detail not in str(exc_info.value)
     assert exc_info.value.__cause__ is None
     assert exc_info.value.__context__ is None
+    assert route.call_count == MAX_RETRIES
+    assert mock_backoff.call_count == MAX_RETRIES - 1
+    assert mock_sleep.await_count == MAX_RETRIES - 1
+    mock_sleep.assert_has_awaits([call(0.0)] * (MAX_RETRIES - 1))
     network_logs = [log for log in log_output if log.get("event") == "request_network_error"]
     assert len(network_logs) == MAX_RETRIES
     for network_log in network_logs:
@@ -619,6 +625,8 @@ async def test_httpx_status_error_5xx(mock_sleep: AsyncMock, mock_backoff: Mock)
                 await client.get_user("octocat")
 
     assert "Server error: 503" in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
     assert route.call_count == MAX_RETRIES
     assert mock_backoff.call_count == MAX_RETRIES - 1  # MAX_RETRIES試行 → 最終試行以外でバックオフ
     assert mock_sleep.await_count == MAX_RETRIES - 1
@@ -1577,30 +1585,18 @@ def test_parse_json_response_invalid_json_raises() -> None:
     assert isinstance(decode_logs[0]["error_lineno"], int)
 
 
-def test_parse_json_response_unexpected_parse_error_raises_invalid_json_without_pii() -> None:
-    """_parse_json_response: JSONDecodeError以外のパース例外もPII-safeにInvalid JSONへ変換"""
+def test_parse_json_response_unexpected_parse_error_propagates() -> None:
+    """_parse_json_response: JSONDecodeError以外のパース例外は呼び出し元へ伝播"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
     sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"
     response = Mock(spec=httpx.Response)
     response.json.side_effect = RuntimeError(sensitive_detail)
 
     with capture_logs() as log_output:
-        with pytest.raises(GitHubAPIError, match="Invalid JSON response") as exc_info:
+        with pytest.raises(RuntimeError, match=re.escape(sensitive_detail)):
             client._parse_json_response(response, "/test-endpoint")
 
-    assert exc_info.value.__cause__ is None
-    assert exc_info.value.__context__ is None
-    assert sensitive_detail not in str(exc_info.value)
-    parse_logs = [log for log in log_output if log.get("event") == "json_parse_unexpected_error"]
-    assert len(parse_logs) == 1
-    assert parse_logs[0]["endpoint"] == "/test-endpoint"
-    assert parse_logs[0]["error_type"] == "RuntimeError"
-    assert parse_logs[0]["error_module"] == "builtins"
-    assert "error" not in parse_logs[0]
-    for value in parse_logs[0].values():
-        assert sensitive_detail not in str(value), (
-            f"sensitive_detail leaked in log field value: {value!r}"
-        )
+    assert not [log for log in log_output if log.get("event") == "json_parse_unexpected_error"]
 
 
 def test_update_etag_cache_no_etag_header() -> None:

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -436,7 +436,8 @@ async def test_network_and_protocol_error_logging_no_pii_leak(
 @respx.mock
 async def test_local_protocol_error_is_not_retried() -> None:
     """LocalProtocolErrorはクライアント側protocol violationのためretry対象外。"""
-    local_protocol_error = httpx.LocalProtocolError("Local protocol failed")
+    sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"
+    local_protocol_error = httpx.LocalProtocolError(sensitive_detail)
     route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=local_protocol_error)
 
     with capture_logs() as log_output:
@@ -452,6 +453,11 @@ async def test_local_protocol_error_is_not_retried() -> None:
     assert len(unexpected_logs) == 1
     assert unexpected_logs[0]["error_type"] == "LocalProtocolError"
     assert unexpected_logs[0]["error_context"] == "unexpected"
+    assert sensitive_detail not in str(exc_info.value)
+    for value in unexpected_logs[0].values():
+        assert sensitive_detail not in str(value), (
+            f"sensitive_detail leaked in log field value: {value!r}"
+        )
 
 
 # =============================================================================

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -251,7 +251,7 @@ async def test_timeout_handling(
     assert str(exc_info.value) == expected_message
     # 例外チェーン切断確認（from None による PII 漏洩防止）
     assert exc_info.value.__cause__ is None
-    assert exc_info.value.__context__ is None  # except外raiseパターン検証
+    assert exc_info.value.__context__ is None  # active exception context 外 raise による PII 防止
     assert route.call_count == MAX_RETRIES  # timeout は max_retries 回まで再試行
     assert mock_backoff.call_count == MAX_RETRIES - 1
     assert mock_sleep.await_count == MAX_RETRIES - 1
@@ -301,7 +301,7 @@ async def test_timeout_logging_no_pii_leak():
     assert sensitive_detail not in str(exc_info.value)
     # __cause__ 切断検証: from None により Sentry/traceback 経由の PII 漏洩を防止
     assert exc_info.value.__cause__ is None
-    assert exc_info.value.__context__ is None  # except外raiseパターン検証
+    assert exc_info.value.__context__ is None  # active exception context 外 raise による PII 防止
     timeout_logs = [log for log in log_output if log.get("event") == "request_timeout"]
     assert len(timeout_logs) == MAX_RETRIES
     # PII値レベル検証: 全logフィールド値にsensitive_detailが漏洩していないこと
@@ -338,14 +338,19 @@ async def test_timeout_logging_no_pii_leak():
             "Network error: CloseError",
             id="close_error",
         ),
+        pytest.param(
+            httpx.RemoteProtocolError("Remote protocol failed"),
+            "Network error: RemoteProtocolError",
+            id="remote_protocol_error",
+        ),
     ],
 )
 @respx.mock
 async def test_network_error_retry_handling(
-    network_exception: httpx.NetworkError,
+    network_exception: httpx.NetworkError | httpx.RemoteProtocolError,
     expected_message: str,
 ) -> None:
-    """NetworkError系をretry後、GitHubAPIErrorへ安全に変換する。"""
+    """NetworkError/RemoteProtocolError系をretry後、GitHubAPIErrorへ安全に変換する。"""
     route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=network_exception)
 
     with patch(
@@ -382,6 +387,71 @@ async def test_network_error_retry_handling(
         }
         assert "error_detail" not in network_log
         assert "error" not in network_log
+
+
+@pytest.mark.parametrize(
+    "exception_class",
+    [
+        pytest.param(httpx.ConnectError, id="network_error"),
+        pytest.param(httpx.RemoteProtocolError, id="remote_protocol_error"),
+    ],
+)
+@respx.mock
+async def test_network_and_protocol_error_logging_no_pii_leak(
+    exception_class: type[Exception],
+) -> None:
+    """NetworkError/RemoteProtocolError例外メッセージがログフィールド値へ漏洩しないこと検証"""
+    sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"
+    transport_exception = exception_class(sensitive_detail)
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=transport_exception)
+
+    with patch(
+        "utils.github_client.exponential_backoff_with_jitter",
+        return_value=0.0,
+    ) as mock_backoff:
+        with patch("utils.github_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            with capture_logs() as log_output:
+                async with AsyncGitHubClient() as client:
+                    with pytest.raises(GitHubAPIError) as exc_info:
+                        await client.get_user("octocat")
+
+    assert sensitive_detail not in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+    network_logs = [log for log in log_output if log.get("event") == "request_network_error"]
+    assert len(network_logs) == MAX_RETRIES
+    for network_log in network_logs:
+        assert network_log["error_type"] == exception_class.__qualname__
+        assert network_log["error_module"] == exception_class.__module__
+        assert network_log["error_context"] == "network"
+        for value in network_log.values():
+            assert sensitive_detail not in str(value), (
+                f"sensitive_detail leaked in log field value: {value!r}"
+            )
+    assert route.call_count == MAX_RETRIES
+    assert mock_backoff.call_count == MAX_RETRIES - 1
+    assert mock_sleep.await_count == MAX_RETRIES - 1
+
+
+@respx.mock
+async def test_local_protocol_error_is_not_retried() -> None:
+    """LocalProtocolErrorはクライアント側protocol violationのためretry対象外。"""
+    local_protocol_error = httpx.LocalProtocolError("Local protocol failed")
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=local_protocol_error)
+
+    with capture_logs() as log_output:
+        async with AsyncGitHubClient() as client:
+            with pytest.raises(GitHubAPIError) as exc_info:
+                await client.get_user("octocat")
+
+    assert str(exc_info.value) == "Unexpected error: LocalProtocolError"
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+    assert route.call_count == 1
+    unexpected_logs = [log for log in log_output if log.get("event") == "unexpected_error"]
+    assert len(unexpected_logs) == 1
+    assert unexpected_logs[0]["error_type"] == "LocalProtocolError"
+    assert unexpected_logs[0]["error_context"] == "unexpected"
 
 
 # =============================================================================
@@ -650,7 +720,7 @@ async def test_httpx_status_error_403_defensive_path() -> None:
         with pytest.raises(RateLimitError) as exc_info:
             await client.get_user("octocat")
 
-    assert exc_info.value.__context__ is None  # sentinel pattern: except外raiseパターン検証
+    assert exc_info.value.__context__ is None  # active exception context 外 raise による PII 防止
     assert exc_info.value.reset_time == 1640000000
     assert "Rate limit exceeded" in str(exc_info.value)
     assert route.call_count == 1
@@ -679,7 +749,7 @@ async def test_httpx_status_error_403_auth_error_defensive_path() -> None:
         with pytest.raises(GitHubAPIError, match="Access forbidden") as exc_info:
             await client.get_user("octocat")
 
-    assert exc_info.value.__context__ is None  # sentinel pattern: except外raiseパターン検証
+    assert exc_info.value.__context__ is None  # active exception context 外 raise による PII 防止
     assert route.call_count == 1
 
 
@@ -1504,6 +1574,32 @@ def test_parse_json_response_invalid_json_raises() -> None:
     assert isinstance(decode_logs[0]["error_lineno"], int)
 
 
+def test_parse_json_response_unexpected_parse_error_raises_invalid_json_without_pii() -> None:
+    """_parse_json_response: JSONDecodeError以外のパース例外もPII-safeにInvalid JSONへ変換"""
+    client = AsyncGitHubClient(max_retries=MAX_RETRIES)
+    sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"
+    response = Mock(spec=httpx.Response)
+    response.json.side_effect = RuntimeError(sensitive_detail)
+
+    with capture_logs() as log_output:
+        with pytest.raises(GitHubAPIError, match="Invalid JSON response") as exc_info:
+            client._parse_json_response(response, "/test-endpoint")
+
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+    assert sensitive_detail not in str(exc_info.value)
+    parse_logs = [log for log in log_output if log.get("event") == "json_parse_unexpected_error"]
+    assert len(parse_logs) == 1
+    assert parse_logs[0]["endpoint"] == "/test-endpoint"
+    assert parse_logs[0]["error_type"] == "RuntimeError"
+    assert parse_logs[0]["error_module"] == "builtins"
+    assert "error" not in parse_logs[0]
+    for value in parse_logs[0].values():
+        assert sensitive_detail not in str(value), (
+            f"sensitive_detail leaked in log field value: {value!r}"
+        )
+
+
 def test_update_etag_cache_no_etag_header() -> None:
     """ETagヘッダー不在時にキャッシュを更新しない"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
@@ -1693,7 +1789,7 @@ async def test_httpx_status_error_429_defensive_path() -> None:
         with pytest.raises(RateLimitError) as exc_info:
             await client.get_user("octocat")
 
-    assert exc_info.value.__context__ is None  # sentinel pattern: except外raiseパターン検証
+    assert exc_info.value.__context__ is None  # active exception context 外 raise による PII 防止
     assert exc_info.value.reset_time == 1640000000
     assert "Rate limit exceeded" in str(exc_info.value)
     assert route.call_count == 1

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -224,7 +224,8 @@ def _resolve_client_config(
         (base_url, timeout, retry_count, retry_delay, default_headers) のタプル
 
     Raises:
-        ValueError: base_urlが空文字列またはスペースのみの文字列の場合
+        ValueError: base_urlが空文字列またはホワイトスペース
+            （スペース・タブ・改行等）のみの文字列の場合
 
     """
     base_url = base_url if base_url is not None else settings.api.base_url
@@ -343,7 +344,8 @@ class SyncAPIClient:
         headers: 追加HTTPヘッダー
 
         Raises:
-            ValueError: base_urlが空文字列またはスペースのみの文字列の場合
+            ValueError: base_urlが空文字列またはホワイトスペース
+                （スペース・タブ・改行等）のみの文字列の場合
 
         """
         # 設定解決・バリデーション（Sync/Async共通ロジック）
@@ -789,7 +791,8 @@ class AsyncAPIClient:
         headers: 追加HTTPヘッダー
 
         Raises:
-            ValueError: base_urlが空文字列またはスペースのみの文字列の場合
+            ValueError: base_urlが空文字列またはホワイトスペース
+                （スペース・タブ・改行等）のみの文字列の場合
 
         """
         # 設定解決・バリデーション（Sync/Async共通ロジック）

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -20,6 +20,9 @@ from structlog.typing import FilteringBoundLogger
 from config.settings import settings
 from utils.logger import get_logger
 
+# httpx 例外（NetworkError, RemoteProtocolError 等）をここに追加してはならない。
+# github_client.py の _request では except 句の順序で先行キャッチしており、
+# この定数に httpx 例外を追加すると NetworkError のリトライが壊れる。
 ASYNC_FATAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
     KeyboardInterrupt,
     SystemExit,
@@ -225,7 +228,7 @@ def _resolve_client_config(
 
     Raises:
         ValueError: base_urlが空文字列またはホワイトスペース
-            （スペース・タブ・改行等）のみの文字列の場合
+            （str.strip() で除去される文字）のみの文字列の場合
 
     """
     base_url = base_url if base_url is not None else settings.api.base_url

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -187,7 +187,8 @@ class AsyncGitHubClient:
         Args:
             event: structlog に渡すイベント名（例: "request_timeout"）
             error_context: ログの error_context フィールド値（例: "timeout"）
-            error: キャッチした例外（TimeoutException、NetworkError、RemoteProtocolError）
+            error: キャッチした例外（TimeoutException、NetworkError、RemoteProtocolError）。
+                   LocalProtocolError はクライアント側 protocol violation のため retry 対象外。
             endpoint: リクエスト先エンドポイント（ログ用）
             method: HTTP メソッド（ログ用）
             attempt: 現在の試行インデックス（0-based）
@@ -241,7 +242,8 @@ class AsyncGitHubClient:
             NotFoundError: ユーザーが存在しない
             RateLimitError: 403 Rate Limit超過 または 429 Too Many Requests
             GitHubServerError: 5xxエラー（リトライ上限後）
-            GitHubAPIError: タイムアウト等の予期しないエラー、または不正なレスポンス型
+            GitHubAPIError: タイムアウト・NetworkError・RemoteProtocolError
+                            リトライ上限後の最終失敗、または不正なレスポンス型
 
         Example:
             >>> async with AsyncGitHubClient() as client:
@@ -276,7 +278,8 @@ class AsyncGitHubClient:
             RateLimitError: 403 Rate Limit超過 または 429 Too Many Requests
             NotFoundError: リソースが見つからない場合
             GitHubServerError: 5xxエラー（リトライ上限後）
-            GitHubAPIError: タイムアウト等の予期しないエラー
+            GitHubAPIError: タイムアウト・NetworkError・RemoteProtocolError
+                            リトライ上限後の最終失敗、または不正なレスポンス型
 
         Example:
             >>> repos = await client.get_repos("octocat", sort="updated")
@@ -305,7 +308,8 @@ class AsyncGitHubClient:
             RateLimitError: 403 Rate Limit超過 または 429 Too Many Requests
             NotFoundError: リソースが見つからない場合
             GitHubServerError: 5xxエラー（リトライ上限後）
-            GitHubAPIError: タイムアウト等の予期しないエラー
+            GitHubAPIError: タイムアウト・NetworkError・RemoteProtocolError
+                            リトライ上限後の最終失敗、または不正なレスポンス型
 
         Example:
             >>> repo = await client.get_repo("octocat", "Hello-World")

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -483,16 +483,7 @@ class AsyncGitHubClient:
                 error_pos=e.pos,
                 error_lineno=e.lineno,
             )
-        except Exception as e:
-            self.logger.error(
-                "json_parse_unexpected_error",
-                endpoint=endpoint,
-                error_type=type(e).__qualname__,
-                error_module=type(e).__module__,
-                error_context="unexpected_parse",
-            )
-
-        # JSONDecodeError.doc やその他パース例外はレスポンスbody/URL等を保持しうる。
+        # JSONDecodeError.doc はレスポンスbody全体を保持する。
         # except 内で raise すると __context__ に元例外が残存して露出するため、
         # active exception context の外で raise して __context__ を None に保つ。
         raise GitHubAPIError("Invalid JSON response") from None

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -91,7 +91,8 @@ def _redact_body_preview(body_preview: str) -> str:
     内容を完全にマスクし、ハッシュベースの指紋を保持して debug に利用。
 
     Args:
-        body_preview: _MAX_HTTP_ERROR_BODY_PREVIEW_BYTES 上限で切り詰めた response body
+        body_preview: デコード済みの response body
+            （先頭 _MAX_HTTP_ERROR_BODY_PREVIEW_BYTES バイトで切り詰め済み）
 
     Returns:
         リダクション済み文字列 (形式: "[redacted:SHA256_16chars]")
@@ -484,6 +485,7 @@ class AsyncGitHubClient:
                 endpoint=endpoint,
                 error_type=type(e).__qualname__,
                 error_module=type(e).__module__,
+                error_context="unexpected_parse",
             )
 
         # JSONDecodeError.doc やその他パース例外はレスポンスbody/URL等を保持しうる。

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -91,7 +91,7 @@ def _redact_body_preview(body_preview: str) -> str:
     内容を完全にマスクし、ハッシュベースの指紋を保持して debug に利用。
 
     Args:
-        body_preview: デコード済みの response body (先頭 200バイト)
+        body_preview: _MAX_HTTP_ERROR_BODY_PREVIEW_BYTES 上限で切り詰めた response body
 
     Returns:
         リダクション済み文字列 (形式: "[redacted:SHA256_16chars]")
@@ -132,7 +132,7 @@ class AsyncGitHubClient:
     特徴:
     - Rate Limit自動対応（X-RateLimit-Remaining監視）
     - Conditional Requests対応（ETag活用）
-    - リトライロジック（5xxエラーのみ、指数バックオフ+ジッター）
+    - リトライロジック（5xx・timeout・NetworkError・RemoteProtocolError、指数バックオフ+ジッター）
     - 例外チェーン（HTTPStatusError は URL+ステータスのみ保持した cause に再ラップ）
 
     使用例:
@@ -153,7 +153,8 @@ class AsyncGitHubClient:
 
         Args:
             timeout: リクエストタイムアウト（秒）
-            max_retries: 最大試行回数（5xx・timeout・NetworkError の再試行回数、初回含む）。
+            max_retries: 最大試行回数
+                （5xx・timeout・NetworkError・RemoteProtocolError の再試行回数、初回含む）。
                 デフォルト設定(timeout=30, max_retries=3)での最悪ケース: 約96秒。
             user_agent: User-Agentヘッダー（GitHub要求事項）
 
@@ -172,7 +173,7 @@ class AsyncGitHubClient:
         *,
         event: str,
         error_context: str,
-        error: httpx.TimeoutException | httpx.NetworkError,
+        error: httpx.TimeoutException | httpx.NetworkError | httpx.RemoteProtocolError,
         endpoint: str,
         method: str,
         attempt: int,
@@ -185,7 +186,7 @@ class AsyncGitHubClient:
         Args:
             event: structlog に渡すイベント名（例: "request_timeout"）
             error_context: ログの error_context フィールド値（例: "timeout"）
-            error: キャッチした例外（TimeoutException または NetworkError）
+            error: キャッチした例外（TimeoutException、NetworkError、RemoteProtocolError）
             endpoint: リクエスト先エンドポイント（ログ用）
             method: HTTP メソッド（ログ用）
             attempt: 現在の試行インデックス（0-based）
@@ -477,9 +478,16 @@ class AsyncGitHubClient:
                 error_pos=e.pos,
                 error_lineno=e.lineno,
             )
+        except Exception as e:
+            self.logger.error(
+                "json_parse_unexpected_error",
+                endpoint=endpoint,
+                error_type=type(e).__qualname__,
+                error_module=type(e).__module__,
+            )
 
-        # JSONDecodeError.doc はレスポンスbody全体を保持する。
-        # except 内で raise すると __context__ に JSONDecodeError が残存し .doc 経由で露出するため、
+        # JSONDecodeError.doc やその他パース例外はレスポンスbody/URL等を保持しうる。
+        # except 内で raise すると __context__ に元例外が残存して露出するため、
         # active exception context の外で raise して __context__ を None に保つ。
         raise GitHubAPIError("Invalid JSON response") from None
 
@@ -557,7 +565,7 @@ class AsyncGitHubClient:
         機能:
         - Rate Limit監視（X-RateLimit-Remaining < _RATE_LIMIT_WARNING_THRESHOLD で警告ログ）
         - Conditional Requests（ETag活用、304 Not Modified対応）
-        - 5xx・timeout・NetworkError リトライ（指数バックオフ+ジッター）
+        - 5xx・timeout・NetworkError・RemoteProtocolError リトライ（指数バックオフ+ジッター）
         - 4xxエラー即失敗（NotFoundError, RateLimitError例外）
         - 例外情報の安全な保持（HTTPStatusError は URL+ステータスのみ保持した cause に再ラップ、response body 非露出）
 
@@ -574,11 +582,11 @@ class AsyncGitHubClient:
             NotFoundError: 404エラー
             RateLimitError: 403 Rate Limit超過 または 429 Too Many Requests
             GitHubServerError: 5xxエラー（リトライ上限後）
-            GitHubAPIError: タイムアウト・NetworkError は再試行後の最終失敗、
+            GitHubAPIError: タイムアウト・NetworkError・RemoteProtocolError は再試行後の最終失敗、
                 予期しないエラーは即失敗
 
         Note:
-            max_retries は 5xx エラーと timeout / NetworkError の再試行回数を制御する。
+            max_retries は 5xx エラーと timeout / NetworkError / RemoteProtocolError の再試行回数を制御する。
             unexpected エラーは再試行せず、1回目で GitHubAPIError へ変換する。
             X-RateLimit-Remaining ヘッダーが不正値の場合:
             - 監視パス: _RATE_LIMIT_FALLBACK_REMAINING（残量十分と見なし、rate_limit_low警告なし）
@@ -663,7 +671,7 @@ class AsyncGitHubClient:
                 if attempt < self.max_retries - 1:
                     continue
 
-            except httpx.NetworkError as e:
+            except (httpx.NetworkError, httpx.RemoteProtocolError) as e:
                 # PII漏洩防止: str(e)はURL/host:port等を含む可能性があるためログから除外
                 retry_error_message = f"Network error: {type(e).__qualname__}"
                 await self._log_and_sleep_for_retry(
@@ -729,7 +737,7 @@ class AsyncGitHubClient:
 
             if retry_error_message is not None:
                 # PII漏洩防止 (__context__): active exception context の外で raise して
-                # httpx.TimeoutException / httpx.NetworkError の
+                # httpx.TimeoutException / httpx.NetworkError / httpx.RemoteProtocolError の
                 # URL/host:port等を例外チェーンに残さない
                 raise GitHubAPIError(retry_error_message) from None
 
@@ -739,29 +747,4 @@ class AsyncGitHubClient:
                 raise GitHubAPIError(f"Unexpected error: {unexpected_error_type}") from None
 
         # リトライ上限到達（ここに到達することはないはずだが、型チェッカー対策）
-        raise GitHubServerError(f"Failed after {self.max_retries} attempts")
-
-
-# =============================================================================
-# 学習ポイント:
-#
-# 1. GitHub API v3の実務的活用:
-#    - Rate Limit管理: X-RateLimit-Remaining監視、警告ログ出力
-#    - Conditional Requests: ETag活用で304 Not Modified時Rate Limit消費なし
-#    - 認証拡張性: Personal Access Tokenで60 req/h → 5000 req/h拡張可能
-#
-# 2. 非同期HTTP通信の最適化:
-#    - async/awaitパターンによる非ブロッキングI/O
-#    - ETagキャッシュによるネットワーク帯域削減
-#    - 指数バックオフ+ジッターによる過負荷防止
-#
-# 3. エラーハンドリング戦略:
-#    - 階層的な例外設計（GitHubAPIError基底 + 4派生例外）
-#    - HTTPステータスコード別処理（4xx即失敗、5xxリトライ）
-#    - 例外チェーン（HTTPStatusError は URL+ステータスのみ cause に再ラップ）
-#
-# 4. ロギング・監視:
-#    - structlog構造化ロギング（JSON形式、フィールド検索可能）
-#    - Rate Limit警告（残リクエスト数が _RATE_LIMIT_WARNING_THRESHOLD 未満で通知）
-#    - リトライログ（試行回数、遅延時間、ステータスコード記録）
-# =============================================================================
+        raise GitHubServerError(f"Failed after {self.max_retries} attempts") from None


### PR DESCRIPTION
## 概要

PR#341マージ後に未収録だったRemoteProtocolError対応とリトライロジックのSRP化。squash merge後のfeatureブランチ追加コミット分のみを含むクリーンなPR（develop直接ベース）。

## 変更内容

- utils/github_client.py: httpx.RemoteProtocolErrorをリトライ対象追加・_log_retry_error()にログ処理集約
- utils/api_client.py: docstring精度向上（ホワイトスペース記述）
- tests/unit/test_github_client.py: PII非露出テスト・LocalProtocolError非リトライテスト・unexpected parse errorテスト追加
- tests/conftest.py: コメント簡潔化

## テスト

- [x] ローカルテスト完了（968 tests passed / 95.49% coverage / ruff 0 errors / mypy 0 errors）
- [ ] CI/CD パイプライン確認

## 関連Issue/PR

Refs #341 (PR)

---
このPRは /push-pr スキルで自動生成されました。

<!-- resolve-review:61b50a3 -->
## Review Response (2026-05-05)

| 分類 | 件数 | 対応 |
|------|------|------|
| AUTO-FIX | 3件 | 修正済み |
| NEEDS-DECISION | 2件 | オーナー判断待ち |
| SKIP | 1件 | pushback返信済み |

コミット: `61b50a3`
<!-- /resolve-review:61b50a3 -->
