### PR TITLE
docs(readme): カバレッジバッジを動的SVGに変更、GHCRバッジ追加 (#413)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@
 SSRFやPII漏洩、不安定なリトライといった連携特有のアンチパターンを排除し、1,300件超の自動テストを品質ゲートとして構築・運用しています。
 
 [![CI/CD Pipeline](https://github.com/yaoki-dev/api-test-devops-portfolio/actions/workflows/ci.yml/badge.svg)](https://github.com/yaoki-dev/api-test-devops-portfolio/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/badge/coverage-96.15%25-brightgreen)](https://yaoki-dev.github.io/api-test-devops-portfolio/htmlcov/)
+[![Coverage](https://yaoki-dev.github.io/api-test-devops-portfolio/coverage.svg)](https://yaoki-dev.github.io/api-test-devops-portfolio/htmlcov/)
 [![Python](https://img.shields.io/badge/Python-3.14-blue)](https://www.python.org/)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 [![Type checked: mypy](https://img.shields.io/badge/type%20checked-mypy-blue.svg)](https://mypy-lang.org/)
 [![Docker](https://img.shields.io/badge/docker-multi--stage-blue)](./Dockerfile)
+[![GHCR](https://img.shields.io/static/v1?label=ghcr.io&message=api-test-devops-portfolio&color=blue&logo=docker)](https://github.com/yaoki-dev/api-test-devops-portfolio/pkgs/container/api-test-devops-portfolio)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 
  **CI/CD / Python / Docker** を統合したAPIテスト自動化ポートフォリオ。
- **1,372**件のテスト（CI品質ゲート: **1,358件/96.15%**）
+ **1,372**件のテスト（CI品質ゲート: **1,358件/96.16%**）
 
 ## Demo
 


### PR DESCRIPTION
## 概要
README.md のカバレッジバッジを GitHub Pages の動的 SVG に変更し、GHCR パッケージバッジを追加しました。

## 変更内容
- README.md | 5 +++--
- カバレッジバッジ: 静的URL → GitHub Pages の動的 SVG
- GHCR (GitHub Container Registry) パッケージバッジを追加
- カバレッジ数値を 96.15% → 96.16% に更新

## テスト
- [ ] ローカルテスト完了
- [ ] CI/CD パイプライン確認

## 関連Issue
Closes #413

---
このPRは /push-pr スキルで自動生成されました。