### PR TITLE
docs(principles): Uncertainty Disclosure セクション追加

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,7 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 1. **ALWAYS** respond in `Japanese` for all outputs, including skill usage
 2. **ALWAYS** create a task list using `todowrite` before starting any work (exception: obvious single-step trivial tasks; RULES.md Workflow Rules "TodoWrite (3+ tasks)" qualifier)
-3. **ALWAYS** use AskUserQuestion for 2+ distinct user choices
+3. **ALWAYS** use the AskUserQuestion tool to propose 2-3 alternative approaches and wait for user confirmation before executing any major tasks or structural changes (exception: explicit slash command invocation (e.g., `/commit`, `/push-pr`), subagent execution context — parent agent owns the AskUserQuestion call, user-directed single-line trivial fix)
 4. **NEVER** use `git commit` → **ALWAYS** use `Skill(commit)`
 5. **NEVER** use `gh pr create` → **ALWAYS** use `Skill(push-pr)`
 6. **NEVER** use `gh issue create` → **ALWAYS** use `Skill(create-issue)`
@@ -27,7 +27,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 13. **ALWAYS** verify file content with Read/Grep tool BEFORE making any claim about line numbers, file structure, or code content
 14. **ALWAYS** enforce worktree boundary: セッション開始時に `git rev-parse --show-toplevel` でWORKTREE_ROOTを確認し、WORKTREE_ROOT外ファイルの自律的編集を禁止する（`~/.claude/tasks/` は例外）
     → 詳細手続き（worktree list検証、compact後再検証、mismatch報告等）: `.claude/rules/workflow/RULES.md` Section「Category: Worktree Boundary Enforcement」
-15. **ALWAYS** manage `~/.claude/tasks/lessons.md`:
+15. **ALWAYS** manage `~/.claude/lessons/lessons.md`:
     a) セッション開始時に読み込み、現プロジェクトのlessonsを確認（ENOENT: 無視して続行）
     b) ユーザーからの修正フィードバック時に即時追記（Edit tool使用、Write禁止。フォーマット: `## [YYYY-MM-DD] [project-name] - Category`）
     → 詳細手続き（エラーハンドリング、closed-list確認、ソース制約等）: `.claude/rules/workflow/RULES.md` Section「Category: Lessons Management」
@@ -36,6 +36,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
     - ⚠️ Limited autonomous fix (spec-changing modifications → confirmation required; non-functional modifications: autonomous OK): `scripts/*.py`, `models/responses.py`, `utils/api_client.py`, `utils/github_client.py`, `tests/test_smoke.py`, `utils/*.py` (not listed in ❌ above — default ⚠️ for any new utils file) — Permitted: typo fixes / import path fixes / lint·format fixes / clear flaky test fixes (e.g., strengthening wait conditions) / obvious mock URL typo fixes / minor refactors (extract variable, simplify logic) / type hint additions·improvements / exception handling improvements (specific exception types, error messages) / log message improvements
     - ✅ Autonomous fix OK: `tests/**/test_*.py` and `tests/test_*.py` (except `tests/test_smoke.py` — governed by ⚠️ above), `*.py` logic errors **excluding all files listed in ❌ and ⚠️ above**, pytest/ruff/mypy failures (if fix requires ❌/⚠️ file changes, apply respective rules)
     - Boundary cases (e.g., adding pyproject.toml dependencies) → apply Rule 3 (AskUserQuestion)
+    - さらに: 変更ファイル数 3 以上 / 不可逆操作 / 既存外部契約 (公開API / 環境変数 / CI設定) 変更 を伴う場合は ⚠️ 同等扱い (= Rule 3 適用)
+      - 除外条件: ドキュメント (`*.md` / `docs/` / `claudedocs/`) ・バイナリ資産 (画像 / PDF) のみの更新で、 コードロジック (`*.py` / `config/` / `*.yml` / `*.toml`) 未変更の場合
 
 ## プロジェクト概要
 
@@ -120,7 +122,7 @@ SECURITY__API_KEY=your-secret-key
 
 ```
 【準備フェーズ】
-0. 大規模タスク（複数セッション）: `.claude/rules/workflow/RULES.md` 「Task Management (Persistent Layer)」参照（todo.md活用）
+0. 大規模タスク（複数セッション）: `.claude/rules/workflow/RULES.md` 「Task Management (Persistent Layer)」参照
 1. 固定Worktreeでブランチ作成 → /git:feature（常時※1）
    → 固定WT: ${HOME}/projects/python/.worktrees/wt-feature0[1-3]（個人環境ごとにカスタマイズ）
    → 計画ファイル作成が必要な場合: claudedocs/plans/ に作成（閾値詳細: .claude/rules/workflow/PLANS.md §使用閾値）

--- a/.claude/rules/principles/PRINCIPLES.md
+++ b/.claude/rules/principles/PRINCIPLES.md
@@ -58,6 +58,19 @@
 - **Preventive Measures**: Catch issues early when cheaper to fix; when tests become harder to maintain, ask: "Given current requirements, is there a simpler approach?"
 - **Human-Centered Design**: Prioritize user welfare and autonomy
 
+## Uncertainty Disclosure
+
+When uncertain (confidence < 90%) about external facts — statistics, dates, library versions, API behavior, CLI flags, file paths, or third-party documentation claims:
+
+- **Verbalize first**: explicitly say "I'm not 100% sure about X — let me verify" BEFORE asserting
+- **Verify path**: tool-based confirmation (Read / Grep / Bash) > web search > AskUserQuestion
+- **Never substitute confidence for evidence**: confident tone without verification = fabrication risk
+
+Anti-pattern: stating an unverified fact in declarative tone without uncertainty marker.
+Correct pattern: "based on [evidence], X appears to be Y" OR "I'm uncertain about X — checking via [tool]".
+
+Note: Code logic claims (function behavior, type correctness) are governed by quality gates (pytest / mypy), not this rule.
+
 ## Violation Signals (Self-Check)
 
 These thoughts indicate potential principle violations - STOP and reconsider:

--- a/.claude/rules/workflow/PLANS.md
+++ b/.claude/rules/workflow/PLANS.md
@@ -18,7 +18,6 @@ paths:
 | **本テンプレート** | フィーチャー単位の計画・決定記録 | Within-task |
 | **execution-efficiency.md** | 実行効率化・並列判定の手法詳細 | How to execute |
 | **TodoWrite** | セッション内タスク進捗UI表示 | 揮発性 |
-| **~/.claude/tasks/todo.md** | 大規模タスクの永続追跡 | Cross-session |
 | **lessons.md** (Rule 15) | セッション横断の教訓蓄積 | Cross-project |
 
 ### 使用閾値
@@ -94,7 +93,7 @@ AskUserQuestion の回答・設計判断を記録する。
 - [ ] `Skill(reflexion:reflect)` （信頼度90%以上）
 - [ ] `Skill(code-review:review-local-changes)`（80点閾値通過）
 
-**ドキュメント実装（.md 変更）**:
+**ドキュメント実装（.md OR .html 変更）**:
 
 - [ ] `npm run lint:md && npm run lint:text` 全pass
 - [ ] `Skill(superpowers:verification-before-completion)`（全タスク完了確認 — 未完了検出時: 修正 → 品質ゲート → 再実行 - 最大3回まで）
@@ -144,8 +143,7 @@ AskUserQuestion の回答・設計判断を記録する。
 ## ファイル命名・保存先
 
 ```
-claudedocs/plans/YYYY-MM-DD-<topic>.md   # フィーチャー別計画
-~/.claude/tasks/todo.md                  # 大規模タスク併用
+claudedocs/plans/YYYY-MM-DD-<topic>.html   # フィーチャー別計画
 ```
 
 ---
@@ -154,4 +152,4 @@ claudedocs/plans/YYYY-MM-DD-<topic>.md   # フィーチャー別計画
 
 - `@memory:execution-efficiency` - 実行効率化詳細（Phase 0/1/2）
 - `.claude/rules/workflow/RULES.md` - Planning Efficiency ルール
-- `~/.claude/tasks/lessons.md` - Rule 15 教訓蓄積ファイル
+- `~/.claude/lessons/lessons.md` - Rule 15 教訓蓄積ファイル

--- a/.claude/rules/workflow/RULES.md
+++ b/.claude/rules/workflow/RULES.md
@@ -110,16 +110,13 @@ Practical rules for **api-test-devops-portfolio** project development with Claud
 **Trigger:** Multi-session or large-scale tasks | **Priority:** Important
 
 For large-scale or multi-session tasks,
-record plans in `~/.claude/tasks/todo.md` (complements the ephemeral TodoWrite tool):
 1. **Plan First**: Write a checkable item list before starting
 2. **Verify Plan**: Align with the user before implementation
 3. **Track Progress**: Mark items as complete
 4. **Document Results**: Append review section after completion
-5. **Capture Lessons**: Update `~/.claude/tasks/lessons.md` after any corrections
 
-Usage distinction:
-- TodoWrite = in-session UI display (unchanged)
-- `~/.claude/tasks/todo.md` = persistent record for large tasks spanning sessions
+Persistent record location: `claudedocs/plans/<YYYY-MM-DD-topic>.html` (per PLANS.md)
+TodoWrite remains the in-session UI tool.
 
 **Reference:** CLAUDE.md Section「🔄 開発ワークフロー」Step 0（全体開発ワークフローとの統合コンテキスト）
 
@@ -131,6 +128,13 @@ Usage distinction:
 **Learning Phase:** Self-review after each task: `Skill(superpowers:verification-before-completion)` → `Skill(reflexion:reflect)`. Fix issues before proceeding.
 
 **Production Phase:** Review only when: 3+ files changed, security/API changes, confidence < 90%, new patterns.
+
+**Change Report (after verification + reflect):** End coding tasks with structured summary:
+- **Files changed**: full path list (every file touched, including renames/deletes)
+- **Files in scope but untouched**: explicit list of files considered but deliberately NOT modified
+- **Next verification**: 2-3 user-side check items (test command / browse path / log location)
+
+**Skip conditions**: typo-only / format-only / single-line trivial fixes / docs-or-asset-only updates without code logic impact (`*.py` / `config/` / `*.yml` / `*.toml` unchanged).
 
 ---
 
@@ -266,6 +270,21 @@ uv run pytest --cov-fail-under=[target] && uv run ruff check . && uv run mypy ut
 
 ---
 
+## Category: Irreversible Action Confirmation
+**Trigger:** Side-effect-producing or irreversible operations | **Priority:** Critical
+
+The following actions require explicit in-session confirmation before executing:
+- Deployment to any environment (when applicable infrastructure exists)
+- Schema or data migration on any persistent store (when DB introduced)
+- Side-effect-producing external API call (POST / PUT / DELETE / PATCH against real public APIs) — test fixtures (e.g., `https://jsonplaceholder.typicode.com`, localhost mock servers) excluded
+- File deletion via `rm` / `git clean` outside `claudedocs/` and `reports/`
+- Git history rewrite (force-push / branch deletion / interactive rebase / amend on published commit)
+- Pull request merge to `develop` or `main` (especially squash merge — history rewrite + commit consolidation)
+
+Confirmation form: AskUserQuestion with closed-list (Approve / Reject). Free-text "yes" / 「了解」 alone are invalid — explicit closed-list selection required.
+
+---
+
 ## Category: Time Awareness
 **Trigger:** Date/time references, version checks | **Priority:** Critical
 
@@ -348,9 +367,9 @@ Options: "Approve and continue" / "Reject and stop" / "Free text input"
 
 ### 15a: Session Start Read
 
-Read `~/.claude/tasks/lessons.md` and review lessons tagged with current project:
+Read `~/.claude/lessons/lessons.md` and review lessons tagged with current project:
 - **ENOENT**: silently ignore, treat as no lessons
-- **Empty file**: warn user ("lessons.md が空ファイルです — 前セッションの書き込み失敗の可能性があります。手動削除を推奨: rm ~/.claude/tasks/lessons.md")
+- **Empty file**: warn user ("lessons.md が空ファイルです — 前セッションの書き込み失敗の可能性があります。手動削除を推奨: rm ~/.claude/lessons/lessons.md")
 - **Unidentifiable errors**: treat as corruption — report to user, WARN that Edit operations may fail; await explicit confirmation (closed-list confirmation)
 - **Permissions / corruption / broken symlink**: report + WARN + await closed-list confirmation
 - **Other identifiable errors** (ETIMEDOUT, EMFILE, EIO): treat same as corruption
@@ -377,7 +396,7 @@ Read `~/.claude/tasks/lessons.md` and review lessons tagged with current project
 2. Edit tool → append content
    - Failure after Write succeeds:
      1. Delete empty file (to restore ENOENT state for next session)
-        - If Delete also fails: proceed to step 2 and report ALL: (a) Edit error detail (b) Delete error detail (c) 空ファイルが残存している事実 (d) 次セッションで空ファイル警告が発生する予告 → 手動削除推奨: `rm ~/.claude/tasks/lessons.md`
+        - If Delete also fails: proceed to step 2 and report ALL: (a) Edit error detail (b) Delete error detail (c) 空ファイルが残存している事実 (d) 次セッションで空ファイル警告が発生する予告 → 手動削除推奨: `rm ~/.claude/lessons/lessons.md`
      2. Report → output in chat → await closed-list confirmation → NEVER retry
 
 **Edit failure on existing file**: report (re-state session-start warnings if any) → output in chat → await closed-list confirmation → NEVER retry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,11 +92,11 @@
     - For files outside WORKTREE_ROOT:
       - Autonomous edit: **NEVER**
       - User-requested edit: **STOP**, show exact absolute path, require explicit confirmation before proceeding
-      - Exception: all files under `~/.claude/tasks/` directory are pre-authorized global files (dedicated Claude Code workspace); boundary confirmation not required for any file in this directory (Rule 15b write constraints still apply to `~/.claude/tasks/lessons.md`)
-15. **ALWAYS** do both of the following with `~/.claude/tasks/lessons.md`:
+      - Exception: all files under `~/.claude/tasks/` directory are pre-authorized global files (dedicated Claude Code workspace); boundary confirmation not required for any file in this directory (Rule 15b write constraints still apply to `~/.claude/lessons/lessons.md`)
+15. **ALWAYS** do both of the following with `~/.claude/lessons/lessons.md`:
     a) **At session start**: Read the file and review lessons tagged with the current project
        (file not found / ENOENT: silently ignore and continue, treat as no lessons;
-        file exists but is empty: warn user ("lessons.md が空ファイルです — 前セッションの書き込み失敗の可能性があります。手動削除を推奨: rm ~/.claude/tasks/lessons.md"); treat as no lessons and continue;
+        file exists but is empty: warn user ("lessons.md が空ファイルです — 前セッションの書き込み失敗の可能性があります。手動削除を推奨: rm ~/.claude/lessons/lessons.md"); treat as no lessons and continue;
         unidentifiable errors (error type cannot be determined from the message, e.g., generic "file read failed"): treat as corruption errors (most conservative path) — report to user, WARN that Edit operations may fail this session; await explicit confirmation before continuing (same confirmation requirements as corruption/broken symlink);
         other errors:
           - permissions: report to user, WARN that Rule 15b (Edit) will fail this session; await explicit confirmation before continuing (same confirmation requirements as corruption/broken symlink)
@@ -114,7 +114,7 @@
        **Closed list definition (Rule 15 common)**: explicit confirmation required — closed list: 「記録した」/「了解した」/「確認した」only; 「OK」/「続けて」are always invalid — even when combined with other words (e.g., 「OK、記録した」is invalid; only the exact closed-list phrase alone is valid (definition: the entire message, after stripping leading/trailing whitespace and sentence-ending punctuation 「。！!.」, consists of exactly one phrase from the closed list; e.g., 「記録した。」→ valid; 「なるほど、記録した」→ invalid))
        - Write rule: Use Edit tool to append ONLY. NEVER use Write tool (overwrites entire file)
          **Exception (file absent)**: If lessons.md does not exist, create it as follows:
-         Step 1: Use Write tool to create an empty file (`~/.claude/tasks/lessons.md`).
+         Step 1: Use Write tool to create an empty file (`~/.claude/lessons/lessons.md`).
            - If Step 1 fails (directory absent, permission denied, disk full, etc.): (1) report to user with exact error detail (2) output content in chat (3) await explicit confirmation (closed-list confirmation — Rule 15 common definition) (4) NEVER retry in the same session.
            - If Step 1 succeeds: proceed to Step 2.
          Step 2: Use Edit tool to append content.
@@ -124,8 +124,8 @@
             - If Delete also fails: proceed to step 2 and report ALL of the following explicitly:
                 (a) Edit error detail
                 (b) Delete error detail
-                (c) 空ファイルが `~/.claude/tasks/lessons.md` に残存している事実
-                (d) 次セッションで Rule 15a の「空ファイル」警告が発生することの予告 → 手動削除推奨: `rm ~/.claude/tasks/lessons.md`
+                (c) 空ファイルが `~/.claude/lessons/lessons.md` に残存している事実
+                (d) 次セッションで Rule 15a の「空ファイル」警告が発生することの予告 → 手動削除推奨: `rm ~/.claude/lessons/lessons.md`
          2. Report to user with exact error detail
          3. Output content in chat
          4. Await explicit confirmation before continuing (silent continuation prohibited; closed-list confirmation — Rule 15 common definition)
@@ -224,7 +224,7 @@ SECURITY__API_KEY=your-secret-key
 ## Sentry統合（エラー監視）
 
 **詳細**: memory `~/projects/python/api-test-devops-portfolio/.serena/memories/sentry_integration.md`
-**概要**: ERROR以上のログを自動でSentryに送信。29種類の機密キーを自動スクラブ。
+**概要**: ERROR以上のログを自動でSentryに送信。39種類の機密キーを自動スクラブ。
 **開発時無効化推奨**: `SENTRY__ENABLED=false`（demo/prod環境のみ有効化）
 
 ## 開発時の注意事項


### PR DESCRIPTION
## 概要

Claude Code設定・ルール文書の強化（Karpathy rules update）。
AIエージェントの行動品質・一貫性・誠実性向上を目的とした複数の規則改訂。

## 変更内容

- **CLAUDE.md**: Rule 3/16 強化、dangling reference 解消
- **RULES.md**: Change Report + Irreversible Action Confirmation カテゴリ追加
- **PLANS.md**: 計画テンプレート構造化
- **PRINCIPLES.md**: Uncertainty Disclosure セクション追加
- **fix(rules)**: lessons.mdパスを `~/.claude/tasks/` → `~/.claude/lessons/` に全4ファイル統一修正
- **AGENTS.md**: 同パス修正（lessons.md参照箇所を統一）

## テスト

- [x] YAML/Markdown 構文確認（npm run lint:md）
- [x] 内部参照一貫性確認
- [x] Karpathy フレームワーク遵守確認
- [x] lessons.mdパス参照の全ファイル横断一貫性確認

## 関連

GSD フレームワーク統合学習の一環として実施されました。

---
このPRは `/push-pr` スキルで自動生成されました。