### PR TITLE
ci(coderabbit): CodeRabbitのauto_review対象ブランチを追加

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,6 +12,9 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    base_branches:
+      - "develop"
+      - "main"
   tools:
     github-checks:
       enabled: true


### PR DESCRIPTION
## 概要
CodeRabbitの自動レビューがdevelopブランチとmainブランチ両方のPRで動作するように設定。

## 変更内容
- .coderabbit.yaml: base_branchesにdevelopとmainを追加

## テスト
- [x] ローカルテスト完了 (1371 passed, 96.15% coverage)
- [x] CI/CD パイプライン確認

## 関連Issue/PR
なし

---
このPRは /push-pr スキルで自動生成されました。