### PR TITLE
test(unit): pytest-socket で unit 層のネットワークを構造的分離

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "pytest-asyncio>=1.4.0",
     "pytest-cov>=4.1.0",
     "pytest-xdist>=3.5.0",
+    "pytest-socket>=0.8.0",     # unit層のネットワーク構造的分離
     "genbadge[coverage]==1.1.3",  # Coverage badge生成（Q19 C3: uv.lock管理）
     "respx>=0.23.1",            # httpx用モックライブラリ
     "socksio>=1.0.0",           # SOCKS5 proxy support for httpx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
     "pytest-asyncio>=1.4.0",
     "pytest-cov>=4.1.0",
     "pytest-xdist>=3.5.0",
-    "pytest-socket>=0.8.0",     # unit層のネットワーク構造的分離
+    "pytest-socket>=0.8.0,<0.9",     # unit層のネットワーク構造的分離
     "genbadge[coverage]==1.1.3",  # Coverage badge生成（Q19 C3: uv.lock管理）
     "respx>=0.23.1",            # httpx用モックライブラリ
     "socksio>=1.0.0",           # SOCKS5 proxy support for httpx

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,8 +3,31 @@
 from collections.abc import Generator
 
 import pytest
+from pytest_socket import disable_socket, enable_socket
 
 from utils.sentry_init import _is_sensitive_key
+
+
+@pytest.fixture(autouse=True)
+def block_network_socket() -> Generator[None]:
+    """unit テスト実行中のみ実 TCP/UDP socket 使用を構造的に遮断する
+
+    実 DNS 解決すり抜けを、テスト実装者の注意ではなく
+    socket レベルの失敗 (SocketBlockedError) で再発防止する。
+
+    - 適用範囲は tests/unit/ 配下のみ (conftest 限定)。integration / external /
+      performance の実ネットワーク方針には影響しない。
+    - allow_unix_socket=True: pytest-xdist の並列ワーカー間通信や asyncio
+      イベントループが Unix domain socket を使うため許可する。
+    - function スコープで disable→enable を都度トグルし、グローバル socket
+      パッチが unit 層の外へ漏れないようにする。
+
+    NOTE: socket.gethostbyname() による DNS 解決は pytest-socket で遮断されない（Cレベル呼び出しのため）。
+    DNS 決定論化が必要なテストは file-local fixture で socket.gethostbyname seam を patch すること
+    """  # noqa: E501
+    disable_socket(allow_unix_socket=True)
+    yield
+    enable_socket()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -21,9 +21,15 @@ def block_network_socket() -> Generator[None]:
       イベントループが Unix domain socket を使うため許可する。
     - function スコープで disable→enable を都度トグルし、グローバル socket
       パッチが unit 層の外へ漏れないようにする。
+    - pytest-socket v0.8.0でgethostbynameが遮断される
+    - pytest fixture 解決順序の制約: session または module スコープのfixture は、 function スコープの本 fixture より先に解決されるため、
+      それらの setup 中に発生した socket 操作は遮断されない。
+      現在の tests/unit/ 配下に該当 fixture は存在しないが、将来追加時の注意点として明記する。
 
-    NOTE: socket.gethostbyname() による DNS 解決は pytest-socket で遮断されない（Cレベル呼び出しのため）。
-    DNS 決定論化が必要なテストは file-local fixture で socket.gethostbyname seam を patch すること
+    # NOTE: pytest-socket v0.8.0 は socket.gethostbyname() も SocketBlockedError で遮断する。
+    # SSRF validator のように DNS 解決結果を制御する必要があるテストでは、
+    # deterministic_ssrf_validator_dns fixture が socket.gethostbyname を fake に差し替え、
+    # テスト実行中のみ決定論的な DNS 解決結果（localhost→127.0.0.1, その他→1.2.3.4）を提供する。
     """  # noqa: E501
     disable_socket(allow_unix_socket=True)
     yield

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -30,6 +30,38 @@ from config.settings import (
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture(autouse=True)
+def deterministic_ssrf_validator_dns(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """SSRF validator 専用の DNS 決定論化
+
+    NOTE: これは unit 全域の DNS stub ではなく、本ファイルの SSRF validator
+    テスト専用の決定論化である。tests/unit/conftest.py の socket blocker により
+    実 socket.gethostbyname が SocketBlockedError になるため、SSRF validator が
+    本番コードで呼ぶ DNS 解決を固定 IP に差し替える。is_private_ip 等の判定
+    ロジック自体は実コードのまま検証される（DNS 解決結果のみ決定論化）。
+
+    設計:
+        - fake map で `localhost -> 127.0.0.1` を返し、private/loopback 判定を維持。
+          未登録ホスト名は public IP `1.2.3.4` を返し、ドメイン allowlist 判定を検証。
+          固定値 1 つだけでは localhost の private 判定が壊れるため fake map にする。
+        - patch 対象は `socket.gethostbyname` seam（既存の個別 monkeypatch と同層）。
+          `_resolve_hostname_cached` は patch せず実コードのまま動かす。
+        - lru_cache 汚染防止のため patch 前と teardown 後に cache_clear する。
+        - 個別テストが `socket.gethostbyname` を再 monkeypatch する場合、pytest の
+          後勝ち規則によりテスト側が優先される（衝突しない）。
+    """
+    fake_dns = {"localhost": "127.0.0.1"}
+
+    def fake_gethostbyname(hostname: str) -> str:
+        # public dummy IP for SSRF allowlist/IP判定テスト
+        return fake_dns.get(hostname, "1.2.3.4")
+
+    _resolve_hostname_cached.cache_clear()
+    monkeypatch.setattr(socket, "gethostbyname", fake_gethostbyname)
+    yield
+    _resolve_hostname_cached.cache_clear()
+
+
 class TestAPIConfigBaseUrlDependencyInjection:
     """base_url検証の許可ドメイン注入テスト。"""
 

--- a/tests/unit/test_network_isolation_guard.py
+++ b/tests/unit/test_network_isolation_guard.py
@@ -1,0 +1,32 @@
+"""unit 層ネットワーク分離ガードテスト
+
+tests/unit/conftest.py の `block_network_socket` fixture が満たすべき契約を
+最小固定する。pytest-socket 自体の網羅テストは目的ではなく、本プロジェクトの
+「実 TCP は遮断・Unix socket は許可」という 2 点の契約のみを退行防止する。
+"""
+
+import socket
+
+import pytest
+from pytest_socket import SocketBlockedError
+
+pytestmark = pytest.mark.unit
+
+
+def test_real_tcp_socket_is_blocked() -> None:
+    """実 TCP socket の生成は SocketBlockedError で構造的に遮断される。"""
+    with pytest.raises(SocketBlockedError):
+        socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+
+def test_unix_socket_is_allowed() -> None:
+    """Unix domain socket は allow_unix_socket=True により許可される。
+
+    pytest-xdist の並列ワーカー間通信や asyncio イベントループが
+    Unix socket を使うため、これを遮断するとテストランナー自体が壊れる。
+    """
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        assert sock.family == socket.AF_UNIX
+    finally:
+        sock.close()

--- a/uv.lock
+++ b/uv.lock
@@ -83,7 +83,7 @@ dev = [
     { name = "pytest", specifier = ">=9.1.0" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
-    { name = "pytest-socket", specifier = ">=0.8.0" },
+    { name = "pytest-socket", specifier = ">=0.8.0,<0.9" },
     { name = "pytest-xdist", specifier = ">=3.5.0" },
     { name = "respx", specifier = ">=0.23.1" },
     { name = "ruff", specifier = ">=0.15.17,<0.16" },

--- a/uv.lock
+++ b/uv.lock
@@ -55,6 +55,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-socket" },
     { name = "pytest-xdist" },
     { name = "respx" },
     { name = "ruff" },
@@ -82,6 +83,7 @@ dev = [
     { name = "pytest", specifier = ">=9.1.0" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
+    { name = "pytest-socket", specifier = ">=0.8.0" },
     { name = "pytest-xdist", specifier = ">=3.5.0" },
     { name = "respx", specifier = ">=0.23.1" },
     { name = "ruff", specifier = ">=0.15.17,<0.16" },
@@ -944,6 +946,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-socket"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/3c/f9b58e57830e58980dbe8867d0e348f45701d3f3ea065672d448f4366da5/pytest_socket-0.8.0.tar.gz", hash = "sha256:af9bb5f487da72be63573a6194cfac033b6c7a1c1561e150521105970f9e99f2", size = 13912, upload-time = "2026-05-21T16:50:22.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/e8/4a8568580bae3dcd678599ed8e86a82d505a44df71c1ced4246c1aa14b4b/pytest_socket-0.8.0-py3-none-any.whl", hash = "sha256:81821ba59f07d7600fe2b551d8714f40b068bd46e8b6704c48664e9d60cdacb8", size = 8414, upload-time = "2026-05-21T16:50:21.022Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要
pytest-socket を導入し、unit テスト層で実ネットワークアクセスを構造的に遮断する。従来の環境変数フラグによる分離から、pytest fixture機構による宣言的・強制的な分離へ移行する。

## 変更内容
- `pyproject.toml`: pytest-socket>=0.8.0 を dev dependencies に追加
- `tests/unit/conftest.py`: `block_network_socket` autouse fixture 追加 — unit テスト中の実 TCP/UDP socket を `SocketBlockedError` で遮断 (`allow_unix_socket=True` で pytest-xdist 互換)
- `tests/unit/test_config_settings.py`: SSRF validator 向け DNS 決定論化 fixture を追加
- `tests/unit/test_network_isolation_guard.py`: 遮断契約を検証する退行防止テストを追加

## テスト
- [x] ローカルテスト完了 (pytest 1374 passed, coverage 96.16%)
- [x] mypy 型チェック通過
- [x] ruff リンター通過 (staged code clean)

## 関連Issue
Closes #408

---
このPRは `/push-pr` スキルで自動生成されました。