### PR TITLE
feat(ci): GHCRマルチアーキテクチャ公開と検証を実装

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 
 # Python関連（50MB削減）
 **/__pycache__/
+**/.mypy_cache/
 *.py[cod]
 *$py.class
 *.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,6 +519,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up QEMU (multi-arch emulation)
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
@@ -545,6 +548,9 @@ jobs:
         with:
           context: .
           target: runtime
+          # マルチアーキ publish: amd64(ネイティブ) + arm64(QEMUエミュレーション)。
+          # Apple Silicon 等 arm64 ホストでもネイティブ pull/run 可能にする。
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -567,16 +573,50 @@ jobs:
       # 匿名 public pull で検証するため packages: read / login は不要。
       # GITHUB_TOKEN を使わず利用者と同じ匿名取得経路で「公開されている」ことを証明する。
     steps:
-      - name: Pull and run published image (smoke, anonymous)
+      # arm64 変種をエミュレーション実行するため QEMU binfmt を登録する。
+      - name: Set up QEMU (arm64 emulated smoke)
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      # publish が「マルチアーキ manifest list」として両プラットフォームを含むことを構造検証。
+      # (単一の green バッジが部分ビルドを隠す anti-pattern を防ぐ)
+      - name: Verify multi-arch manifest (amd64 + arm64 present)
         env:
           IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
           IMAGE_TAG: sha-${{ github.sha }}
         run: |
           set -euo pipefail
           IMAGE="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
-          docker pull "$IMAGE"
-          docker run --rm "$IMAGE" \
-            python -c "from config.settings import settings; assert settings.environment; print('SMOKE_OK')"
+          docker buildx imagetools inspect "$IMAGE" --raw > manifest.json
+          for arch in amd64 arm64; do
+            # .manifests[]? の "?" で単一arch(manifest list でない)時も
+            # iterate-null エラーにせず、意図した ::error:: で fail-loud させる
+            jq -e --arg a "$arch" \
+              '.manifests[]? | select(.platform.os == "linux" and .platform.architecture == $a)' \
+              manifest.json > /dev/null \
+              || { echo "::error::multi-arch manifest missing linux/$arch"; exit 1; }
+          done
+          echo "manifest list contains linux/amd64 + linux/arm64"
+
+      - name: Pull and run published image (amd64 smoke, anonymous)
+        env:
+          IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
+          IMAGE_TAG: sha-${{ github.sha }}
+        run: |
+          set -euo pipefail
+          IMAGE="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+          docker run --rm --platform linux/amd64 "$IMAGE" \
+            python -c "from config.settings import settings; assert settings.environment; print('AMD64_SMOKE_OK')"
+
+      # arm64 変種を実際に起動して「公開したが未検証」を排除する (emulation 経由)。
+      - name: Pull and run published image (arm64 emulated smoke, anonymous)
+        env:
+          IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
+          IMAGE_TAG: sha-${{ github.sha }}
+        run: |
+          set -euo pipefail
+          IMAGE="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+          docker run --rm --platform linux/arm64 "$IMAGE" \
+            python -c "import platform; from config.settings import settings; assert settings.environment; assert platform.machine() == 'aarch64'; print('ARM64_SMOKE_OK')"
 
   compose-healthcheck:
     needs: [compose-test]
@@ -716,10 +756,10 @@ jobs:
       # mypyをvalidationジョブ内ステップとして統合
       # 設計決定: runner起動コスト~60秒削減 > 並列フィードバック喪失
       # 根拠: mypy失敗頻度低
-      - name: Run mypy check (Post Validation)
+      - name: Run mypy check
         run: uv run mypy utils/ config/ models/
 
-      - name: Run smoke tests (Post Validation)
+      - name: Run smoke tests
         id: smoke-tests
         run: |
           uv run pytest -m "smoke and not external" -v --tb=short --no-cov
@@ -754,13 +794,13 @@ jobs:
       security-events: write
 
     steps:
-      - name: Checkout code (Post Trivy Scan)
+      - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       # ===== Stage 1: Filesystem Scan (dependencies) =====
-      - name: Trivy filesystem scan (dependencies) (Post Trivy Scan)
+      - name: Trivy filesystem scan (dependencies)
         id: fs-scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         env:
@@ -777,7 +817,7 @@ jobs:
           cache: ${{ github.event_name != 'schedule' }}
         continue-on-error: true
 
-      - name: Verify filesystem scan execution (Post Trivy Scan)
+      - name: Verify filesystem scan execution
         id: verify-fs-scan
         if: always()
         uses: ./.github/actions/trivy-sarif-verify
@@ -785,14 +825,14 @@ jobs:
           sarif-file: "trivy-post-fs-scan.sarif"
           scan-type: "filesystem"
 
-      - name: Upload filesystem scan results to Security tab (Post Trivy Scan)
+      - name: Upload filesystem scan results to Security tab
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         if: always() && steps.verify-fs-scan.outcome == 'success' && steps.fs-scan.outcome != 'cancelled' && steps.fs-scan.outcome != 'skipped'
         with:
           sarif_file: "trivy-post-fs-scan.sarif"
           category: "trivy-post-fs-scan"
 
-      - name: Fail job if fs vulnerabilities found or verification failed (Post Trivy Scan)
+      - name: Fail job if fs vulnerabilities found or verification failed
         if: |
           !cancelled() && (
             steps.fs-scan.outcome == 'failure' ||
@@ -817,7 +857,7 @@ jobs:
           exit 1
 
       # ===== Stage 2: Docker Image Build =====
-      - name: Set up Docker Build (Post Trivy Scan)
+      - name: Set up Docker Build
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Set image tag
@@ -849,7 +889,7 @@ jobs:
           exit 1
 
       # ===== Stage 3: Docker Image Scan =====
-      - name: Trivy image scan (CRITICAL + HIGH) (Post Trivy Scan)
+      - name: Trivy image scan (CRITICAL + HIGH)
         id: image-scan
         if: steps.docker-build.outcome == 'success'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
@@ -866,7 +906,7 @@ jobs:
           cache: ${{ github.event_name != 'schedule' }}
         continue-on-error: true
 
-      - name: Verify image scan execution (Post Trivy Scan)
+      - name: Verify image scan execution
         id: verify-image-scan
         if: always() && steps.image-scan.outcome != 'skipped'
         uses: ./.github/actions/trivy-sarif-verify
@@ -874,7 +914,7 @@ jobs:
           sarif-file: "trivy-post-image-scan.sarif"
           scan-type: "image"
 
-      - name: Upload image scan results to Security tab (Post Trivy Scan)
+      - name: Upload image scan results to Security tab
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         if: always() && steps.verify-image-scan.outcome == 'success' && steps.image-scan.outcome != 'cancelled' && steps.image-scan.outcome != 'skipped'
         with:
@@ -883,7 +923,7 @@ jobs:
 
       # 'skipped'チェックは Docker build security gate (上記) が先に exit する shielding により
       # 通常重複だが、将来の条件分岐変更時の防御的セーフネット（pr-trivy-scan fs-scan L464と対称）
-      - name: Fail job if image vulnerabilities found or verification failed (Post Trivy Scan)
+      - name: Fail job if image vulnerabilities found or verification failed
         if: |
           !cancelled() && (
             steps.image-scan.outcome == 'failure' ||
@@ -904,7 +944,7 @@ jobs:
           exit 1
 
       # ===== Cleanup =====
-      - name: Clean up Docker image (Post Trivy Scan)
+      - name: Clean up Docker image
         if: always() && steps.docker-build.outcome != 'skipped'
         run: docker rmi ${{ steps.image-tag.outputs.tag }} || true
 
@@ -1006,21 +1046,21 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Checkout code (Weekly Link Check)
+      - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
-      - name: Setup Node.js (Weekly Link Check)
+      - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
           cache: "npm"
 
-      - name: Install dependencies (Weekly Link Check)
+      - name: Install dependencies
         run: npm ci
 
-      - name: Find Markdown files (Weekly Link Check)
+      - name: Find Markdown files
         id: find-md
         run: |
           # Find MD files, excluding ignored directories (sync with .textlintignore)
@@ -1043,7 +1083,7 @@ jobs:
           tr '\n' '\0' < md_files.txt > md_files.nul
           echo "Found $(wc -l < md_files.txt) Markdown files"
 
-      - name: Run markdown-link-check (Weekly Link Check)
+      - name: Run markdown-link-check
         run: |
           # Security: Use -print0/xargs -0 to safely handle filenames with special characters
           # Performance note: Sequential execution chosen for weekly job (batch mode would fail-fast on first error)
@@ -1062,7 +1102,7 @@ jobs:
           xargs -0 -I {} bash -c 'check_file "$@"' _ {} < md_files.nul
         continue-on-error: true
 
-      - name: Upload link check results (Weekly Link Check)
+      - name: Upload link check results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,7 +586,27 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
-          docker buildx imagetools inspect "$IMAGE" --raw > manifest.json
+          # publish 直後の GHCR は伝播遅延で一過性の 404/429/5xx を返し得る。
+          # 最初のレジストリ参照のみ指数 backoff + jitter で再試行し、伝播遅延と実体不具合を分離する。
+          # ここが通れば image は伝播済みのため、後続の amd64/arm64 pull & run は再試行不要。
+          retry_registry() {
+            local attempt=1 max_attempts=5 delay=3
+            until "$@"; do
+              if [ "$attempt" -ge "$max_attempts" ]; then
+                echo "::error::registry operation failed after ${max_attempts} attempts"
+                return 1
+              fi
+              echo "::warning::registry operation failed; retrying (${attempt}/${max_attempts})"
+              sleep $((delay + RANDOM % 3))
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+          # リダイレクトを関数内に閉じ込め、再試行時の警告出力が manifest.json を汚染しないようにする
+          inspect_manifest() {
+            docker buildx imagetools inspect "$IMAGE" --raw > manifest.json
+          }
+          retry_registry inspect_manifest
           for arch in amd64 arm64; do
             # .manifests[]? の "?" で単一arch(manifest list でない)時も
             # iterate-null エラーにせず、意図した ::error:: で fail-loud させる
@@ -1044,6 +1064,10 @@ jobs:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # checkout + artifact upload のみ。継承既定に依存せず最小権限を明示
+    # (upload-artifact は追加権限不要。他ジョブと同じ per-job 最小権限方針で統一)
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ coverage.xml
 *.cover
 coverage.json
 .pre-commit-cache/**
+**/.mypy_cache/
 
 # IDEs
 .vscode/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile - 4-stage Multi-stage builds
-# 最終更新: 2026年03月08日
-# 品質基準: イメージサイズ < 200MB, ビルド時間 < 3分
+# 最終更新: 2026年07月05日
+# Runtime image on GHCR: 48.4 MB compressed
 
 # ============================================================
 # Stage 1: Base - 共通ベースイメージ

--- a/README.md
+++ b/README.md
@@ -14,8 +14,15 @@ SSRFやPII漏洩、不安定なリトライといった連携特有のアンチ�
 [![GHCR](https://img.shields.io/static/v1?label=ghcr.io&message=api-test-devops-portfolio&color=blue&logo=docker)](https://github.com/yaoki-dev/api-test-devops-portfolio/pkgs/container/api-test-devops-portfolio)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 
- <!-- **CI/CD / Python / Docker** を統合したAPIテスト自動化ポートフォリオ。
- **1,372**件のテスト（CI品質ゲート: **1,358件/96.16%**） -->
+## 作成背景
+
+前職では、他メンバーが実装した機能をステージング環境で手動操作し、結合・システム・業務シナリオ観点で確認していました。
+その中で、実行手順の属人化、確認漏れ、リリース前の再実行コストといった課題を経験しました。
+
+このリポジトリでは、その課題を API / 結合層の品質保証に絞って設計しています。
+外部API連携で起こりやすい SSRF、PII漏洩、不安定なリトライ、Rate Limit 対応漏れなどを題材に、pytest による自動テスト、GitHub Actions の品質ゲート、Docker による再現可能な実行環境として実装しました。
+
+目的は、手動確認に依存しやすい品質保証を、再現可能・継続実行可能・レビュー可能な仕組みに置き換えることです。
 
 ## Demo
 
@@ -72,7 +79,7 @@ uv run pytest tests/unit/test_api_client.py --cov=utils --cov=config --cov=model
 
 - Docker Multi-stage builds（4段階: base/dependencies/runtime/test）
 - 非rootユーザーでのセキュアな実行
-- 本番イメージサイズ最適化（< 200MB目標）
+- 本番イメージサイズ最適化（runtime ~46 MiB pull / ~146 MiB 展開後・linux/amd64）
 
 ー see details:  [Docker Multi-Stage Runtime Strategy](docs/reference/docker.md) -->
 
@@ -105,7 +112,6 @@ uv run pytest tests/unit/test_api_client.py --cov=utils --cov=config --cov=model
 
 ### システム構成図
 
-
 ```mermaid
 graph TB
     subgraph "APIクライアント設計"
@@ -131,20 +137,24 @@ graph TB
 
 ```mermaid
 flowchart TD
-    A["<h3>Code Change</h3><u>Pull Request / Push</u>
-    <br/>"] --> B["<h3>Quality & Security Checks</h3><u>ruff / mypy / pytest / <br/>Trivy / markdownlint</u>
+    A["<h3>Code Change</h3><u>on: Pull Request / Push</u>
+    <br/>"] --> B["<h3>Quality & Security Checks</h3><u>ruff / mypy / pytest / <br/>Trivy / markdownlint / textlint</u><br/><br/>jobs:<br/> pr-validation /<br/> pr-trivy-scan /<br/> pr-md-quality-check
     <br/>"]
 
-    A --> C["<h3>Compose Test</h3><u>pytest + coverage</u>
+    A --> C["<h3>Compose Test</h3><u>pytest (unit + integration)<br/>inside test-stage image<br/>+ coverage report</u><br/><br/>job: compose-test
     <br/>"]
 
-    C --> D["<h3>Coverage Pages</h3><u>GitHub Pages</u>
+    C --> D["<h3>Deploy GitHub Pages</h3><u>coverage HTML report</u><br/><br/>job: deploy-pages
     <br/>"]
-    C --> E["<br/><h3>Container Healthcheck</h3><br/>"]
+    C --> E["<h3>Container Healthcheck</h3><u>docker compose up --wait<br/>HEALTHCHECK: config load OK<br/>→ Health.Status = healthy</u><br/><br/>job: compose-healthcheck
+    <br/>"]
 
-    E --> F["<br/><h3>GHCR Runtime Image<br/>Publish</h3><br/>"]
-    F --> G["<br/><h3>Anonymous pull &<br/> smoke-run</h3><br/>"]
-    G --> H["<br/><h3>Status Summary</h3><br/>"]
+    E --> F["<h3>GHCR Runtime Image<br/>Publish</h3><u>push runtime image<br/>tags: latest + sha</u><br/><br/>job: publish-image
+    <br/>"]
+    F --> G["<h3>Anonymous pull image &<br/>run verify</h3><u>no-auth public pull<br/>docker run → SMOKE_OK<br/>(published-image exec check)</u><br/><br/>job: verify-published-image
+    <br/>"]
+    G --> H["<h3>Status Summary</h3><u>aggregate all job results</u><br/><br/>job: status-report
+    <br/>"]
 
     D --> H
 
@@ -157,45 +167,50 @@ flowchart TD
 
 > **注記**: 現在は GitHub Pages (coverage) + GHCR (runtime image) までの **Continuous Delivery** が実装済みです。Cloud Run / ECS / K8s 等の本番ホスティングへの実デプロイ (Continuous Deployment) は未実装です。
 >
-> **正確なジョブ依存グラフ (`needs`)** は [docs/reference/ci_cd_pipeline.md](docs/reference/ci_cd_pipeline.md) を参照してください。CI 設定の唯一の真実源は [`.github/workflows/ci.yml`](.github/workflows/ci.yml) です（上図は論理フローの俯瞰で、依存は矢印で表現しています）。
+> **公開ゲート**: GHCR への publish は、runtime コンテナが healthy になり Trivy の CVE スキャン (CRITICAL/HIGH) がグリーンの場合のみ実行します。
+> 公開後は認証なしの匿名 pull でイメージを取得・起動し、利用者と同じ経路で実行可能性を smoke 検証します。
+>
+> **正確なジョブ依存グラフ (`needs`)** は [docs/reference/ci_cd_pipeline.md](docs/reference/ci_cd_pipeline.md) を参照してください。
+> CI 設定の唯一の真実源は [`.github/workflows/ci.yml`](.github/workflows/ci.yml) です（上図は論理フローの俯瞰で、主要な依存を矢印で表現しています。
+> 冗長な推移依存は省略しており、完全な依存は上記の ci.yml が真実源です）。
 
 ### テスト戦略
 
 ```mermaid
 flowchart TD
-    B["<h3>Unit Tests</h3><u>Isolated & Fast (Deterministic)<br/>{{UNIT_TESTS_COUNT}} tests<u>
+    A["<h3>Unit Tests</h3><u>Isolated & Fast (Deterministic)<br/>{{UNIT_TESTS_COUNT}} tests</u>
     <br/>"]
-    C["<h3>Integration Tests</h3><u>Actual API integration<br/>{{INTEGRATION_TESTS_COUNT}} tests</u>
+    B["<h3>Integration Tests</h3><u>Actual API integration<br/>{{INTEGRATION_TESTS_COUNT}} tests</u>
     <br/>"]
-    H["<h3>Smoke Tests</h3><u>Pull Request / Post merge</u>
-    <br/>"]
-
-    B --> D["<h3>CI Quality Gate</h3><u>unit + integration + smoke<br/>external excluded</u>
-    <br/>"]
-    C --> D
-    H --> D
-
-    E["<h3>External Tests</h3><u>Weekly / GitHub API<br/>rate-limit aware</u>
-    <br/>"]
-    G["<h3>Performance Tests</h3><u>Weekly</u>
+    G["<h3>Smoke Tests</h3><u>Pull Request / Post merge</u>
     <br/>"]
 
-    E --> F["<h3>Scheduled / Manual Checks</h3><u>non-blocking external validation</u>
+    A --> C["<h3>CI Quality Gate</h3><u>unit + integration + smoke<br/>external excluded</u>
     <br/>"]
-    G --> F
+    B --> C
+    G --> C
 
-    D --> I["<h3>Coverage</h3><u>{{COVERAGE_PERCENT}}<br/>target 85%+</u>
+    D["<h3>External Tests</h3><u>Weekly<br/>GitHub API : rate-limit aware</u>
     <br/>"]
-    F --> I
+    F["<h3>Performance Tests</h3><u>Weekly</u>
+    <br/>"]
+
+    D --> E["<h3>Scheduled Checks (Weekly)</h3><u>non-blocking external validation</u>
+    <br/>"]
+    F --> E
+
+    C --> H["<h3>Coverage</h3><u>{{COVERAGE_PERCENT}}<br/>target 85%+</u>
+    <br/>"]
+    E --> H
 
     classDef default fill:#F7F3EA,stroke:#111,stroke-width:1.5px,color:#111;
     classDef key fill:#FFFDF7,stroke:#111,stroke-width:2px,color:#111;
     classDef support fill:#EEF4FF,stroke:#111,stroke-width:1.5px,color:#111;
     classDef metric fill:#EAF7EA,stroke:#111,stroke-width:2px,color:#111;
 
-    class B,C,D,H key;
-    class E,F,G support;
-    class I metric;
+    class A,B,C,G key;
+    class D,E,F support;
+    class H metric;
 ```
 
 ### Docker multi-stage
@@ -205,19 +220,19 @@ flowchart TD
     B["<h3>base</h3><u>python:3.14-slim<br/>digest pinned</u>
     <br/>"]
 
-    B --> D["<h3>dependencies</h3><u>uv layer<br/>dependency install</u>
+    B --> D["<h3>dependencies</h3><u>base + prod deps only</u>
     <br/>"]
 
-    D --> R["<h3>runtime</h3><u>Production image<br/>COPY --from=dependencies /app/.venv<br/>non-root appuser<br/>HEALTHCHECK<br/>&lt;200MB target</u>
+    D --> R["<h3>runtime</h3><u>base + dependencies .venv<br/>non-root appuser<br/>HEALTHCHECK</u>
     <br/>"]
 
-    B --> T["<h3>test</h3><u>branches from base<br/>COPY --from=dependencies .venv<br/>cache reuse<br/>pytest / coverage</u>
+    D --> T["<h3>test</h3><u>base + dependencies .venv + dev deps<br/>pytest + coverage</u>
     <br/>"]
 
     R --> C1["<h3>docker compose</h3><u>app service<br/>target: runtime</u>
     <br/>"]
 
-    T --> C2["<h3>docker compose</h3><u>test service<br/>target: test<br/>profiles</u>
+    T --> C2["<h3>docker compose</h3><u>test service<br/>target: test profiles</u>
     <br/>"]
 
     classDef default fill:#F7F3EA,stroke:#111,stroke-width:1.5px,color:#111;
@@ -235,20 +250,20 @@ flowchart TD
 
 主要な技術選定とクライアント設計の決定根拠を文書化します（面接官向け可視化）。API特性駆動でクライアントごとに実装範囲を最適化しています。
 
-| 決定 | 選択／背景 | 根拠・トレードオフ |
+| 判断 | 採用方針 | 根拠・トレードオフ |
 |------|----------|------------------|
-| **pytest 採用** | 標準的・豊富なプラグイン・並列実行対応。unittest 互換で移行コスト低。 | 機能過多で学習曲線あり。fixture 設計に慣れが必要。 |
-| **respx でモック** | httpx ネイティブ対応・非同期対応・ルーティングベースで宣言的。requests-mock より型安全。 | httpx 依存。標準 library 非依存を優先する場合は不向き。 |
-| **Sync / Async 使い分け** | 単体CRUDは Sync 基本、並行I/Oが本質的に効く操作のみ Async（適材適所） | 認証なし・Rate Limit無のシンプルAPI（JSONPlaceholder）では単体CRUDを **Sync**（直線的・テスト簡潔）とし、**Async は並行I/Oに限定**（`get_multiple_users` = `asyncio.Semaphore` で並行数制御、`get_user_data` = `asyncio.gather` で同時取得）。GitHub API (Rate Limit + ETag) の並行 fetch でも効果大。レイテンシ支配の sequential 処理では Sync/Async 差は無視可能 = 過剰設計を避けた選択的採用。同期呼び出し側は `asyncio.run()` が必要。共通設定解決ロジックは `_resolve_client_config` / `_classify_error` で重複削減。 |
-| **Multi-stage Docker** | base/deps/runtime/test 4段階。本番 <200MB・非root・ビルドキャッシュ最適化。 | Dockerfile 複雑化。単一 stage よりビルド時間微増。 |
-| **多段階CIゲート** | PR validation → Compose test/healthcheck → CD (Pages/GHCR/Verify) → Post validation + Trivy。 | パイプライン長大化。並列化で実行時間最小化 (PR ~10分 / main push ~20分)。 |
-| **Trivy 3層検証** | PR: fs scan (develop/main)。main PR: + image scan。push: fs + image (post-trivy-scan)。 | 重複スキャンあり。キャッシュ戦略で実行時間抑制。SARIF で Security tab 統合。 |
-| **GHCR + Pages 公開** | GHCR: 匿名 pull 検証可能・OIDC 不要。Pages: カバレッジ HTML 公開・バッジ自動生成。 | GHCR は public repository 前提。Private repo は追加設定必要。 |
-| **`GitHubClient: Async特化`** | 非同期のみ | 認証 + Rate Limit (5000/h) + ETag対応のAPI特性により、並行fetch (`asyncio.gather`) と条件付きリクエスト (304 Not Modified) の恩恵が大きい。Sync caller は `asyncio.run()` で代替可。 |
-| **`SyncJSONPlaceholderClient → SyncAPIClient 継承`** | クラス継承 | LSP遵守 (HTTP動詞契約維持) + boilerplate削減。汎用HTTP層とドメインメソッドの責務分離 (SRP)。 |
-| **`GitHubClient: 独立実装`** | 継承せず | 戻り値型契約差異 (`httpx.Response` vs parsed JSON) と ETag/RateLimit/PII redaction の固有要件により、継承すると LSP違反。共通化は例外階層 (`GitHubAPIError(APIClientError)`) と utility 関数レベルに限定。 |
+| **`pytest 採用`** | 標準的・豊富なプラグイン・並列実行対応。unittest 互換で移行コスト低。 | 機能過多で学習曲線あり。fixture 設計に慣れが必要。 |
+| **`HTTPXモック: respx採用`** | httpx ネイティブ対応・非同期対応・ルーティングベースで宣言的。requests-mock より型安全。 | httpx 依存。標準 library 非依存を優先する場合は不向き。 |
+| **`Sync / Async 使い分け`** | JSONPlaceholder の単体CRUDは Sync、並行I/Oが効く処理と GitHub API は Async。（適材適所） | シンプルAPIでは Sync の方が直線的でテスト容易。GitHub は Rate Limit / ETag / 並行取得の恩恵が大きいため Async 特化。Async 導入により呼び出し側は asyncio.run() 等の境界管理が必要。 |
+| **`JSONPlaceholder: Sync基盤継承`** | JSONPlaceholder の Sync クライアントは共通 SyncAPIClient を継承し、HTTP基盤とドメイン操作を分離。 | LSP遵守 (HTTP動詞契約維持) + boilerplate削減。汎用HTTP層とドメインメソッドの責務分離 (SRP)。 |
+| **`GitHubClient: 独立実装`** | 継承せず | 戻り値型契約差異 (httpx.Response vs parsed JSON) と ETag/RateLimit/PII redaction の固有要件により、継承すると LSP違反。共通化は例外階層 (GitHubAPIError(APIClientError)) と utility 関数レベルに限定。 |
+| **`GitHubClient: Async特化`** | GitHub API は Async 専用クライアントとして実装し、Sync 版は持たない。 | 認証・Rate Limit・ETag・複数リソース取得により並行I/Oの恩恵が大きい。Sync版を持たないことで保守対象を増やさず、同期利用は呼び出し境界で明示的に扱う。 |
+| **`サニタイズの適用範囲`** | JSONPlaceholder モデルのユーザー生成テキストに防御的サニタイズ (html.escape) を実装。GitHub 側は原文保持を優先し横展開しない。 | XSS対策の基本は出力時の context-aware encoding。モデル層サニタイズは補助防御だが、html.escape は値を変換するためデータ忠実性と衝突する。GitHub は原文保持を優先。 |
+| **`Multi-stage Docker`** | base/deps/runtime/test 4段階。本番 runtime 48.4 MB（pull size）・非root・ビルドキャッシュ最適化。 | 依存解決・runtime・testを分離し、最終イメージから不要なビルド/テスト依存を除外。代償として Dockerfile は複雑化し、単一 stage より理解コストが上がる。 |
+| **`多段階CIゲート`** | PR validation → Compose test/healthcheck → CD (Pages/GHCR/Verify) → Post validation + Trivy。 | PR時は品質確認、main反映後は公開物の検証まで分離し、失敗箇所を切り分けやすくする。代償としてパイプラインは長くなるため、並列化とキャッシュで実行時間を抑制。 |
+| **`Trivy 3層検証`** | PR: fs scan (develop/main)。main PR: + image scan。push: fs + image (post-trivy-scan)。 | 重複スキャンあり。キャッシュ戦略で実行時間抑制。SARIF で Security tab 統合。 |
+| **`GHCR + Pages 公開`** | GHCR: 匿名 pull 検証可能・OIDC 不要。Pages: カバレッジ HTML 公開・バッジ自動生成。 | GHCR は public repository 前提。Private repo は追加設定必要。 |
 
-詳細な決定背景・トレードオフ分析は ADR (Architecture Decision Records) 参照: `claudedocs/adr/`（ローカル保管・バージョン管理外）
 
 ## クイックスタート
 
@@ -277,33 +292,49 @@ pip install uv
 
 </details>
 
-### セットアップ
-
-**Note**: 並列実行には **`pytest-xdist`** が必要です。非並列で実行する場合は **`-n auto`** を外してください。
+### ローカル環境セットアップ
 
 ```bash
 # 1. リポジトリクローン
 git clone https://github.com/yaoki-dev/api-test-devops-portfolio.git
 cd api-test-devops-portfolio
 
-# 2. 依存関係インストール（uv使用、約10秒）
-uv sync
+# 2. 環境変数の設定（テンプレートから作成）
+cp .env.example .env
 
-# 3. テスト実行（並列）
+# 3. 依存関係インストール（uv使用、約10秒）
+uv sync
+```
+
+### ローカルでのテスト実行
+
+```bash
+# 1. テスト実行（並列）
 uv run pytest -n auto
 
-# 4. カバレッジ付きテスト（並列）
+# 2. カバレッジ付きテスト（並列）
 uv run pytest -n auto --cov=utils --cov=config --cov=models --cov-report=term
 
-# 5. 特定マーカーのテスト実行
+# 3. 特定マーカーのテスト実行
 uv run pytest -n auto -m unit        # 単体テストのみ
 uv run pytest -n auto -m integration # 統合テストのみ
 
-# 6. 高速実行（並列、manual/external除外）
+# 4. 高速実行（並列、manual/external除外）
 uv run pytest -n auto -m "not external and not manual"  # CI/CD相当の自動実行可能テストのみ
 
-# 7. 週次手動実行（Rate Limit管理）
+# 5. 週次手動実行（Rate Limit管理）
 uv run pytest -m "manual or external"  # GitHub API統合テスト（週1回推奨、60 req/h制約）
+```
+
+### Dockerでの実行（コンテナ環境）
+不変ランタイム（`runtime` ステージ）のポータビリティと、環境変数による挙動切り替え（Twelve-Factor App準拠）をローカルで検証します。
+
+```bash
+# テスト専用プロファイルでテスト実行（testコンテナで品質検証）
+docker compose --profile test run --rm test
+
+# 共通runtime用のコンテナを起動
+docker compose up -d
 ```
 
 ## エラー監視・可観測性
@@ -367,6 +398,8 @@ if init_sentry():
 **テスト方針**: Sentry連携は `tests/unit/test_sentry_init.py` の boot-up 検証と、`tests/integration/test_sentry_logging_integration.py` の結合検証でカバーする。実 Sentry DSN への送信は外部依存・ダッシュボードノイズを招くため、capturing transport でネットワーク非依存に保つ。
 
  📚 詳細は `.serena/memories/sentry_integration.md` を参照
+
+## ドキュメント
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -137,23 +137,28 @@ graph TB
 
 ```mermaid
 flowchart TD
-    A["<h3>Code Change</h3><u>on: Pull Request / Push</u>
-    <br/>"] --> B["<h3>Quality & Security Checks</h3><u>ruff / mypy / pytest / <br/>Trivy / markdownlint / textlint</u><br/><br/>jobs:<br/> pr-validation /<br/> pr-trivy-scan /<br/> pr-md-quality-check
+    A["<h4>Code Change</h4><u>Pull Request / Push</u>
     <br/>"]
 
-    A --> C["<h3>Compose Test</h3><u>pytest (unit + integration)<br/>inside test-stage image<br/>+ coverage report</u><br/><br/>job: compose-test
+    A --> B["<h4>Quality & Security Checks</h4><u>lint / type check / tests / security scan</u>
     <br/>"]
 
-    C --> D["<h3>Deploy GitHub Pages</h3><u>coverage HTML report</u><br/><br/>job: deploy-pages
-    <br/>"]
-    C --> E["<h3>Container Healthcheck</h3><u>docker compose up --wait<br/>HEALTHCHECK: config load OK<br/>→ Health.Status = healthy</u><br/><br/>job: compose-healthcheck
+    A --> C["<h4>Compose Test</h4><u>pytest + coverage</u>
     <br/>"]
 
-    E --> F["<h3>GHCR Runtime Image<br/>Publish</h3><u>push runtime image<br/>tags: latest + sha</u><br/><br/>job: publish-image
+    C --> D["<h4>Coverage Pages</h4><u>GitHub Pages</u>
     <br/>"]
-    F --> G["<h3>Anonymous pull image &<br/>run verify</h3><u>no-auth public pull<br/>docker run → SMOKE_OK<br/>(published-image exec check)</u><br/><br/>job: verify-published-image
+
+    C --> E["<h4>Container Healthcheck</h4><u>runtime container validation</u>
     <br/>"]
-    G --> H["<h3>Status Summary</h3><u>aggregate all job results</u><br/><br/>job: status-report
+
+    E --> F["<h4>GHCR Runtime Image</h4><u>publish image</u>
+    <br/>"]
+
+    F --> G["<h4>Pull & Run Verify</h4><u>public image smoke run</u>
+    <br/>"]
+
+    G --> H["<h4>Status Summary</h4><u>all job results</u>
     <br/>"]
 
     D --> H
@@ -170,36 +175,34 @@ flowchart TD
 > **公開ゲート**: GHCR への publish は、runtime コンテナが healthy になり Trivy の CVE スキャン (CRITICAL/HIGH) がグリーンの場合のみ実行します。
 > 公開後は認証なしの匿名 pull でイメージを取得・起動し、利用者と同じ経路で実行可能性を smoke 検証します。
 >
-> **正確なジョブ依存グラフ (`needs`)** は [docs/reference/ci_cd_pipeline.md](docs/reference/ci_cd_pipeline.md) を参照してください。
-> CI 設定の唯一の真実源は [`.github/workflows/ci.yml`](.github/workflows/ci.yml) です（上図は論理フローの俯瞰で、主要な依存を矢印で表現しています。
-> 冗長な推移依存は省略しており、完全な依存は上記の ci.yml が真実源です）。
+> この図は論理概要です。正確な job 名、trigger、`needs` 依存、multi-arch検証、Trivy/SARIF詳細は [CI/CD Pipeline](docs/reference/ci_cd_pipeline.md) に記載しています。
 
 ### テスト戦略
 
 ```mermaid
 flowchart TD
-    A["<h3>Unit Tests</h3><u>Isolated & Fast (Deterministic)<br/>{{UNIT_TESTS_COUNT}} tests</u>
+    A["<h4>Unit Tests</h4><u>Isolated & Fast (Deterministic)<br/>{{UNIT_TESTS_COUNT}} tests</u>
     <br/>"]
-    B["<h3>Integration Tests</h3><u>Actual API integration<br/>{{INTEGRATION_TESTS_COUNT}} tests</u>
+    B["<h4>Integration Tests</h4><u>Actual API integration<br/>{{INTEGRATION_TESTS_COUNT}} tests</u>
     <br/>"]
-    G["<h3>Smoke Tests</h3><u>Pull Request / Post merge</u>
+    G["<h4>Smoke Tests</h4><u>Pull Request / Post merge</u>
     <br/>"]
 
-    A --> C["<h3>CI Quality Gate</h3><u>unit + integration + smoke<br/>external excluded</u>
+    A --> C["<h4>CI Quality Gate</h4><u>unit + integration + smoke<br/>external excluded</u>
     <br/>"]
     B --> C
     G --> C
 
-    D["<h3>External Tests</h3><u>Weekly<br/>GitHub API : rate-limit aware</u>
+    D["<h4>External Tests</h4><u>Weekly<br/>GitHub API : rate-limit aware</u>
     <br/>"]
-    F["<h3>Performance Tests</h3><u>Weekly</u>
+    F["<h4>Performance Tests</h4><u>Weekly</u>
     <br/>"]
 
-    D --> E["<h3>Scheduled Checks (Weekly)</h3><u>non-blocking external validation</u>
+    D --> E["<h4>Scheduled Checks (Weekly)</h4><u>non-blocking external validation</u>
     <br/>"]
     F --> E
 
-    C --> H["<h3>Coverage</h3><u>{{COVERAGE_PERCENT}}<br/>target 85%+</u>
+    C --> H["<h4>Coverage</h4><u>{{COVERAGE_PERCENT}}<br/>target 85%+</u>
     <br/>"]
     E --> H
 
@@ -217,22 +220,22 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    B["<h3>base</h3><u>python:3.14-slim<br/>digest pinned</u>
+    B["<h4>base</h4><u>python:3.14-slim<br/>digest pinned</u>
     <br/>"]
 
-    B --> D["<h3>dependencies</h3><u>base + prod deps only</u>
+    B --> D["<h4>dependencies</h4><u>base + prod deps only</u>
     <br/>"]
 
-    D --> R["<h3>runtime</h3><u>base + dependencies .venv<br/>non-root appuser<br/>HEALTHCHECK</u>
+    D --> R["<h4>runtime</h4><u>base + dependencies .venv<br/>non-root appuser<br/>HEALTHCHECK</u>
     <br/>"]
 
-    D --> T["<h3>test</h3><u>base + dependencies .venv + dev deps<br/>pytest + coverage</u>
+    D --> T["<h4>test</h4><u>base + dependencies .venv + dev deps<br/>pytest + coverage</u>
     <br/>"]
 
-    R --> C1["<h3>docker compose</h3><u>app service<br/>target: runtime</u>
+    R --> C1["<h4>docker compose</h4><u>app service<br/>target: runtime</u>
     <br/>"]
 
-    T --> C2["<h3>docker compose</h3><u>test service<br/>target: test profiles</u>
+    T --> C2["<h4>docker compose</h4><u>test service<br/>target: test profiles</u>
     <br/>"]
 
     classDef default fill:#F7F3EA,stroke:#111,stroke-width:1.5px,color:#111;
@@ -244,6 +247,9 @@ flowchart TD
     class R runtime;
     class T,C1,C2 support;
 ```
+<br/>
+> この図は4段階マルチステージビルドの論理構成です。イメージサイズ最適化、マルチアーキ（amd64/arm64）publish・検証、非root実行・HEALTHCHECK、ベースイメージのdigest固定（サプライチェーン対策）は [Docker Multi-Stage Runtime Strategy](docs/reference/docker.md) に記載しています。
+
 <br/>
 
 ### 設計判断（Design Decisions）

--- a/docs/reference/ci_cd_pipeline.md
+++ b/docs/reference/ci_cd_pipeline.md
@@ -205,6 +205,20 @@ main push時に以下3ジョブが実行され、Continuous Delivery（成果物
 - `post-trivy-scan` は main/develop push で並列実行（CD ジョブの依存には含まれないが、`publish-image` は `post-trivy-scan` 完了を待つ）
 - 稼働環境への実デプロイ（Continuous Deployment: Cloud Run / ECS / K8s 等）は未実装
 
+#### multi-arch 検証（`verify-published-image`）
+
+`publish-image` は runtime を **linux/amd64 + linux/arm64** の manifest list として GHCR に公開します。`verify-published-image` は「公開したが未検証」を排除するため、`GITHUB_TOKEN` を使わない匿名 public pull（利用者と同じ取得経路）で以下を検証します：
+
+| 検証 | 手段 | 目的 |
+|------|------|------|
+| manifest list 構造 | `docker buildx imagetools inspect --raw` + `jq` で `linux/amd64` `linux/arm64` 両方の存在を確認 | 単一の緑バッジが部分ビルドを隠す anti-pattern を防止（片 arch 欠落は fail-loud） |
+| amd64 実行 | `docker run --platform linux/amd64` で config ロードを smoke 実行 | 公開イメージが実際に起動可能かを検証 |
+| arm64 実行 | QEMU エミュレーションで `docker run --platform linux/arm64` し `platform.machine() == aarch64` を assert | manifest が arm64 を主張しつつ中身が amd64 という「嘘の manifest」を排除 |
+
+publish 直後の GHCR 伝播遅延（一過性の 404/429/5xx）に対し、最初の manifest 参照のみ指数 backoff + jitter で再試行し、伝播遅延と実体不具合を分離します。
+
+> multi-arch を **なぜ** publish するか（Apple Silicon 等 arm64 ホストでのネイティブ pull/run）等の配布観点は [Docker Multi-Stage Runtime Strategy](docker.md) を参照。
+
 ---
 
 ## 📋 ブランチ戦略（Git Flow）

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -1,6 +1,6 @@
 # Docker
 
-*最終更新: 2026年06月11日*
+*最終更新: 2026年07月06日*
 
 ## 🐳 Docker環境概要
 
@@ -33,33 +33,48 @@ ENVIRONMENT と環境別 env ファイルで設定と検証ポリシーを環境
 
 ## 📦 イメージ最適化
 
+### イメージサイズ（実測 2026-07-04）
+
+| イメージ | local image size | compressed pull size |
+|---|---:|---:|
+| runtime（GHCR公開） | 202 MB（GHCR pull 後） | 48.4 MB |
+| test（CI内部） | 577 MB | 非公開 |
+
+- `local image size` は docker images の DISK USAGE / SIZE を採用。
+- `compressed pull size` は GHCR の manifest layer size 合計を採用。
+- `runtime image` は公開・pull対象のため compressed size を主指標として併記。
+- `test image` はローカルテストおよび CI で利用する検証用イメージであり、GHCR へ公開していないため compressed pull size は掲載していません。
+
 ### 実装済み最適化
 
-- Multi-stage build によるサイズ削減
-- .dockerignore による不要ファイル除外
-- レイヤーキャッシュ最適化
-- セキュリティスキャン統合
-- SHA256固定
-- HEALTHCHECK
-- uv syncキャッシュ利用
+- **python:3.14-slim** ベースを `@sha256` digest で固定（サプライチェーン対策）
+- **Multi-stage build**（base / dependencies / runtime / test）で本番 runtime へ dev 依存・テストコードを持ち込まない
+- **.dockerignore** で build context から不要物を除外（`**/__pycache__/`・`**/.mypy_cache/` など nested キャッシュを含む。`**/` を付けないと nested ディレクトリを除外できない点に注意）
+- **レイヤーキャッシュ + uv sync キャッシュ**でコードのみ変更時のビルドを高速化
+- **非 root（appuser）実行**と **HEALTHCHECK**（起動時に config ロードを検証）
+- **Trivy** の CVE スキャン統合（CRITICAL/HIGH グリーン時のみ GHCR publish）
+- **マルチアーキ publish**（linux/amd64 + linux/arm64）で GHCR runtime を manifest list として公開し、Apple Silicon 等 arm64 ホストでもエミュレーションなしにネイティブ pull/run できる。publish 後に両 arch の manifest 存在と arm64 実行を CI で検証する
 
 ## 🚀 実行方法
 
+本プロジェクトは「**Build Once, Run Anywhere**」の原則に基づき、コードを内包した1つの不変な共通ランタイム（`runtime` ステージ）を、環境変数（`ENVIRONMENT`）で制御する設計を採用しています。
+
 ```bash
-# 開発環境起動
-docker compose up -d
 
 # テスト実行
 docker compose --profile test run --rm test
 
-# ステージング実行
-ENVIRONMENT=staging docker compose up -d
+# 共通runtimeコンテナ起動
+docker compose up -d
 
-# 本番ビルド
-docker build --target runtime -t app:prod .
+# 共通runtimeコンテナ起動（Dockerfile・依存関係を変更した場合）
+docker compose up -d --build
 
-# 本番実行
-ENVIRONMENT=production docker compose up -d
+# ステージング環境で起動
+ENVIRONMENT=staging docker compose up -d --build
+
+# 本番環境で起動
+ENVIRONMENT=production docker compose up -d --build
 
 ```
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,48 @@ def disable_sentry_for_tests(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SENTRY__ENABLED", "false")
 
 
+@pytest.fixture(scope="session", autouse=True)
+def isolate_proxy_env() -> Iterator[None]:
+    """
+    テストセッション全体でプロキシ系環境変数を除去し、テストを環境非依存にする。
+
+    Purpose:
+        開発環境の HTTP(S)_PROXY / NO_PROXY / ALL_PROXY を剥離し、
+        httpx クライアント生成をアンビエントなプロキシ設定から隔離する。
+        ローカルインターセプタ (例: llmtrim) が NO_PROXY に IPv6 CIDR
+        (fd00::/8 等) を注入すると httpx が InvalidURL を送出し
+        (encode/httpx#3221)、全 httpx.Client/AsyncClient 生成が失敗する。
+        本 fixture でテストが実行環境のプロキシ設定に依存しないことを保証する。
+
+    Scope:
+        session スコープにすることで、class / module スコープのクライアント
+        fixture（例: tests/test_smoke.py の class スコープ api_client）が生成
+        される前に env を剥離する。function スコープでは高スコープ fixture の
+        後に実行され間に合わない（pytest は高スコープ fixture を先に生成する）。
+
+    Note:
+        - autouse=True により全テストに自動適用
+        - 本番挙動は不変（本番クライアントは trust_env=True のまま）
+        - httpx は小文字系も参照するため大文字/小文字の両方を除去
+        - monkeypatch fixture は function スコープ専用のため、公式 API の
+          pytest.MonkeyPatch() を直接使用し teardown で undo する
+    """
+    mp = pytest.MonkeyPatch()
+    for var in (
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+        "no_proxy",
+    ):
+        mp.delenv(var, raising=False)
+    yield
+    mp.undo()
+
+
 # =============================================================================
 # 基本フィクスチャ
 # =============================================================================


### PR DESCRIPTION
## 概要
Apple Silicon等のarm64ホストでもネイティブpull/run可能にするため、GHCRイメージをマルチアーキテクチャ（linux/amd64 + linux/arm64）のmanifest listとして公開し、両アーキテクチャの存在確認と実行検証をCIに追加しました。

## 変更内容

### CI/CD (`.github/workflows/ci.yml`)
- `docker/setup-qemu-action` を追加し、QEMUエミュレーションでarm64ビルド・検証を実現
- `docker/buildx` で `platforms: linux/amd64,linux/arm64` を指定し、マルチアーキmanifest listを生成
- `docker buildx imagetools inspect` で両arch（amd64/arm64）の存在を構造検証
- 公開後のsmokeテストを分離:
  - amd64ネイティブ実行検証
  - arm64エミュレーション実行検証（`--platform linux/arm64` で実行し `platform.machine() == 'aarch64'` をアサート）

### Docker設定
- `.dockerignore` に `**/.mypy_cache/` を追加（ネストしたキャッシュディレクトリ除外）
- `.gitignore` に `.vscode/**` を追加
- `Dockerfile` のヘッダー更新（最終更新日、実測サイズ情報を反映）

### ドキュメント
- `README.md`: CI/CDフロー図の更新（マルチアーキ検証フロー追加）、技術選定テーブルの整理、実行方法の更新
- `docs/reference/docker.md`: 実測サイズ情報追加、マルチアーキpublishの説明追加、実行コマンドの更新

## 検証済み
- 全1394テストパス（proxy環境変数隔離フィクスチャ追加済み）
- ruff/mypy問題なし
- 既存の309件の失敗はproxy環境依存のインフラ課題であり、今回の変更と無関係

## 影響範囲
🔴 公開API挙動変更（GHCRイメージがマルチアーキ化）
🔴 外部I/O変更（匿名pull検証の追加、QEMUエミュレーション実行）