### PR TITLE
refactor(core): レビュー対応（SSRF検証分離・コード整備）(PR#340 review)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Run mypy check
         run: uv run mypy utils/ config/ models/
 
+      - name: Run ruff check
+        run: uv run ruff check .
+
       - name: Set test markers
         id: markers
         run: |
@@ -94,7 +97,7 @@ jobs:
   # Checks: markdownlint, textlint (日本語対応)
   # ============================================================
   pr-md-quality-check:
-    name: PR Markdown Quality Check (PR Validation)
+    name: PR Markdown Quality Check
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/config/settings.py
+++ b/config/settings.py
@@ -75,41 +75,6 @@ def _get_allowed_domains() -> frozenset[str]:
 ALLOWED_DOMAINS: frozenset[str] = _get_allowed_domains()
 
 
-def _validate_base_url_with_allowed_domains(v: str, allowed_domains: frozenset[str]) -> str:
-    """許可ドメインを注入してベースURLを検証する。"""
-    if not v.startswith(("http://", "https://")):
-        raise ValueError("Base URL must start with http:// or https://")
-
-    # URLパース
-    parsed = urlparse(v)
-    hostname = parsed.hostname
-
-    if not hostname:
-        raise ValueError("Invalid URL: hostname not found")
-
-    # SSRF Prevention: プライベートIPチェック
-    if is_private_ip(hostname):
-        raise ValueError(
-            f"SSRF Prevention: Private/loopback IP addresses are not allowed: {hostname}",
-        )
-
-    # SSRF Prevention: 許可ドメインチェック
-    if hostname not in allowed_domains:
-        _logger.warning(
-            "SSRF Prevention: Domain not in allowlist: %r. Allowed domains count: %d",
-            hostname[:200],
-            len(allowed_domains),
-        )
-        raise ValueError(
-            f"SSRF Prevention: Domain not in allowlist: {hostname}. "
-            f"Allowed domains count: {len(allowed_domains)}",
-        )
-
-    if v.endswith("/"):
-        v = v.rstrip("/")
-    return v
-
-
 # 危険なプライベートIPレンジ
 PRIVATE_IP_RANGES: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (
     ipaddress.ip_network("10.0.0.0/8"),
@@ -261,6 +226,41 @@ def is_private_ip(hostname: str) -> bool:
                 resolved[:100],
             )
             return True
+
+
+def _validate_base_url_with_allowed_domains(v: str, allowed_domains: frozenset[str]) -> str:
+    """許可ドメインを注入してベースURLを検証する。"""
+    if not v.startswith(("http://", "https://")):
+        raise ValueError("Base URL must start with http:// or https://")
+
+    # URLパース
+    parsed = urlparse(v)
+    hostname = parsed.hostname
+
+    if not hostname:
+        raise ValueError("Invalid URL: hostname not found")
+
+    # SSRF Prevention: プライベートIPチェック
+    if is_private_ip(hostname):
+        raise ValueError(
+            f"SSRF Prevention: Private/loopback IP addresses are not allowed: {hostname}",
+        )
+
+    # SSRF Prevention: 許可ドメインチェック
+    if hostname not in allowed_domains:
+        _logger.warning(
+            "SSRF Prevention: Domain not in allowlist: %r. Allowed domains count: %d",
+            hostname[:200],
+            len(allowed_domains),
+        )
+        raise ValueError(
+            f"SSRF Prevention: Domain not in allowlist: {hostname}. "
+            f"Allowed domains count: {len(allowed_domains)}",
+        )
+
+    if v.endswith("/"):
+        v = v.rstrip("/")
+    return v
 
 
 # =============================================================================

--- a/config/settings.py
+++ b/config/settings.py
@@ -74,6 +74,42 @@ def _get_allowed_domains() -> frozenset[str]:
 # import 前の環境変数設定が必要。
 ALLOWED_DOMAINS: frozenset[str] = _get_allowed_domains()
 
+
+def _validate_base_url_with_allowed_domains(v: str, allowed_domains: frozenset[str]) -> str:
+    """許可ドメインを注入してベースURLを検証する。"""
+    if not v.startswith(("http://", "https://")):
+        raise ValueError("Base URL must start with http:// or https://")
+
+    # URLパース
+    parsed = urlparse(v)
+    hostname = parsed.hostname
+
+    if not hostname:
+        raise ValueError("Invalid URL: hostname not found")
+
+    # SSRF Prevention: プライベートIPチェック
+    if is_private_ip(hostname):
+        raise ValueError(
+            f"SSRF Prevention: Private/loopback IP addresses are not allowed: {hostname}",
+        )
+
+    # SSRF Prevention: 許可ドメインチェック
+    if hostname not in allowed_domains:
+        _logger.warning(
+            "SSRF Prevention: Domain not in allowlist: %r. Allowed domains count: %d",
+            hostname[:200],
+            len(allowed_domains),
+        )
+        raise ValueError(
+            f"SSRF Prevention: Domain not in allowlist: {hostname}. "
+            f"Allowed domains count: {len(allowed_domains)}",
+        )
+
+    if v.endswith("/"):
+        v = v.rstrip("/")
+    return v
+
+
 # 危険なプライベートIPレンジ
 PRIVATE_IP_RANGES: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (
     ipaddress.ip_network("10.0.0.0/8"),
@@ -102,6 +138,8 @@ def _check_ip_private(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool
     return any(ip in network for network in PRIVATE_IP_RANGES)
 
 
+# 起動時/設定検証の短期再利用を想定したプロセス内キャッシュ。
+# 長期稼働中のDNS変更追従が必要な用途ではTTL付きキャッシュへ切り替える。
 @lru_cache(maxsize=256)
 def _resolve_hostname_cached(hostname: str) -> str:
     """ホスト名をDNS解決してIPアドレス文字列を返す（成功時のみキャッシュ）
@@ -289,37 +327,7 @@ class APIConfig(BaseModel):
             - 許可されたドメインのみ許可（ALLOWED_DOMAINS）
             - AWS metadata endpoint (169.254.169.254) をブロック
         """
-        if not v.startswith(("http://", "https://")):
-            raise ValueError("Base URL must start with http:// or https://")
-
-        # URLパース
-        parsed = urlparse(v)
-        hostname = parsed.hostname
-
-        if not hostname:
-            raise ValueError("Invalid URL: hostname not found")
-
-        # SSRF Prevention: プライベートIPチェック
-        if is_private_ip(hostname):
-            raise ValueError(
-                f"SSRF Prevention: Private/loopback IP addresses are not allowed: {hostname}",
-            )
-
-        # SSRF Prevention: 許可ドメインチェック
-        if hostname not in ALLOWED_DOMAINS:
-            _logger.warning(
-                "SSRF Prevention: Domain not in allowlist: %r. Allowed domains count: %d",
-                hostname[:200],
-                len(ALLOWED_DOMAINS),
-            )
-            raise ValueError(
-                f"SSRF Prevention: Domain not in allowlist: {hostname}. "
-                f"Allowed domains count: {len(ALLOWED_DOMAINS)}",
-            )
-
-        if v.endswith("/"):
-            v = v.rstrip("/")
-        return v
+        return _validate_base_url_with_allowed_domains(v, ALLOWED_DOMAINS)
 
 
 # =============================================================================

--- a/config/settings.py
+++ b/config/settings.py
@@ -229,7 +229,11 @@ def is_private_ip(hostname: str) -> bool:
 
 
 def _validate_base_url_with_allowed_domains(v: str, allowed_domains: frozenset[str]) -> str:
-    """許可ドメインを注入してベースURLを検証する。"""
+    """base_url 検証を切り出す。
+
+    許可ドメインを注入できるようにして、Settings の全体初期化に依存しない
+    直接テストを可能にする。
+    """
     if not v.startswith(("http://", "https://")):
         raise ValueError("Base URL must start with http:// or https://")
 
@@ -258,9 +262,7 @@ def _validate_base_url_with_allowed_domains(v: str, allowed_domains: frozenset[s
             f"Allowed domains count: {len(allowed_domains)}",
         )
 
-    if v.endswith("/"):
-        v = v.rstrip("/")
-    return v
+    return v.rstrip("/")
 
 
 # =============================================================================

--- a/scripts/backup_vault.sh
+++ b/scripts/backup_vault.sh
@@ -16,6 +16,11 @@ cleanup_on_signal() {
     echo "🔄 不完全なバックアップを削除中..." >&2
     # P1-2: .tmpファイルを削除（アトミック書込み対応）
     rm -f "$BACKUP_DIR"/.vault_*.tmp 2>/dev/null || true
+    if [ -n "$CURRENT_BACKUP" ]; then
+      rm -f "$CURRENT_BACKUP" 2>/dev/null || true
+      # チェックサムファイルも削除（シグナル中断時の孤立防止）
+      rm -f "${CURRENT_BACKUP%.tar.gz}.sha256" 2>/dev/null || true
+    fi
   fi
   exit 130  # 標準SIGINT終了コード
 }

--- a/scripts/backup_vault.sh
+++ b/scripts/backup_vault.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 trap 'echo "❌ エラー発生 (line $LINENO): $BASH_COMMAND" >&2' ERR
 
 # P0-3: シグナル処理 - 中断時の不完全バックアップ削除
+# CURRENT_BACKUP="" はシグナルハンドラの [ -n "$CURRENT_BACKUP" ] ガードが
+# バックアップパス未設定時（L248到達前）に空判定となるよう意図的に空文字初期化する。
+# mv 完了前にシグナルを受信した場合、存在しないファイルへの rm -f は || true で安全に扱われる。
 BACKUP_IN_PROGRESS=false
 CURRENT_BACKUP=""
 

--- a/scripts/backup_vault.sh
+++ b/scripts/backup_vault.sh
@@ -8,7 +8,7 @@ trap 'echo "❌ エラー発生 (line $LINENO): $BASH_COMMAND" >&2' ERR
 
 # P0-3: シグナル処理 - 中断時の不完全バックアップ削除
 # CURRENT_BACKUP="" はシグナルハンドラの [ -n "$CURRENT_BACKUP" ] ガードが
-# バックアップパス未設定時（L248到達前）に空判定となるよう意図的に空文字初期化する。
+# バックアップパス未設定時に空判定となるよう意図的に空文字初期化する。
 # mv 完了前にシグナルを受信した場合、存在しないファイルへの rm -f は || true で安全に扱われる。
 BACKUP_IN_PROGRESS=false
 CURRENT_BACKUP=""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,8 +87,11 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 
     # 高速テストを先に実行
     def _sort_key(item: pytest.Item) -> tuple[bool, bool, str]:
-        marker_names = {mark.name for mark in item.iter_markers()}
-        return ("slow" in marker_names, "external" in marker_names, item.name)
+        return (
+            item.get_closest_marker("slow") is not None,
+            item.get_closest_marker("external") is not None,
+            item.name,
+        )
 
     items.sort(key=_sort_key)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,14 +84,13 @@ def pytest_configure(config: pytest.Config) -> None:
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     """テスト実行順序の最適化"""
+
     # 高速テストを先に実行
-    items.sort(
-        key=lambda item: (
-            "slow" in [mark.name for mark in item.iter_markers()],
-            "external" in [mark.name for mark in item.iter_markers()],
-            item.name,
-        ),
-    )
+    def _sort_key(item: pytest.Item) -> tuple[bool, bool, str]:
+        marker_names = {mark.name for mark in item.iter_markers()}
+        return ("slow" in marker_names, "external" in marker_names, item.name)
+
+    items.sort(key=_sort_key)
 
 
 # =============================================================================

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -5,6 +5,6 @@
 
 from typing import Final
 
-BASE_URL: str = "https://jsonplaceholder.typicode.com"
+BASE_URL: Final[str] = "https://jsonplaceholder.typicode.com"
 
 INVALID_BASE_URLS: Final[tuple[str, ...]] = ("", "   ", "\t", "\n")

--- a/tests/integration/test_sentry_logging_integration.py
+++ b/tests/integration/test_sentry_logging_integration.py
@@ -152,8 +152,7 @@ def test_logger_warning_does_not_forward_to_sentry(
     sentry_sdk.flush()
 
     assert len(captured_events) == events_before, (
-        "Sentry test client cleanup 後も新たなイベントがキャプチャされている"
-        "（クリーンアップが正しく機能していない）"
+        "WARNING ログが Sentry event として送信されている（レベルルーティングが誤っている）"
     )
 
 

--- a/tests/integration/test_sentry_logging_integration.py
+++ b/tests/integration/test_sentry_logging_integration.py
@@ -151,7 +151,10 @@ def test_logger_warning_does_not_forward_to_sentry(
     logger.warning("integration_test_warning", password="should-not-appear")  # noqa: S106
     sentry_sdk.flush()
 
-    assert len(captured_events) == events_before
+    assert len(captured_events) == events_before, (
+        "Sentry test client cleanup 後も新たなイベントがキャプチャされている"
+        "（クリーンアップが正しく機能していない）"
+    )
 
 
 def test_sentry_test_client_cleanup_disables_capture_after_fixture_use(

--- a/tests/integration/test_sentry_logging_integration.py
+++ b/tests/integration/test_sentry_logging_integration.py
@@ -141,6 +141,19 @@ def test_logger_error_forwards_to_sentry_with_pii_scrubbed(
     )
 
 
+def test_logger_warning_does_not_forward_to_sentry(
+    captured_events: list[dict[str, Any]],
+) -> None:
+    """WARNINGログはSentryへ転送されないことを保証する。"""
+    logger = get_logger(__name__)
+
+    events_before = len(captured_events)
+    logger.warning("integration_test_warning", password="should-not-appear")  # noqa: S106
+    sentry_sdk.flush()
+
+    assert len(captured_events) == events_before
+
+
 def test_sentry_test_client_cleanup_disables_capture_after_fixture_use(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_allowed_domains_logging.py
+++ b/tests/unit/test_allowed_domains_logging.py
@@ -1,8 +1,7 @@
 """config.settings._get_allowed_domains() の警告ログ契約テスト.
 
-許可リストが空 (全ドメイン拒否) になる設定ミスを起動時に検出するための
-警告ログ出力を退行から保護する。本体テスト (test_config_settings.py) とは
-独立した focused モジュールとして配置する。
+許可リストが空の場合のみ警告ログを出す契約を保護する。
+戻り値の機能検証は test_config_settings.py に集約する。
 """
 
 import logging
@@ -11,32 +10,37 @@ import pytest
 
 from config.settings import _get_allowed_domains
 
+pytestmark = pytest.mark.unit
 
-@pytest.mark.unit
+
 class TestAllowedDomainsLogging:
-    """_get_allowed_domains() の警告ログ挙動を検証する."""
+    """ALLOWED_DOMAINS の警告ログ契約テスト。"""
 
     def test_empty_env_emits_warning(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """空の ALLOWED_DOMAINS で起動時に警告ログを出す契約を保護する."""
+        """ALLOWED_DOMAINS が空文字の場合、起動時に警告ログを出す契約を保護する。"""
         monkeypatch.setenv("ALLOWED_DOMAINS", "")
-        with caplog.at_level(logging.WARNING, logger="config.settings"):
-            result = _get_allowed_domains()
 
-        assert result == frozenset()
+        with caplog.at_level(logging.WARNING, logger="config.settings"):
+            _get_allowed_domains()
+
         assert any(
             record.levelno == logging.WARNING and "全ドメインを拒否" in record.getMessage()
             for record in caplog.records
         )
 
     def test_default_emits_no_warning(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """未設定 (デフォルト許可リスト) では警告を出さない契約を保護する."""
+        """ALLOWED_DOMAINS 未設定時、デフォルト値を使い警告ログを出さない。"""
         monkeypatch.delenv("ALLOWED_DOMAINS", raising=False)
-        with caplog.at_level(logging.WARNING, logger="config.settings"):
-            result = _get_allowed_domains()
 
-        assert result
+        with caplog.at_level(logging.WARNING, logger="config.settings"):
+            _get_allowed_domains()
+
         assert not any("全ドメインを拒否" in record.getMessage() for record in caplog.records)

--- a/tests/unit/test_allowed_domains_logging.py
+++ b/tests/unit/test_allowed_domains_logging.py
@@ -1,7 +1,7 @@
 """config.settings._get_allowed_domains() の警告ログ契約テスト.
 
 許可リストが空の場合のみ警告ログを出す契約を保護する。
-戻り値の機能検証は test_config_settings.py に集約する。
+戻り値の機能検証は test_config_settings.py (TestAllowedDomainsEnvOverride) に集約する。
 """
 
 import logging

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -50,6 +50,14 @@ class TestAPIConfigBaseUrlDependencyInjection:
                 frozenset({"example.com"}),
             )
 
+    def test_validate_base_url_rejects_missing_hostname(self) -> None:
+        """hostname が取れない URL は拒否される。"""
+        with pytest.raises(ValueError, match="Invalid URL: hostname not found"):
+            _validate_base_url_with_allowed_domains(
+                "https://",
+                frozenset({"example.com"}),
+            )
+
     def test_validate_base_url_blocks_private_ip_regardless_of_allowlist(self) -> None:
         """プライベートIPは許可リストに含まれていてもブロックされる。
 

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -17,6 +17,7 @@ from config.settings import (
     Settings,
     _resolve_hostname,
     _resolve_hostname_cached,
+    _validate_base_url_with_allowed_domains,
     get_settings,
     is_private_ip,
     reload_settings,
@@ -27,6 +28,27 @@ from config.settings import (
 
 # Module-level marker: All tests in this file are unit tests
 pytestmark = pytest.mark.unit
+
+
+class TestAPIConfigBaseUrlDependencyInjection:
+    """base_url検証の許可ドメイン注入テスト。"""
+
+    def test_validate_base_url_accepts_injected_allowed_domain(self) -> None:
+        """ALLOWED_DOMAINSのモンキーパッチなしで許可ドメインを注入できる。"""
+        result = _validate_base_url_with_allowed_domains(
+            "https://example.com/",
+            frozenset({"example.com"}),
+        )
+
+        assert result == "https://example.com"
+
+    def test_validate_base_url_rejects_domain_missing_from_injected_allowlist(self) -> None:
+        """注入された許可リスト外のドメインは拒否される。"""
+        with pytest.raises(ValueError, match="Domain not in allowlist"):
+            _validate_base_url_with_allowed_domains(
+                "https://httpbin.org",
+                frozenset({"example.com"}),
+            )
 
 
 class TestAPIConfigBoundaryValues:

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -50,6 +50,19 @@ class TestAPIConfigBaseUrlDependencyInjection:
                 frozenset({"example.com"}),
             )
 
+    def test_validate_base_url_blocks_private_ip_regardless_of_allowlist(self) -> None:
+        """プライベートIPは許可リストに含まれていてもブロックされる。
+
+        SSRF Prevention: DIパスの契約テスト。
+        許可リストにプライベートIPが含まれていても、
+        is_private_ip()による先行チェックでブロックされることを検証する。
+        """
+        with pytest.raises(ValueError, match="Private/loopback IP addresses are not allowed"):
+            _validate_base_url_with_allowed_domains(
+                "http://192.168.1.1",
+                frozenset({"192.168.1.1"}),  # 許可リストに入れても無効
+            )
+
 
 class TestAPIConfigBoundaryValues:
     """APIConfig数値フィールドの境界値テスト（P1-Critical）

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -7,7 +7,7 @@ import yaml
 
 # Module-level marker: All tests in this file are unit tests
 # 外部プロセス(Docker)を起動せずYAML構造のみを検証するため
-# pyproject.toml marker定義「integration: external dependencies」に整合)
+# pyproject.toml marker定義: unitに整合)
 pytestmark = pytest.mark.unit
 
 

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -5,10 +5,10 @@ from typing import Any
 import pytest
 import yaml
 
-# Module-level marker: All tests in this file are integration tests
-# (docker-compose.yml をファイルシステムから読み込むため
+# Module-level marker: All tests in this file are unit tests
+# 外部プロセス(Docker)を起動せずYAML構造のみを検証するため
 # pyproject.toml marker定義「integration: external dependencies」に整合)
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.unit
 
 
 class TestDockerComposeContract:

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -7,7 +7,7 @@ import yaml
 
 # Module-level marker: All tests in this file are unit tests
 # 外部プロセス(Docker)を起動せずYAML構造のみを検証するため
-# pyproject.toml marker定義: unitに整合)
+# pyproject.toml marker定義 「unit」 に整合
 pytestmark = pytest.mark.unit
 
 

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -6,7 +6,7 @@ import random
 import sys
 import time
 from types import TracebackType
-from typing import Any, Self
+from typing import Any, Final, Self
 
 import httpx
 from structlog.typing import FilteringBoundLogger
@@ -1208,7 +1208,7 @@ class AsyncAPIClient:
 
 
 # 一括作成の部分失敗ログで記録する詳細の上限件数
-_MAX_LOGGED_FAILURE_DETAILS: int = 5
+_MAX_LOGGED_FAILURE_DETAILS: Final[int] = 5
 
 
 class AsyncJSONPlaceholderClient(AsyncAPIClient):
@@ -1333,7 +1333,7 @@ class AsyncJSONPlaceholderClient(AsyncAPIClient):
         """複数ユーザーの非同期一括作成
 
         個別失敗を許容し、成功したユーザーのみ返却。
-        失敗時はwarningログを出力（件数上限付きで詳細を記録）。
+        失敗時はwarningログを出力（詳細は _MAX_LOGGED_FAILURE_DETAILS 件まで記録）。
         K8s SIGTERM等で複数タスクが同時キャンセルされた場合はerrorログを出力後、
         CancelledError等のfatal例外を再発生させる（graceful shutdown保護）。
 

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -1207,6 +1207,10 @@ class AsyncAPIClient:
         )
 
 
+# 一括作成の部分失敗ログで記録する詳細の上限件数
+_MAX_LOGGED_FAILURE_DETAILS: int = 5
+
+
 class AsyncJSONPlaceholderClient(AsyncAPIClient):
     """JSONPlaceholder API専用非同期クライアント"""
 
@@ -1329,7 +1333,7 @@ class AsyncJSONPlaceholderClient(AsyncAPIClient):
         """複数ユーザーの非同期一括作成
 
         個別失敗を許容し、成功したユーザーのみ返却。
-        失敗時はwarningログを出力（最初の5件まで詳細表示）。
+        失敗時はwarningログを出力（件数上限付きで詳細を記録）。
         K8s SIGTERM等で複数タスクが同時キャンセルされた場合はerrorログを出力後、
         CancelledError等のfatal例外を再発生させる（graceful shutdown保護）。
 
@@ -1401,7 +1405,8 @@ class AsyncJSONPlaceholderClient(AsyncAPIClient):
                 "bulk_create_partial_failure",
                 failed_count=len(failed),
                 success_count=len(successful),
-                failed_details=failed_details[:5],  # 最初の5件の詳細
+                failed_details=failed_details[:_MAX_LOGGED_FAILURE_DETAILS],
+                details_truncated=len(failed_details) > _MAX_LOGGED_FAILURE_DETAILS,
             )
 
         return successful


### PR DESCRIPTION
## 概要
SSRF検証ロジックの分離・DI対応、テスト分類訂正、CI整備などのコード品質改善。

## 変更内容
- config/settings.py: base_url SSRF検証を _validate_base_url_with_allowed_domains() に抽出
- tests/unit/test_config_settings.py: 抽出関数のユニットテスト追加
- tests/unit/test_allowed_domains_logging.py: ログ契約テストに純化
- tests/unit/test_docker_compose_contract.py: マーカー訂正 (integration→unit)
- .github/workflows/ci.yml: CIにruffチェック工程追加
- scripts/backup_vault.sh: シグナル中断時のチェックサムクリーンアップ
- tests/integration/test_sentry_logging_integration.py: WARNING非転送テスト追加
- tests/conftest.py: ソートキーを名前付き関数に抽出
- tests/constants.py: Final型注釈追加
- utils/api_client.py: マジックナンバー5を定数化

## テスト
- [x] 1358 tests passed / 96.07% coverage
- [x] ruff: 0 errors
- [x] mypy: 0 errors

## 関連Issue/PR
Refs https://github.com/yuta158/api-test-portfolio/pull/340 (PR)