### PR TITLE
fix(docker): base digest更新でCVE-2026-45447(openssl HIGH)を解消

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@
 # 変更履歴:
 #   2026-02-17: Python 3.12→3.13 (セキュリティサポート延長)
 #   2026-03-07: Python 3.13→3.14 (プロジェクト全体統一移行 PR#228)
-FROM python:3.14-slim@sha256:c845af9399020c7e562969a13689e929074a10fd057acd1b1fad06a2fb068e97 AS base
+#   2026-06-13: digest更新 (CVE-2026-45447 openssl-provider-legacy HIGH / 修正版 3.5.6-1~deb13u2 取込)
+FROM python:3.14-slim@sha256:d7a925f9eb9639a93e455b9f12c167569358818c0f62b51b88edbc8fcf34c421 AS base
 
 WORKDIR /app
 


### PR DESCRIPTION
## 概要
CI「Post Trivy Scan」のimage scanが `CVE-2026-45447`(openssl-provider-legacy, HIGH)を検出し exit 1 で失敗していた問題の修正。即時策（base digest bump）のみを単独PRとして実施。

## 根本原因
- Debianが修正版 `openssl 3.5.6-1~deb13u2` を公開 → Trivy脆弱性DB更新で当該CVEが fixed 状態へ遷移。
- `ignore-unfixed: true` は fixed 状態のCVEを除外しないため顕在化。
- ベースイメージが digest 固定（旧 `deb13u1`）で修正版を取り込めていなかった。
- ※ PRの変更内容とは無関係な環境起因（Trivy DB更新タイミング）の時限失敗。

## 変更内容
- `Dockerfile`: base image digest を `c845af93…` → `d7a925f9…`（openssl `3.5.6-1~deb13u2` 同梱）へ更新（1行 + 履歴コメント）。

## テスト
- [x] ローカル trivy `--severity CRITICAL,HIGH --ignore-unfixed` で CRITICAL/HIGH **0件** を確認
- [x] 新base image に openssl `3.5.6-1~deb13u2` 同梱を `dpkg -l` で確認
- [ ] CI/CD パイプライン（Post Trivy Scan）確認

## 恒久策（本PR対象外・別途検討）
- Dependabot(docker, weekly) による digest 自動更新の有効化 → digest固定の蓄積脆弱性による時限失敗の再発防止。
- `.trivyignore` の CVE-2026-0861(glibc) コメント陳腐化（trixie は deb13u2/u3 で fixed）の見直し。

---
このPRは /push-pr スキルで自動生成されました。