### PR TITLE
refactor(utils): 共通例外クラスをutils/exceptions.pyに抽出

### DIFF
--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -18,6 +18,8 @@ import pytest
 import respx
 from structlog.testing import capture_logs
 
+from utils.api_client import APIClientError as ShimAPIClientError
+from utils.exceptions import APIClientError
 from utils.github_client import (
     AsyncGitHubClient,
     GitHubAPIError,
@@ -36,6 +38,13 @@ pytestmark = pytest.mark.unit
 
 GITHUB_API_BASE_URL = "https://api.github.com"
 MAX_RETRIES = 3
+
+
+def test_github_api_error_uses_shared_api_client_error() -> None:
+    """GitHub例外は分割後も共有API例外階層に属する。"""
+    assert ShimAPIClientError is APIClientError
+    assert issubclass(GitHubAPIError, APIClientError)
+
 
 # =============================================================================
 # 基本機能テスト（正常系）

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -14,18 +14,17 @@ from structlog.typing import FilteringBoundLogger
 
 from config.settings import settings
 from models.responses import Album, Comment, Photo, Post, Todo, User
+from utils.exceptions import (
+    ASYNC_FATAL_EXCEPTIONS,
+    APIClientError,
+    APIConnectionError,
+    APIHTTPError,
+    APIJSONDecodeError,
+    APIRetryError,
+    APITimeoutError,
+)
 from utils.logger import get_logger
 
-# httpx 例外（NetworkError, RemoteProtocolError 等）をここに追加してはならない。
-# github_client.py の _request では except 句の順序で先行キャッチしており、
-# この定数に httpx 例外を追加すると NetworkError のリトライが壊れる。
-ASYNC_FATAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
-    KeyboardInterrupt,
-    SystemExit,
-    MemoryError,
-    RecursionError,
-    asyncio.CancelledError,
-)
 SYNC_FATAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
     KeyboardInterrupt,
     SystemExit,
@@ -74,44 +73,6 @@ def _validate_optional_int(value: int | None, name: str, min_value: int) -> None
     """
     if value is not None and value < min_value:
         raise ValueError(f"{name} must be >= {min_value}")
-
-
-# =============================================================================
-# 例外クラス
-# =============================================================================
-
-
-class APIClientError(Exception):
-    """APIクライアント基底例外"""
-
-
-class APIConnectionError(APIClientError):
-    """API接続エラー"""
-
-
-class APITimeoutError(APIClientError):
-    """APIタイムアウトエラー"""
-
-
-class APIHTTPError(APIClientError):
-    """HTTPステータスエラー"""
-
-    def __init__(self, message: str, status_code: int, response: httpx.Response | None = None):
-        super().__init__(message)
-        self.status_code = status_code
-        self.response = response
-
-
-class APIRetryError(APIClientError):
-    """リトライ上限エラー"""
-
-
-class APIJSONDecodeError(APIClientError):
-    """JSONパース＋スキーマ検証エラー"""
-
-    def __init__(self, message: str, response: httpx.Response | None = None):
-        super().__init__(message)
-        self.response = response
 
 
 def _safe_parse_json(response: httpx.Response) -> Any:

--- a/utils/exceptions.py
+++ b/utils/exceptions.py
@@ -1,0 +1,49 @@
+"""Shared API client exceptions and fatal-exception policy."""
+
+import asyncio
+
+import httpx
+
+# httpx 例外（NetworkError, RemoteProtocolError 等）をここに追加してはならない。
+# github_client.py の _request では except 句の順序で先行キャッチしており、
+# この定数に httpx 例外を追加すると NetworkError のリトライが壊れる。
+ASYNC_FATAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    KeyboardInterrupt,
+    SystemExit,
+    MemoryError,
+    RecursionError,
+    asyncio.CancelledError,
+)
+
+
+class APIClientError(Exception):
+    """APIクライアント基底例外"""
+
+
+class APIConnectionError(APIClientError):
+    """API接続エラー"""
+
+
+class APITimeoutError(APIClientError):
+    """APIタイムアウトエラー"""
+
+
+class APIHTTPError(APIClientError):
+    """HTTPステータスエラー"""
+
+    def __init__(self, message: str, status_code: int, response: httpx.Response | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response = response
+
+
+class APIRetryError(APIClientError):
+    """リトライ上限エラー"""
+
+
+class APIJSONDecodeError(APIClientError):
+    """JSONパース＋スキーマ検証エラー"""
+
+    def __init__(self, message: str, response: httpx.Response | None = None):
+        super().__init__(message)
+        self.response = response

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -13,11 +13,10 @@ from urllib.parse import quote, urlencode
 import httpx
 
 from utils.api_client import (
-    ASYNC_FATAL_EXCEPTIONS,
-    APIClientError,
     _log_error_with_stderr_fallback,
     exponential_backoff_with_jitter,
 )
+from utils.exceptions import ASYNC_FATAL_EXCEPTIONS, APIClientError
 from utils.logger import get_logger
 
 # モジュールレベル logger: ``@staticmethod`` (例: ``_cache_key``) など
@@ -319,7 +318,7 @@ class AsyncGitHubClient:
             # （has_body_exception=True 時）捕捉されサイレント隠蔽される。KeyboardInterrupt/
             # SystemExit/CancelledError は BaseException 直系で except Exception の境界外（素通り）
             # だが、_client=None 設定の一貫性のため本句で先取りする。
-            # NOTE: 本クラスは _request パス（utils.api_client の ASYNC_FATAL_EXCEPTIONS 方針）と
+            # NOTE: 本クラスは _request パス（utils.exceptions の ASYNC_FATAL_EXCEPTIONS 方針）と
             # 同一の定数を close 経路でも使用する。一方 AsyncAPIClient._close_async_client は
             # close 文脈で (MemoryError, RecursionError) のみを使う別方針（CancelledError 等は
             # BaseException 直系として素通りさせる設計）であり、両クラスの close ヘルパーは


### PR DESCRIPTION
## 概要
共通例外クラスを `utils/exceptions.py` に抽出し、責務分離を実施しました。

## 変更内容
- `utils/exceptions.py` を新規作成：共通例外クラスを集約
- 既存コードからの例外インポートパスを更新

## テスト
- [ ] ローカルテスト完了
- [ ] CI/CD パイプライン確認

## 関連Issue/PR
Closes #460 (refactor)

---
このPRは /push-pr スキルで自動生成されました。