### PR TITLE
docs(docs): Sentry機密キー数を39から44に修正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,7 +224,7 @@ SECURITY__API_KEY=your-secret-key
 ## Sentry統合（エラー監視）
 
 **詳細**: memory `~/projects/python/api-test-devops-portfolio/.serena/memories/sentry_integration.md`
-**概要**: ERROR以上のログを自動でSentryに送信。39種類の機密キーを自動スクラブ。
+**概要**: ERROR以上のログを自動でSentryに送信。44種類の機密キーを自動スクラブ。
 **開発時無効化推奨**: `SENTRY__ENABLED=false`（demo/prod環境のみ有効化）
 
 ## 開発時の注意事項


### PR DESCRIPTION
## 概要
Sentry統合の機密キー自動スクラブ数をドキュメントで修正（39→44種類）。

## 変更内容
- AGENTS.md: SENTRY_INTEGRATION.mdメモリの実装（44種類）と合わせてドキュメントの数を修正

## テスト
- [x] ローカルテスト完了（pytest 1371 passed, ruff 0 errors, mypy 0 errors）
- [ ] CI/CD パイプライン確認

## 関連Issue/PR
なし

---
このPRは /push-pr スキルで自動生成されました。