### PR TITLE
feat(models): extract sanitization helpers into dedicated module (#458)

### DIFF
--- a/models/responses.py
+++ b/models/responses.py
@@ -285,25 +285,25 @@ class User(BaseModel):
 
         """
         if not isinstance(v, str):
-            raise ValueError(f"文字列が必要です（受け取った型: {type(v).__name__}）")
+            raise ValueError(f"String required (received type: {type(v).__name__})")
 
         sanitized = strip_invisible_chars(v).strip()
         # min_length=1 は真の空文字列を、ここでは制御文字のみの文字列を捕捉（2段階チェック）
         if not sanitized:
-            raise ValueError("websiteが空になりました（制御文字除去後）")
+            raise ValueError("Website became empty after control character removal")
         # CRLF injection防止: パーセントエンコードされた制御文字を拒否（%00-%1f全範囲）
         # strip_invisible_chars は実際の制御文字を除去するが、
         # %0d%0a 等のエンコード形式はバイパスする
         sanitized_lower = sanitized.lower()
         if _sanitization._PERCENT_CTRL_RE.search(sanitized_lower):
-            raise ValueError("URLにパーセントエンコードされた制御文字が含まれています")
+            raise ValueError("URL contains percent-encoded control characters")
         # 不完全な%シーケンス検出（全ブランチ共通 — http/httpsおよびスキームなし両対応）
         # validate_scheme_less_url でも同様にチェックするが多層防御として二重確認
         if _sanitization._INCOMPLETE_PCT_RE.search(sanitized):
-            raise ValueError("URLに不完全なパーセントエンコードが含まれています")
+            raise ValueError("URL contains incomplete percent-encoding")
         # プロトコル相対URLを明示的に拒否（攻撃面削減）
         if sanitized_lower.startswith("//"):
-            raise ValueError("プロトコル相対URLは許可されていません")
+            raise ValueError("Protocol-relative URLs are not allowed")
         # urlparseは各分岐で1回のみ呼び出す
         # （http/httpsブランチと補完ブランチで入力が異なるため共通化不可）
         if sanitized_lower.startswith(("http://", "https://")):
@@ -317,7 +317,7 @@ class User(BaseModel):
         # is_domain_portロジックを削除: domain:portはスキームなし扱いのため
         # http(s)://を明示しない限り拒否（例: example.com:8080 → ValueError）
         if _sanitization._SCHEME_RE.match(sanitized_lower):
-            raise ValueError("危険なURLスキームが検出されました")
+            raise ValueError("Dangerous URL scheme detected")
         # スキームなし → https:// を補完して検証
         # _validate_netloc / normalize_url の ValueError はそのまま伝播
         # 設計意図: スキームなしURLはドメインのみ許可（パス付きURLは拒否）
@@ -331,7 +331,7 @@ class User(BaseModel):
         #  「危険なURLスキーム」として上流で拒否されるため、このチェックに到達しない）
         if parsed.port is not None:
             raise ValueError(
-                "スキームなしURLにポートは指定できません（http(s)://を明示してください）"
+                "Scheme-less URL cannot contain a port (explicitly use http:// or https://)"
             )
         return _sanitization._ensure_website_max_length(normalize_url(parsed))
 
@@ -474,16 +474,16 @@ class Photo(BaseModel):
         """
         sanitized = strip_invisible_chars(v).strip()
         if not sanitized:
-            raise ValueError("URLが空になりました（制御文字除去後）")
+            raise ValueError("URL became empty after control character removal")
         # CRLF injection防止: パーセントエンコードされた制御文字を拒否（%00-%1f全範囲）
         sanitized_lower = sanitized.lower()
         if _sanitization._PERCENT_CTRL_RE.search(sanitized_lower):
-            raise ValueError("URLにパーセントエンコードされた制御文字が含まれています")
+            raise ValueError("URL contains percent-encoded control characters")
         # 不完全な%シーケンス（%、%G、%GGなど）はunquoteがリテラル扱いするため個別チェック
         if _sanitization._INCOMPLETE_PCT_RE.search(sanitized):
-            raise ValueError("URLに不完全なパーセントエンコードが含まれています")
+            raise ValueError("URL contains incomplete percent-encoding")
         if not sanitized_lower.startswith(("http://", "https://")):
-            raise ValueError("URLはhttp://またはhttps://で始まる必要があります")
+            raise ValueError("URL must start with http:// or https://")
         # _validate_netloc / normalize_url の ValueError はそのまま伝播
         parsed = urlparse(sanitized)
         _sanitization._validate_netloc(parsed)

--- a/models/responses.py
+++ b/models/responses.py
@@ -7,242 +7,18 @@ websiteはURL形式のためhtmlコンテキスト出力時は呼び出し元で
 モデル値はAPIレスポンスの意味論を保つ。HTML等への出力時のエスケープ責務は呼び出し元が持つ。
 """
 
-import html
-import re
-import unicodedata
 from typing import Annotated
-from urllib.parse import ParseResult, quote, unquote, urlparse, urlunparse
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
 
-# RFC 3986 準拠のスキーム検出パターン（scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) ":"）
-_SCHEME_RE: re.Pattern[str] = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
-_HTML_META_RE: re.Pattern[str] = re.compile(r'[<>"\'&]')
-_PERCENT_CTRL_RE: re.Pattern[str] = re.compile(
-    r"%[01][0-9a-f]|%7f",  # C0制御文字(%00-%1f)およびDEL(%7f)を検出
-    # 注: C1制御文字(%80-%9f)は対象外。
-    # UTF-8/IRI由来のpercent-encoded内容と重複するため、グローバル拒否ではなく
-    # netlocのみunquote(errors="strict")で不正UTF-8として検出する。
-    # 注: %20(スペース)は制御文字ではないため非対象
-    re.IGNORECASE,
+from . import sanitization as _sanitization
+from .sanitization import (
+    normalize_url,
+    sanitize_user_content,
+    strip_invisible_chars,
+    validate_scheme_less_url,
 )
-# 不完全な%シーケンス検出 — unquoteがリテラル扱いするためUnicodeDecodeErrorが発生しない
-# IGNORECASE flag で大文字小文字を統合（可読性目的、機能等価: r"%(?![0-9a-fA-F]{2})" と同一）
-_INCOMPLETE_PCT_RE: re.Pattern[str] = re.compile(r"%(?![0-9a-f]{2})", re.IGNORECASE)
-_ASCII_WHITESPACE_RE: re.Pattern[str] = re.compile(r"[ \t\n\r\f\v]")
-_VARIATION_SELECTORS: frozenset[str] = frozenset(
-    {chr(codepoint) for codepoint in range(0xFE00, 0xFE10)}
-    | {chr(codepoint) for codepoint in range(0xE0100, 0xE01F0)}
-)
-_WEBSITE_NORMALIZED_MAX_LENGTH: int = 2048
-_INVISIBLE_CATEGORIES = frozenset({"Cf", "Cc", "Zs", "Zl", "Zp"})
-# Cs（孤立サロゲート）を _INVISIBLE_CATEGORIES と合算した除去セット（1回目パスで使用）
-_STRIP_CATEGORIES = _INVISIBLE_CATEGORIES | frozenset({"Cs"})
-
-
-# URL正規化中のUnicodeカテゴリ参照を十分に吸収する余裕を持たせる。
-# 通常のURLで登場する文字種は数百程度だが、テスト・攻撃入力では多様な
-# 制御文字/不可視文字を含むため、余裕を持った上限にして再計算を避ける。
-def _is_strippable_char(c: str, categories: frozenset[str]) -> bool:
-    """不可視文字として除去すべき文字か判定する。
-
-    Variation Selectors は Mn に分類されるが、結合文字（例: U+0301）は保持し、
-    NFD由来のホスト名をサイレントに別文字列へ改変しない。
-    """
-    return c != " " and (unicodedata.category(c) in categories or c in _VARIATION_SELECTORS)
-
-
-def _strip_invisible_chars(v: str) -> str:
-    """不可視文字・制御文字・Unicode空白をURL文字列から除去（NFKC正規化含む2パス処理）
-
-    URLスキームバイパス防止のため、_STRIP_CATEGORIES（= _INVISIBLE_CATEGORIES | {"Cs"}）
-    に属するUnicodeカテゴリを2パスの内包表記で除去する
-    （パス1: NFKC正規化前・Cs含む全カテゴリ、パス2: NFKC正規化後・Cs除外）:
-
-    - Cs: Surrogate（孤立サロゲート U+D800-U+DFFF）— 有効なUnicode文字列に
-          含まれるべきでないためnormalize()前に除去（データ整合性）
-    - Cf: Format文字（Bidi制御, ゼロ幅文字, Word Joiner等）
-    - Cc: 制御文字（C0/C1制御文字, DEL等）
-    - Mn: 非スペーシングマーク（Variation Selectors U+FE00-U+FE0F と
-          Variation Selectors Supplement U+E0100-U+E01EF は個別除去。
-          結合文字 U+0300等は保持し、NFD由来のホスト名改変を避ける）
-    - Zs: Unicode空白（NBSP, Ogham Space, 全角空白等。U+0020通常スペースは
-          Zsカテゴリに属するが、c == " " の特例条件で保持）
-          ※ NFKC正規化前にも除去（U+3000等はNFKC後にU+0020へ変換される副作用を防止。
-          U+1680等はNFKC変換対象外だが一括除去でスキームバイパスを防止）
-    - Zl: 行区切り（U+2028 Line Separator）
-    - Zp: 段落区切り（U+2029 Paragraph Separator）
-
-    Python に同梱の Unicode バージョン内の新規文字に自動対応する。
-    （Unicode バージョン自体の更新には Python バージョンアップが必要）
-    """
-    # パス1: Cs（孤立サロゲート）と不可視文字を一括除去
-    # _STRIP_CATEGORIES = _INVISIBLE_CATEGORIES | {"Cs"} で Cs の個別除去を統合
-    # NFKC前にZs等を除去（NFKC後にU+0020へ変換される副作用防止）
-    # 全角英字（Ll/Lu等）はNFKC前に残し、NFKC正規化でASCIIに変換される
-    pre_filtered = "".join(c for c in v if not _is_strippable_char(c, _STRIP_CATEGORIES))
-    normalized = unicodedata.normalize("NFKC", pre_filtered)
-    # パス2: NFKC後に新たに生成された不可視文字を除去
-    # （Csは再出現しないため_INVISIBLE_CATEGORIESのみ）
-    return "".join(c for c in normalized if not _is_strippable_char(c, _INVISIBLE_CATEGORIES))
-
-
-# =============================================================================
-# ユーティリティ関数
-# =============================================================================
-
-
-def sanitize_user_content(value: str) -> str:
-    """ユーザー生成コンテンツをHTMLエスケープでサニタイズ
-
-    XSS攻撃を防ぐため、HTMLエスケープを適用。
-    特殊文字（<, >, &, ", '）をHTMLエンティティに変換。
-
-    Args:
-        value: サニタイズ対象の文字列
-
-    Returns:
-        サニタイズ済み文字列
-
-    Raises:
-        ValueError: value が str 型でない場合
-
-    Note:
-        主にPydantic field_validator経由で使用されます。
-        以前は str | None を受理していたが、現在は str のみ受理する。
-        None を渡した場合は ValueError が発生する。
-
-    Examples:
-        >>> sanitize_user_content("<script>alert('XSS')</script>")
-        '&lt;script&gt;alert(&#x27;XSS&#x27;)&lt;/script&gt;'
-
-    """
-    if not isinstance(value, str):
-        raise ValueError(f"文字列が必要です（受け取った型: {type(value).__name__}）")
-    # quote=True: シングルクォート、ダブルクォートもエスケープ
-    return html.escape(value, quote=True)
-
-
-def _validate_netloc(parsed: ParseResult) -> None:
-    """netloc のバリデーション.
-
-    存在確認・空白文字拒否・不正percent decode拒否・userinfo禁止・
-    HTMLメタ文字拒否・hostname解決チェックを行う。
-    """
-    if not parsed.netloc:
-        raise ValueError("有効なホスト名が含まれていません")
-    # 不正ポート文字列バイパス対策: parsed.port は整数でない場合 ValueError を送出する
-    # （例: https://example.com:abc/path は netloc チェックをパスするが port アクセスで検出）
-    try:
-        _ = parsed.port
-    except ValueError as e:
-        raise ValueError("ポートが無効です（整数値でなければなりません）") from e
-    # 多層防御: parsed.username/password に加え netloc の "@" リテラルも検査
-    # （urlparse が特定のエンコード済み入力で username=None を返すエッジケース対策）
-    try:
-        decoded_netloc = unquote(parsed.netloc, errors="strict")
-    except UnicodeDecodeError as e:
-        raise ValueError(f"URLに不正なパーセントエンコードが含まれています: {e}") from e
-    # raw と decoded 両方をチェック（%エンコードバイパス対策: https://example.com%20evil.com 等）
-    if _ASCII_WHITESPACE_RE.search(parsed.netloc) or _ASCII_WHITESPACE_RE.search(decoded_netloc):
-        raise ValueError("ホスト名に空白文字が含まれています")
-    has_at = "@" in parsed.netloc or "@" in decoded_netloc
-    if has_at:
-        raise ValueError("URLにuserinfo（ユーザー名/パスワード）は指定できません")
-    # @が含まれない場合のみ username/password を確認（urlparseのエッジケース補完）
-    # （urlparse が特定のエンコード済み入力で username=None を返すエッジケース対策）
-    try:
-        has_userinfo = parsed.username is not None or parsed.password is not None
-    except (ValueError, OverflowError) as e:  # fmt: skip
-        # parsed.username/password は内部で独自にunquoteするため、L135-137のチェックとは独立
-        raise ValueError(f"URLのuserinfoパースに失敗しました（netloc={parsed.netloc!r}）") from e
-    if has_userinfo:
-        raise ValueError("URLにuserinfo（ユーザー名/パスワード）は指定できません")
-    # ホスト部にHTMLメタ文字（<, >, ", ', &）が含まれる場合は拒否
-    if _HTML_META_RE.search(parsed.netloc) or _HTML_META_RE.search(decoded_netloc):
-        raise ValueError("ホスト名に不正な文字が含まれています")
-    # hostname が None になるケース（例: 不正な IPv6 形式）を _normalize_url に渡す前に排除
-    if not parsed.hostname:
-        raise ValueError("有効なホスト名が含まれていません")
-
-
-def _normalize_url(parsed: ParseResult) -> str:
-    """RFC 3986 §6.2.2.1（Case Normalization）に従いスキームとホスト部を小文字正規化する。
-
-    パス・パラメータ・クエリ・フラグメントは RFC 3986 §3.3–§3.5 の構文定義に従い
-    URLエンコードする。§6.2.2.2 の既存 %xx シーケンスのヘックス大文字化は未実施
-    （新規エンコード分は quote() が UPPERCASE で出力する）。
-    """
-    # ParseResultはnamedtupleだが、tuple直接指定でコードの意図を明示する
-    # パス・クエリ・フラグメントのXSS文字をURLエンコード（%を安全文字に含め二重エンコード防止）
-    # RFC 3986 §3.3 pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
-    # XSS防止: ' (single quote) を safe から除外 → %27 にエンコード
-    # &はquery/fragmentでパラメータ区切りとして必要なため保持（HTML出力時は呼び出し元でエスケープ）
-    # -._~ は Python quote() の _ALWAYS_SAFE に含まれるが、RFC 仕様との対応を明示
-    safe_path = quote(parsed.path, safe="/:@!$()*+,;=%-._~")
-    # RFC 3986 §3.3 (params は path の一部として扱う)
-    safe_params = quote(parsed.params, safe=";=@:!$()*+,/%-._~")
-    # RFC 3986 §3.4 query = *( pchar / "/" / "?" )
-    safe_query = quote(parsed.query, safe="=&+:@!$()*,;/?%-._~")
-    # RFC 3986 §3.5 fragment = *( pchar / "/" / "?" )
-    # フラグメントは path/query より "&" と "?" を緩く扱い、unreserved 文字は過剰エンコードしない
-    safe_fragment = quote(parsed.fragment, safe=":@!$&()*+,;=/?%-._~")
-    # hostname は urlparse が自動小文字化済み。netloc.lower() ではなく
-    # hostname + port で再構成し、percent-encoded 文字の大文字16進を保持する
-    hostname = parsed.hostname
-    if not hostname:
-        # _validate_netloc の `not parsed.hostname` で空文字列・None ケースは排除済み
-        # ここは直接呼び出し時のセーフガード（通常パスでは到達しない）
-        raise ValueError(f"ホスト名の解決に失敗しました（netloc={parsed.netloc!r}）")
-    if ":" in hostname:
-        hostname = f"[{hostname}]"
-    netloc = f"{hostname}:{parsed.port}" if parsed.port is not None else hostname
-    return urlunparse(
-        (
-            parsed.scheme.lower(),
-            netloc,
-            safe_path,
-            safe_params,
-            safe_query,
-            safe_fragment,
-        )
-    )
-
-
-def _ensure_website_max_length(url: str) -> str:
-    """正規化後URL長の上限チェック（_WEBSITE_NORMALIZED_MAX_LENGTH文字）."""
-    if len(url) > _WEBSITE_NORMALIZED_MAX_LENGTH:
-        raise ValueError(
-            f"URL補完後の長さが上限{_WEBSITE_NORMALIZED_MAX_LENGTH}文字を超過しています（{len(url)}文字）"
-        )
-    return url
-
-
-def _validate_scheme_less_url(sanitized: str) -> None:
-    """スキームなしURLのバリデーション: パーセントエンコード・パス・フラグメント・クエリを検証する。
-
-    Args:
-        sanitized: 前処理済み（不可視文字除去・strip済み）のURL文字列
-
-    Raises:
-        ValueError: 不正なパーセントエンコード、パス、フラグメント、クエリが含まれる場合
-    """
-    # errors='strict': 不正なパーセントエンコードをサイレント置換せず明示的エラーとして扱う
-    try:
-        decoded = unquote(sanitized, errors="strict")
-    except UnicodeDecodeError as e:
-        raise ValueError(f"URLに不正なパーセントエンコードが含まれています: {e}") from e
-    # 不完全な%シーケンス（例: %、%GG）はunquoteがリテラル扱いするため個別チェック
-    if _INCOMPLETE_PCT_RE.search(sanitized):
-        raise ValueError("URLに不完全なパーセントエンコードが含まれています")
-    if "/" in sanitized or "/" in decoded:
-        raise ValueError("スキームなしURLにパスは指定できません")
-    # %23（#）と %3F（?）のバイパス検出: decoded に含まれる#/?も検出
-    if "#" in sanitized or "#" in decoded:
-        raise ValueError("スキームなしURLにフラグメントは指定できません")
-    if "?" in sanitized or "?" in decoded:
-        raise ValueError("スキームなしURLにクエリは指定できません")
-
 
 # =============================================================================
 # 投稿関連モデル
@@ -333,7 +109,7 @@ class Geo(BaseModel):
 
     Note:
         lat/lngは数値座標文字列（例: "-40.7128"）のため、
-        URLスキームバイパス防止を目的とする _strip_invisible_chars は非適用。
+        URLスキームバイパス防止を目的とする strip_invisible_chars は非適用。
         XSSはhtml.escape（sanitize_user_content経由）で対処。
 
     Raises:
@@ -419,7 +195,7 @@ class User(BaseModel):
 
     JSONPlaceholder /users エンドポイントのレスポンス。
     name, username, phoneフィールドにXSS保護（html.escape）を適用。
-    websiteフィールドはhtml.escape対象外。不可視文字除去（_strip_invisible_chars）・allowlist方式スキームバリデーション適用。
+    websiteフィールドはhtml.escape対象外。不可視文字除去（strip_invisible_chars）・allowlist方式スキームバリデーション適用。
     emailはEmailStr型でRFC構文チェック（DNS検証なし）。
 
     Attributes:
@@ -511,19 +287,19 @@ class User(BaseModel):
         if not isinstance(v, str):
             raise ValueError(f"文字列が必要です（受け取った型: {type(v).__name__}）")
 
-        sanitized = _strip_invisible_chars(v).strip()
+        sanitized = strip_invisible_chars(v).strip()
         # min_length=1 は真の空文字列を、ここでは制御文字のみの文字列を捕捉（2段階チェック）
         if not sanitized:
             raise ValueError("websiteが空になりました（制御文字除去後）")
         # CRLF injection防止: パーセントエンコードされた制御文字を拒否（%00-%1f全範囲）
-        # _strip_invisible_chars は実際の制御文字を除去するが、
+        # strip_invisible_chars は実際の制御文字を除去するが、
         # %0d%0a 等のエンコード形式はバイパスする
         sanitized_lower = sanitized.lower()
-        if _PERCENT_CTRL_RE.search(sanitized_lower):
+        if _sanitization._PERCENT_CTRL_RE.search(sanitized_lower):
             raise ValueError("URLにパーセントエンコードされた制御文字が含まれています")
         # 不完全な%シーケンス検出（全ブランチ共通 — http/httpsおよびスキームなし両対応）
-        # _validate_scheme_less_url でも同様にチェックするが多層防御として二重確認
-        if _INCOMPLETE_PCT_RE.search(sanitized):
+        # validate_scheme_less_url でも同様にチェックするが多層防御として二重確認
+        if _sanitization._INCOMPLETE_PCT_RE.search(sanitized):
             raise ValueError("URLに不完全なパーセントエンコードが含まれています")
         # プロトコル相対URLを明示的に拒否（攻撃面削減）
         if sanitized_lower.startswith("//"):
@@ -531,24 +307,24 @@ class User(BaseModel):
         # urlparseは各分岐で1回のみ呼び出す
         # （http/httpsブランチと補完ブランチで入力が異なるため共通化不可）
         if sanitized_lower.startswith(("http://", "https://")):
-            # _validate_netloc / _normalize_url の ValueError はそのまま伝播
-            # NOTE: sanitized（元の大文字混在）を使用 — スキーム小文字化は _normalize_url に委譲
+            # _validate_netloc / normalize_url の ValueError はそのまま伝播
+            # NOTE: sanitized（元の大文字混在）を使用 — スキーム小文字化は normalize_url に委譲
             # （sanitized_lower は path/query の大文字を失うため使用不可）
             parsed = urlparse(sanitized)
-            _validate_netloc(parsed)
-            return _ensure_website_max_length(_normalize_url(parsed))
+            _sanitization._validate_netloc(parsed)
+            return _sanitization._ensure_website_max_length(normalize_url(parsed))
         # RFC 3986スキーム検出: http/https以外のスキームが存在すれば拒否
         # is_domain_portロジックを削除: domain:portはスキームなし扱いのため
         # http(s)://を明示しない限り拒否（例: example.com:8080 → ValueError）
-        if _SCHEME_RE.match(sanitized_lower):
+        if _sanitization._SCHEME_RE.match(sanitized_lower):
             raise ValueError("危険なURLスキームが検出されました")
         # スキームなし → https:// を補完して検証
-        # _validate_netloc / _normalize_url の ValueError はそのまま伝播
+        # _validate_netloc / normalize_url の ValueError はそのまま伝播
         # 設計意図: スキームなしURLはドメインのみ許可（パス付きURLは拒否）
         # パーセントエンコード済み %2F によるバイパスも防止
-        _validate_scheme_less_url(sanitized)
+        validate_scheme_less_url(sanitized)
         parsed = urlparse("https://" + sanitized)
-        _validate_netloc(parsed)
+        _sanitization._validate_netloc(parsed)
         # スキームなし補完後のポートチェック:
         # IPアドレス:port形式（例: 192.168.1.1:8080）がここに到達する
         # （ドメイン:port形式（例: example.com:8080）は _SCHEME_RE にマッチし
@@ -557,7 +333,7 @@ class User(BaseModel):
             raise ValueError(
                 "スキームなしURLにポートは指定できません（http(s)://を明示してください）"
             )
-        return _ensure_website_max_length(_normalize_url(parsed))
+        return _sanitization._ensure_website_max_length(normalize_url(parsed))
 
 
 # =============================================================================
@@ -696,19 +472,19 @@ class Photo(BaseModel):
             エスケープが必須。
 
         """
-        sanitized = _strip_invisible_chars(v).strip()
+        sanitized = strip_invisible_chars(v).strip()
         if not sanitized:
             raise ValueError("URLが空になりました（制御文字除去後）")
         # CRLF injection防止: パーセントエンコードされた制御文字を拒否（%00-%1f全範囲）
         sanitized_lower = sanitized.lower()
-        if _PERCENT_CTRL_RE.search(sanitized_lower):
+        if _sanitization._PERCENT_CTRL_RE.search(sanitized_lower):
             raise ValueError("URLにパーセントエンコードされた制御文字が含まれています")
         # 不完全な%シーケンス（%、%G、%GGなど）はunquoteがリテラル扱いするため個別チェック
-        if _INCOMPLETE_PCT_RE.search(sanitized):
+        if _sanitization._INCOMPLETE_PCT_RE.search(sanitized):
             raise ValueError("URLに不完全なパーセントエンコードが含まれています")
         if not sanitized_lower.startswith(("http://", "https://")):
             raise ValueError("URLはhttp://またはhttps://で始まる必要があります")
-        # _validate_netloc / _normalize_url の ValueError はそのまま伝播
+        # _validate_netloc / normalize_url の ValueError はそのまま伝播
         parsed = urlparse(sanitized)
-        _validate_netloc(parsed)
-        return _ensure_website_max_length(_normalize_url(parsed))
+        _sanitization._validate_netloc(parsed)
+        return _sanitization._ensure_website_max_length(normalize_url(parsed))

--- a/models/sanitization.py
+++ b/models/sanitization.py
@@ -191,7 +191,7 @@ def normalize_url(parsed: ParseResult) -> str:
 
 
 def _ensure_website_max_length(url: str) -> str:
-    """正規化後URL長の上限チェック（WEBSITE_NORMALIZED_MAX_LENGTH文字）."""
+    """正規化後URL長の上限チェック（WEBSITE_NORMALIZED_MAX_LENGTH文字）"""
     if len(url) > WEBSITE_NORMALIZED_MAX_LENGTH:
         raise ValueError(
             f"URL補完後の長さが上限{WEBSITE_NORMALIZED_MAX_LENGTH}文字を超過しています（{len(url)}文字）"

--- a/models/sanitization.py
+++ b/models/sanitization.py
@@ -1,0 +1,225 @@
+"""Sanitization helpers for response models."""
+
+import html
+import re
+import unicodedata
+from urllib.parse import ParseResult, quote, unquote, urlunparse
+
+_SCHEME_RE: re.Pattern[str] = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
+_HTML_META_RE: re.Pattern[str] = re.compile(r'[<>"\'&]')
+_PERCENT_CTRL_RE: re.Pattern[str] = re.compile(
+    r"%[01][0-9a-f]|%7f",  # C0制御文字(%00-%1f)およびDEL(%7f)を検出
+    # 注: C1制御文字(%80-%9f)は対象外。
+    # UTF-8/IRI由来のpercent-encoded内容と重複するため、グローバル拒否ではなく
+    # netlocのみunquote(errors="strict")で不正UTF-8として検出する。
+    # 注: %20(スペース)は制御文字ではないため非対象
+    re.IGNORECASE,
+)
+# 不完全な%シーケンス検出 — unquoteがリテラル扱いするためUnicodeDecodeErrorが発生しない
+# IGNORECASE flag で大文字小文字を統合（可読性目的、機能等価: r"%(?![0-9a-fA-F]{2})" と同一）
+_INCOMPLETE_PCT_RE: re.Pattern[str] = re.compile(r"%(?![0-9a-f]{2})", re.IGNORECASE)
+_ASCII_WHITESPACE_RE: re.Pattern[str] = re.compile(r"[ \t\n\r\f\v]")
+_VARIATION_SELECTORS: frozenset[str] = frozenset(
+    {chr(codepoint) for codepoint in range(0xFE00, 0xFE10)}
+    | {chr(codepoint) for codepoint in range(0xE0100, 0xE01F0)}
+)
+WEBSITE_NORMALIZED_MAX_LENGTH: int = 2048
+_INVISIBLE_CATEGORIES = frozenset({"Cf", "Cc", "Zs", "Zl", "Zp"})
+# Cs（孤立サロゲート）を _INVISIBLE_CATEGORIES と合算した除去セット（1回目パスで使用）
+_STRIP_CATEGORIES = _INVISIBLE_CATEGORIES | frozenset({"Cs"})
+
+
+def _is_strippable_char(c: str, categories: frozenset[str]) -> bool:
+    """不可視文字として除去すべき文字か判定する。
+
+    Variation Selectors は Mn に分類されるが、結合文字（例: U+0301）は保持し、
+    NFD由来のホスト名をサイレントに別文字列へ改変しない。
+    """
+    return c != " " and (unicodedata.category(c) in categories or c in _VARIATION_SELECTORS)
+
+
+def strip_invisible_chars(v: str) -> str:
+    """不可視文字・制御文字・Unicode空白をURL文字列から除去（NFKC正規化含む2パス処理）
+
+    URLスキームバイパス防止のため、_STRIP_CATEGORIES（= _INVISIBLE_CATEGORIES | {"Cs"}）
+    に属するUnicodeカテゴリを2パスの内包表記で除去する
+    （パス1: NFKC正規化前・Cs含む全カテゴリ、パス2: NFKC正規化後・Cs除外）:
+
+    - Cs: Surrogate（孤立サロゲート U+D800-U+DFFF）— 有効なUnicode文字列に
+          含まれるべきでないためnormalize()前に除去（データ整合性）
+    - Cf: Format文字（Bidi制御, ゼロ幅文字, Word Joiner等）
+    - Cc: 制御文字（C0/C1制御文字, DEL等）
+    - Mn: 非スペーシングマーク（Variation Selectors U+FE00-U+FE0F と
+          Variation Selectors Supplement U+E0100-U+E01EF は個別除去。
+          結合文字 U+0300等は保持し、NFD由来のホスト名改変を避ける）
+    - Zs: Unicode空白（NBSP, Ogham Space, 全角空白等。U+0020通常スペースは
+          Zsカテゴリに属するが、c == " " の特例条件で保持）
+          ※ NFKC正規化前にも除去（U+3000等はNFKC後にU+0020へ変換される副作用を防止。
+          U+1680等はNFKC変換対象外だが一括除去でスキームバイパスを防止）
+    - Zl: 行区切り（U+2028 Line Separator）
+    - Zp: 段落区切り（U+2029 Paragraph Separator）
+
+    Python に同梱の Unicode バージョン内の新規文字に自動対応する。
+    （Unicode バージョン自体の更新には Python バージョンアップが必要）
+    """
+    # パス1: Cs（孤立サロゲート）と不可視文字を一括除去
+    # _STRIP_CATEGORIES = _INVISIBLE_CATEGORIES | {"Cs"} で Cs の個別除去を統合
+    # NFKC前にZs等を除去（NFKC後にU+0020へ変換される副作用防止）
+    # 全角英字（Ll/Lu等）はNFKC前に残し、NFKC正規化でASCIIに変換される
+    pre_filtered = "".join(c for c in v if not _is_strippable_char(c, _STRIP_CATEGORIES))
+    normalized = unicodedata.normalize("NFKC", pre_filtered)
+    # パス2: NFKC後に新たに生成された不可視文字を除去
+    # （Csは再出現しないため_INVISIBLE_CATEGORIESのみ）
+    return "".join(c for c in normalized if not _is_strippable_char(c, _INVISIBLE_CATEGORIES))
+
+
+def sanitize_user_content(value: str) -> str:
+    """ユーザー生成コンテンツをHTMLエスケープでサニタイズ
+
+    XSS攻撃を防ぐため、HTMLエスケープを適用。
+    特殊文字（<, >, &, ", '）をHTMLエンティティに変換。
+
+    Args:
+        value: サニタイズ対象の文字列
+
+    Returns:
+        サニタイズ済み文字列
+
+    Raises:
+        ValueError: value が str 型でない場合
+
+    Note:
+        主にPydantic field_validator経由で使用されます。
+        以前は str | None を受理していたが、現在は str のみ受理する。
+        None を渡した場合は ValueError が発生する。
+
+    Examples:
+        >>> sanitize_user_content("<script>alert('XSS')</script>")
+        '&lt;script&gt;alert(&#x27;XSS&#x27;)&lt;/script&gt;'
+
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"文字列が必要です（受け取った型: {type(value).__name__}）")
+    # quote=True: シングルクォート、ダブルクォートもエスケープ
+    return html.escape(value, quote=True)
+
+
+def _validate_netloc(parsed: ParseResult) -> None:
+    """netloc のバリデーション.
+
+    存在確認・空白文字拒否・不正percent decode拒否・userinfo禁止・
+    HTMLメタ文字拒否・hostname解決チェックを行う。
+    """
+    if not parsed.netloc:
+        raise ValueError("有効なホスト名が含まれていません")
+    # 不正ポート文字列バイパス対策: parsed.port は整数でない場合 ValueError を送出する
+    # （例: https://example.com:abc/path は netloc チェックをパスするが port アクセスで検出）
+    try:
+        _ = parsed.port
+    except ValueError as e:
+        raise ValueError("ポートが無効です（整数値でなければなりません）") from e
+    # 多層防御: parsed.username/password に加え netloc の "@" リテラルも検査
+    # （urlparse が特定のエンコード済み入力で username=None を返すエッジケース対策）
+    try:
+        decoded_netloc = unquote(parsed.netloc, errors="strict")
+    except UnicodeDecodeError as e:
+        raise ValueError(f"URLに不正なパーセントエンコードが含まれています: {e}") from e
+    # raw と decoded 両方をチェック（%エンコードバイパス対策: https://example.com%20evil.com 等）
+    if _ASCII_WHITESPACE_RE.search(parsed.netloc) or _ASCII_WHITESPACE_RE.search(decoded_netloc):
+        raise ValueError("ホスト名に空白文字が含まれています")
+    has_at = "@" in parsed.netloc or "@" in decoded_netloc
+    if has_at:
+        raise ValueError("URLにuserinfo（ユーザー名/パスワード）は指定できません")
+    # @が含まれない場合のみ username/password を確認（urlparseのエッジケース補完）
+    # （urlparse が特定のエンコード済み入力で username=None を返すエッジケース対策）
+    try:
+        has_userinfo = parsed.username is not None or parsed.password is not None
+    except (ValueError, OverflowError) as e:  # fmt: skip
+        # parsed.username/password は内部で独自にunquoteするため、L135-137のチェックとは独立
+        raise ValueError(f"URLのuserinfoパースに失敗しました（netloc={parsed.netloc!r}）") from e
+    if has_userinfo:
+        raise ValueError("URLにuserinfo（ユーザー名/パスワード）は指定できません")
+    # ホスト部にHTMLメタ文字（<, >, ", ', &）が含まれる場合は拒否
+    if _HTML_META_RE.search(parsed.netloc) or _HTML_META_RE.search(decoded_netloc):
+        raise ValueError("ホスト名に不正な文字が含まれています")
+    # hostname が None になるケース（例: 不正な IPv6 形式）を normalize_url に渡す前に排除
+    if not parsed.hostname:
+        raise ValueError("有効なホスト名が含まれていません")
+
+
+def normalize_url(parsed: ParseResult) -> str:
+    """RFC 3986 §6.2.2.1（Case Normalization）に従いスキームとホスト部を小文字正規化する。
+
+    パス・パラメータ・クエリ・フラグメントは RFC 3986 §3.3–§3.5 の構文定義に従い
+    URLエンコードする。§6.2.2.2 の既存 %xx シーケンスのヘックス大文字化は未実施
+    （新規エンコード分は quote() が UPPERCASE で出力する）。
+    """
+    # ParseResultはnamedtupleだが、tuple直接指定でコードの意図を明示する
+    # パス・クエリ・フラグメントのXSS文字をURLエンコード（%を安全文字に含め二重エンコード防止）
+    # RFC 3986 §3.3 pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
+    # XSS防止: ' (single quote) を safe から除外 → %27 にエンコード
+    # &はquery/fragmentでパラメータ区切りとして必要なため保持（HTML出力時は呼び出し元でエスケープ）
+    # -._~ は Python quote() の _ALWAYS_SAFE に含まれるが、RFC 仕様との対応を明示
+    safe_path = quote(parsed.path, safe="/:@!$()*+,;=%-._~")
+    # RFC 3986 §3.3 (params は path の一部として扱う)
+    safe_params = quote(parsed.params, safe=";=@:!$()*+,/%-._~")
+    # RFC 3986 §3.4 query = *( pchar / "/" / "?" )
+    safe_query = quote(parsed.query, safe="=&+:@!$()*,;/?%-._~")
+    # RFC 3986 §3.5 fragment = *( pchar / "/" / "?" )
+    # フラグメントは path/query より "&" と "?" を緩く扱い、unreserved 文字は過剰エンコードしない
+    safe_fragment = quote(parsed.fragment, safe=":@!$&()*+,;=/?%-._~")
+    # hostname は urlparse が自動小文字化済み。netloc.lower() ではなく
+    # hostname + port で再構成し、percent-encoded 文字の大文字16進を保持する
+    hostname = parsed.hostname
+    if not hostname:
+        # _validate_netloc の `not parsed.hostname` で空文字列・None ケースは排除済み
+        # ここは直接呼び出し時のセーフガード（通常パスでは到達しない）
+        raise ValueError(f"ホスト名の解決に失敗しました（netloc={parsed.netloc!r}）")
+    if ":" in hostname:
+        hostname = f"[{hostname}]"
+    netloc = f"{hostname}:{parsed.port}" if parsed.port is not None else hostname
+    return urlunparse(
+        (
+            parsed.scheme.lower(),
+            netloc,
+            safe_path,
+            safe_params,
+            safe_query,
+            safe_fragment,
+        )
+    )
+
+
+def _ensure_website_max_length(url: str) -> str:
+    """正規化後URL長の上限チェック（WEBSITE_NORMALIZED_MAX_LENGTH文字）."""
+    if len(url) > WEBSITE_NORMALIZED_MAX_LENGTH:
+        raise ValueError(
+            f"URL補完後の長さが上限{WEBSITE_NORMALIZED_MAX_LENGTH}文字を超過しています（{len(url)}文字）"
+        )
+    return url
+
+
+def validate_scheme_less_url(sanitized: str) -> None:
+    """スキームなしURLのバリデーション: パーセントエンコード・パス・フラグメント・クエリを検証する。
+
+    Args:
+        sanitized: 前処理済み（不可視文字除去・strip済み）のURL文字列
+
+    Raises:
+        ValueError: 不正なパーセントエンコード、パス、フラグメント、クエリが含まれる場合
+    """
+    # errors='strict': 不正なパーセントエンコードをサイレント置換せず明示的エラーとして扱う
+    try:
+        decoded = unquote(sanitized, errors="strict")
+    except UnicodeDecodeError as e:
+        raise ValueError(f"URLに不正なパーセントエンコードが含まれています: {e}") from e
+    # 不完全な%シーケンス（例: %、%GG）はunquoteがリテラル扱いするため個別チェック
+    if _INCOMPLETE_PCT_RE.search(sanitized):
+        raise ValueError("URLに不完全なパーセントエンコードが含まれています")
+    if "/" in sanitized or "/" in decoded:
+        raise ValueError("スキームなしURLにパスは指定できません")
+    # %23（#）と %3F（?）のバイパス検出: decoded に含まれる#/?も検出
+    if "#" in sanitized or "#" in decoded:
+        raise ValueError("スキームなしURLにフラグメントは指定できません")
+    if "?" in sanitized or "?" in decoded:
+        raise ValueError("スキームなしURLにクエリは指定できません")

--- a/models/sanitization.py
+++ b/models/sanitization.py
@@ -39,28 +39,34 @@ def _is_strippable_char(c: str, categories: frozenset[str]) -> bool:
 
 
 def strip_invisible_chars(v: str) -> str:
-    """不可視文字・制御文字・Unicode空白をURL文字列から除去（NFKC正規化含む2パス処理）
+    """不可視文字・制御文字・Unicode空白をURL文字列から除去する（NFKC正規化を含む2パス処理）。
 
-    URLスキームバイパス防止のため、_STRIP_CATEGORIES（= _INVISIBLE_CATEGORIES | {"Cs"}）
-    に属するUnicodeカテゴリを2パスの内包表記で除去する
-    （パス1: NFKC正規化前・Cs含む全カテゴリ、パス2: NFKC正規化後・Cs除外）:
+    URLスキームバイパス防止のため、``_STRIP_CATEGORIES``（= ``_INVISIBLE_CATEGORIES | {"Cs"}``）
+    に属するUnicodeカテゴリを2パスの内包表記で除去する。パス1はNFKC正規化前にCsを含む全カテゴリを、
+    パス2はNFKC正規化後にCsを除いたカテゴリを除去する。Python に同梱の Unicode バージョン内の
+    新規文字に自動対応する（Unicode バージョン自体の更新には Python バージョンアップが必要）。
 
-    - Cs: Surrogate（孤立サロゲート U+D800-U+DFFF）— 有効なUnicode文字列に
-          含まれるべきでないためnormalize()前に除去（データ整合性）
-    - Cf: Format文字（Bidi制御, ゼロ幅文字, Word Joiner等）
-    - Cc: 制御文字（C0/C1制御文字, DEL等）
-    - Mn: 非スペーシングマーク（Variation Selectors U+FE00-U+FE0F と
-          Variation Selectors Supplement U+E0100-U+E01EF は個別除去。
-          結合文字 U+0300等は保持し、NFD由来のホスト名改変を避ける）
-    - Zs: Unicode空白（NBSP, Ogham Space, 全角空白等。U+0020通常スペースは
-          Zsカテゴリに属するが、c == " " の特例条件で保持）
-          ※ NFKC正規化前にも除去（U+3000等はNFKC後にU+0020へ変換される副作用を防止。
-          U+1680等はNFKC変換対象外だが一括除去でスキームバイパスを防止）
-    - Zl: 行区切り（U+2028 Line Separator）
-    - Zp: 段落区切り（U+2029 Paragraph Separator）
+    除去対象カテゴリ:
+        - Cs: Surrogate（孤立サロゲート U+D800-U+DFFF）。有効なUnicode文字列に含まれるべきで
+          ないため ``normalize()`` 前に除去する（データ整合性）。
+        - Cf: Format文字（Bidi制御, ゼロ幅文字, Word Joiner等）。
+        - Cc: 制御文字（C0/C1制御文字, DEL等）。
+        - Mn: 非スペーシングマーク。Variation Selectors U+FE00-U+FE0F と Variation Selectors
+          Supplement U+E0100-U+E01EF は個別除去し、結合文字 U+0300 等は保持して NFD 由来の
+          ホスト名改変を避ける。
+        - Zs: Unicode空白（NBSP, Ogham Space, 全角空白等）。U+0020 通常スペースは Zs に属するが
+          ``c == " "`` の特例条件で保持する。NFKC正規化前にも除去する（U+3000 等が NFKC 後に
+          U+0020 へ変換される副作用を防止。U+1680 等は NFKC 変換対象外だが一括除去でスキーム
+          バイパスを防止）。
+        - Zl: 行区切り（U+2028 Line Separator）。
+        - Zp: 段落区切り（U+2029 Paragraph Separator）。
 
-    Python に同梱の Unicode バージョン内の新規文字に自動対応する。
-    （Unicode バージョン自体の更新には Python バージョンアップが必要）
+    Args:
+        v: サニタイズ対象の文字列。
+
+    Returns:
+        不可視文字・制御文字・Unicode空白を除去し NFKC 正規化した文字列。
+        U+0020 通常スペースは保持される。
     """
     # パス1: Cs（孤立サロゲート）と不可視文字を一括除去
     # _STRIP_CATEGORIES = _INVISIBLE_CATEGORIES | {"Cs"} で Cs の個別除去を統合
@@ -99,7 +105,7 @@ def sanitize_user_content(value: str) -> str:
 
     """
     if not isinstance(value, str):
-        raise ValueError(f"文字列が必要です（受け取った型: {type(value).__name__}）")
+        raise ValueError(f"String required (received type: {type(value).__name__})")
     # quote=True: シングルクォート、ダブルクォートもエスケープ
     return html.escape(value, quote=True)
 
@@ -111,40 +117,40 @@ def _validate_netloc(parsed: ParseResult) -> None:
     HTMLメタ文字拒否・hostname解決チェックを行う。
     """
     if not parsed.netloc:
-        raise ValueError("有効なホスト名が含まれていません")
+        raise ValueError("Valid hostname not found")
     # 不正ポート文字列バイパス対策: parsed.port は整数でない場合 ValueError を送出する
     # （例: https://example.com:abc/path は netloc チェックをパスするが port アクセスで検出）
     try:
         _ = parsed.port
     except ValueError as e:
-        raise ValueError("ポートが無効です（整数値でなければなりません）") from e
+        raise ValueError("Invalid port (must be an integer)") from e
     # 多層防御: parsed.username/password に加え netloc の "@" リテラルも検査
     # （urlparse が特定のエンコード済み入力で username=None を返すエッジケース対策）
     try:
         decoded_netloc = unquote(parsed.netloc, errors="strict")
     except UnicodeDecodeError as e:
-        raise ValueError(f"URLに不正なパーセントエンコードが含まれています: {e}") from e
+        raise ValueError("URL contains invalid percent-encoding") from e
     # raw と decoded 両方をチェック（%エンコードバイパス対策: https://example.com%20evil.com 等）
     if _ASCII_WHITESPACE_RE.search(parsed.netloc) or _ASCII_WHITESPACE_RE.search(decoded_netloc):
-        raise ValueError("ホスト名に空白文字が含まれています")
+        raise ValueError("Hostname contains whitespace")
     has_at = "@" in parsed.netloc or "@" in decoded_netloc
     if has_at:
-        raise ValueError("URLにuserinfo（ユーザー名/パスワード）は指定できません")
+        raise ValueError("URL cannot contain userinfo (username/password)")
     # @が含まれない場合のみ username/password を確認（urlparseのエッジケース補完）
     # （urlparse が特定のエンコード済み入力で username=None を返すエッジケース対策）
     try:
         has_userinfo = parsed.username is not None or parsed.password is not None
     except (ValueError, OverflowError) as e:  # fmt: skip
         # parsed.username/password は内部で独自にunquoteするため、L135-137のチェックとは独立
-        raise ValueError(f"URLのuserinfoパースに失敗しました（netloc={parsed.netloc!r}）") from e
+        raise ValueError("Failed to parse userinfo from URL") from e
     if has_userinfo:
-        raise ValueError("URLにuserinfo（ユーザー名/パスワード）は指定できません")
+        raise ValueError("URL cannot contain userinfo (username/password)")
     # ホスト部にHTMLメタ文字（<, >, ", ', &）が含まれる場合は拒否
     if _HTML_META_RE.search(parsed.netloc) or _HTML_META_RE.search(decoded_netloc):
-        raise ValueError("ホスト名に不正な文字が含まれています")
+        raise ValueError("Hostname contains invalid characters")
     # hostname が None になるケース（例: 不正な IPv6 形式）を normalize_url に渡す前に排除
     if not parsed.hostname:
-        raise ValueError("有効なホスト名が含まれていません")
+        raise ValueError("Valid hostname not found")
 
 
 def normalize_url(parsed: ParseResult) -> str:
@@ -153,6 +159,16 @@ def normalize_url(parsed: ParseResult) -> str:
     パス・パラメータ・クエリ・フラグメントは RFC 3986 §3.3–§3.5 の構文定義に従い
     URLエンコードする。§6.2.2.2 の既存 %xx シーケンスのヘックス大文字化は未実施
     （新規エンコード分は quote() が UPPERCASE で出力する）。
+
+    Args:
+        parsed: バリデーション済みの urlparse 結果（通常は ``_validate_netloc`` 通過後を渡す）。
+
+    Returns:
+        スキーム・ホスト部を小文字化し、パス以降を URL エンコードした正規化 URL 文字列。
+
+    Raises:
+        ValueError: hostname が解決できない場合（直接呼び出し時のセーフガード。
+            通常パスでは ``_validate_netloc`` が事前に排除する）。
     """
     # ParseResultはnamedtupleだが、tuple直接指定でコードの意図を明示する
     # パス・クエリ・フラグメントのXSS文字をURLエンコード（%を安全文字に含め二重エンコード防止）
@@ -174,7 +190,7 @@ def normalize_url(parsed: ParseResult) -> str:
     if not hostname:
         # _validate_netloc の `not parsed.hostname` で空文字列・None ケースは排除済み
         # ここは直接呼び出し時のセーフガード（通常パスでは到達しない）
-        raise ValueError(f"ホスト名の解決に失敗しました（netloc={parsed.netloc!r}）")
+        raise ValueError("Failed to resolve hostname")
     if ":" in hostname:
         hostname = f"[{hostname}]"
     netloc = f"{hostname}:{parsed.port}" if parsed.port is not None else hostname
@@ -194,7 +210,8 @@ def _ensure_website_max_length(url: str) -> str:
     """正規化後URL長の上限チェック（WEBSITE_NORMALIZED_MAX_LENGTH文字）"""
     if len(url) > WEBSITE_NORMALIZED_MAX_LENGTH:
         raise ValueError(
-            f"URL補完後の長さが上限{WEBSITE_NORMALIZED_MAX_LENGTH}文字を超過しています（{len(url)}文字）"
+            f"URL length after normalization exceeds limit of "
+            f"{WEBSITE_NORMALIZED_MAX_LENGTH} characters ({len(url)} characters)"
         )
     return url
 
@@ -212,14 +229,14 @@ def validate_scheme_less_url(sanitized: str) -> None:
     try:
         decoded = unquote(sanitized, errors="strict")
     except UnicodeDecodeError as e:
-        raise ValueError(f"URLに不正なパーセントエンコードが含まれています: {e}") from e
+        raise ValueError("URL contains invalid percent-encoding") from e
     # 不完全な%シーケンス（例: %、%GG）はunquoteがリテラル扱いするため個別チェック
     if _INCOMPLETE_PCT_RE.search(sanitized):
-        raise ValueError("URLに不完全なパーセントエンコードが含まれています")
+        raise ValueError("URL contains incomplete percent-encoding")
     if "/" in sanitized or "/" in decoded:
-        raise ValueError("スキームなしURLにパスは指定できません")
+        raise ValueError("Scheme-less URL cannot contain a path")
     # %23（#）と %3F（?）のバイパス検出: decoded に含まれる#/?も検出
     if "#" in sanitized or "#" in decoded:
-        raise ValueError("スキームなしURLにフラグメントは指定できません")
+        raise ValueError("Scheme-less URL cannot contain a fragment")
     if "?" in sanitized or "?" in decoded:
-        raise ValueError("スキームなしURLにクエリは指定できません")
+        raise ValueError("Scheme-less URL cannot contain a query")

--- a/tests/unit/test_responses_models.py
+++ b/tests/unit/test_responses_models.py
@@ -12,7 +12,6 @@ from pydantic import BaseModel, ValidationError
 
 import models.responses as responses_module
 from models.responses import (
-    _WEBSITE_NORMALIZED_MAX_LENGTH,  # noqa: PLC2701 - private helper length invariantを直接検証するため
     Address,
     Album,
     Comment,
@@ -22,10 +21,13 @@ from models.responses import (
     Post,
     Todo,
     User,
-    _normalize_url,  # noqa: PLC2701 - private helper length invariantを直接検証するため
-    _strip_invisible_chars,  # noqa: PLC2701 - private sanitizerの挙動を直接検証するため
-    _validate_scheme_less_url,  # noqa: PLC2701 - private validatorのバイパス防止を直接検証するため
+)
+from models.sanitization import (
+    WEBSITE_NORMALIZED_MAX_LENGTH,
+    normalize_url,
     sanitize_user_content,
+    strip_invisible_chars,
+    validate_scheme_less_url,
 )
 from tests.types import (
     _UserData,  # noqa: PLC2701 - test-internal helper naming preserved
@@ -237,21 +239,21 @@ def test_strip_invisible_chars_preserves_ascii_space() -> None:
     """
     # ASCII スペースは保持される
     assert (
-        _strip_invisible_chars("https://example.com/path?a=1 b=2")
+        strip_invisible_chars("https://example.com/path?a=1 b=2")
         == "https://example.com/path?a=1 b=2"
     )
     # NBSP (U+00A0: Zs) はNFKC前に除去される（NFKC変換前にZsフィルタが適用されるため）
-    assert _strip_invisible_chars("https://\u00a0example.com") == "https://example.com"
+    assert strip_invisible_chars("https://\u00a0example.com") == "https://example.com"
     # 全角スペース (U+3000: Zs) はNFKC前に除去される
-    assert _strip_invisible_chars("https://\u3000example.com") == "https://example.com"
+    assert strip_invisible_chars("https://\u3000example.com") == "https://example.com"
     # Variation Selector-1 (U+FE00) は除去される
-    assert _strip_invisible_chars("java\ufe00script:alert(1)") == "javascript:alert(1)"
+    assert strip_invisible_chars("java\ufe00script:alert(1)") == "javascript:alert(1)"
     # Variation Selector Supplement (U+E0100) も除去される
-    assert _strip_invisible_chars("java\U000e0100script:alert(1)") == "javascript:alert(1)"
+    assert strip_invisible_chars("java\U000e0100script:alert(1)") == "javascript:alert(1)"
     # Line Separator (U+2028: Zl) は除去される
-    assert _strip_invisible_chars("java\u2028script:alert(1)") == "javascript:alert(1)"
+    assert strip_invisible_chars("java\u2028script:alert(1)") == "javascript:alert(1)"
     # Paragraph Separator (U+2029: Zp) は除去される
-    assert _strip_invisible_chars("java\u2029script:alert(1)") == "javascript:alert(1)"
+    assert strip_invisible_chars("java\u2029script:alert(1)") == "javascript:alert(1)"
 
 
 def test_strip_invisible_chars_removes_surrogate_codepoint() -> None:
@@ -261,39 +263,39 @@ def test_strip_invisible_chars_removes_surrogate_codepoint() -> None:
     送出するため、事前除去が必要。
     """
     # 孤立サロゲートが除去され、残りの文字列が返される
-    assert _strip_invisible_chars("https://\ud800example.com") == "https://example.com"
+    assert strip_invisible_chars("https://\ud800example.com") == "https://example.com"
     # サロゲートのみの入力は空文字列になる
-    assert _strip_invisible_chars("\ud800\udbff\udfff") == ""
+    assert strip_invisible_chars("\ud800\udbff\udfff") == ""
     # サロゲートが混在しても正常な文字は保持される
-    assert _strip_invisible_chars("abc\ud800def") == "abcdef"
+    assert strip_invisible_chars("abc\ud800def") == "abcdef"
 
 
 def test_strip_invisible_chars_returns_empty_for_empty_input() -> None:
     """_strip_invisible_chars に空文字列を渡すと空文字列が返ること。"""
-    assert _strip_invisible_chars("") == ""
+    assert strip_invisible_chars("") == ""
 
 
 def test_strip_invisible_chars_strips_zero_width_space() -> None:
     """ゼロ幅スペース(U+200B, Cf)を除去すること"""
-    result = _strip_invisible_chars("exam\u200bple.com")
+    result = strip_invisible_chars("exam\u200bple.com")
     assert result == "example.com"
 
 
 def test_strip_invisible_chars_strips_bidi_override() -> None:
     """Bidi制御文字(U+202E, Cf)を除去すること"""
-    result = _strip_invisible_chars("exam\u202eple.com")
+    result = strip_invisible_chars("exam\u202eple.com")
     assert result == "example.com"
 
 
 def test_strip_invisible_chars_preserves_regular_space() -> None:
     """通常スペース(U+0020)は保持すること"""
-    result = _strip_invisible_chars("hello world")
+    result = strip_invisible_chars("hello world")
     assert result == "hello world"
 
 
 def test_strip_invisible_chars_preserves_combining_mark() -> None:
     """結合文字は保持され、NFD由来のホスト名をサイレントに改変しないこと。"""
-    result = _strip_invisible_chars("cafe\u0301.com")
+    result = strip_invisible_chars("cafe\u0301.com")
     assert result == "café.com"
 
 
@@ -669,8 +671,8 @@ class TestUserModel:
         )
 
     def test_user_website_max_length_boundary(self, valid_user_data: _UserData) -> None:
-        """website の正規化後URL長 _WEBSITE_NORMALIZED_MAX_LENGTH(2048) 境界値テスト."""
-        max_len = _WEBSITE_NORMALIZED_MAX_LENGTH  # 2048
+        """website の正規化後URL長 WEBSITE_NORMALIZED_MAX_LENGTH(2048) 境界値テスト."""
+        max_len = WEBSITE_NORMALIZED_MAX_LENGTH  # 2048
         base = "https://example.com/"
         # ちょうど max_len 文字: 正常
         path = "a" * (max_len - len(base))
@@ -1894,7 +1896,7 @@ class TestPhotoModel:
         難読化スキーム拒否テストは「http以外」の catch-all で弾くため、不可視文字が実際に
         除去されたかを判別できない（除去が壊れても非httpとして拒否され緑のまま）。本テストは
         正規httpURLに不可視文字を埋め込み、除去後に等価な正規URLへ正規化されることを表明し、
-        _strip_invisible_chars の各カテゴリ除去ロジックの回帰を直接検出する。
+        strip_invisible_chars の各カテゴリ除去ロジックの回帰を直接検出する。
         """
         photo = Photo(
             album_id=1,
@@ -1910,7 +1912,7 @@ class TestPhotoModel:
 
         Note:
             Pydanticはfield_validator呼び出し前にstring_unicodeエラーで拒否する。
-            _strip_invisible_charsのサロゲート除去は直接文字列呼び出し時に機能する。
+            strip_invisible_charsのサロゲート除去は直接文字列呼び出し時に機能する。
         """
         with pytest.raises(ValidationError, match=re.escape("string_unicode")):
             Photo(
@@ -1924,7 +1926,7 @@ class TestPhotoModel:
     def test_photo_url_rejects_empty_string(self) -> None:
         """Photo.url に空文字列を渡すと ValidationError が発生すること。
 
-        min_length 制約がないため、空文字列は _strip_invisible_chars → .strip() を通過後
+        min_length 制約がないため、空文字列は strip_invisible_chars → .strip() を通過後
         validate_url_scheme のガード節（if not sanitized）に到達する。
         """
         with pytest.raises(ValidationError, match=re.escape("URLが空になりました")):
@@ -1998,7 +2000,7 @@ class TestPhotoModel:
         }
         with pytest.raises(
             ValidationError,
-            match=rf"URL補完後の長さが上限{_WEBSITE_NORMALIZED_MAX_LENGTH}文字を超過しています",
+            match=rf"URL補完後の長さが上限{WEBSITE_NORMALIZED_MAX_LENGTH}文字を超過しています",
         ):
             Photo.model_validate(photo_data)
 
@@ -2033,33 +2035,33 @@ class TestNormalizeUrl:
 
     def test_basic_normalization(self) -> None:
         """スキームとホストの小文字正規化"""
-        result = _normalize_url(urlparse("HTTPS://EXAMPLE.COM/Path"))
+        result = normalize_url(urlparse("HTTPS://EXAMPLE.COM/Path"))
         assert result == "https://example.com/Path"
 
     def test_ipv6_bracket_preservation(self) -> None:
         """IPv6アドレスのブラケット復元"""
-        result = _normalize_url(urlparse("https://[::1]:8080/path"))
+        result = normalize_url(urlparse("https://[::1]:8080/path"))
         assert result == "https://[::1]:8080/path"
 
     def test_safe_params_encoding(self) -> None:
         """RFC 3986 §3.3 パラメータ部のエンコード"""
-        result = _normalize_url(urlparse("https://example.com/path;type=pdf"))
+        result = normalize_url(urlparse("https://example.com/path;type=pdf"))
         assert ";type=pdf" in result
 
     def test_fragment_preserves_unreserved(self) -> None:
         """フラグメントのunreserved文字（._~）が過剰エンコードされないこと"""
-        result = _normalize_url(urlparse("https://example.com/page#section_1.2~draft"))
+        result = normalize_url(urlparse("https://example.com/page#section_1.2~draft"))
         assert result.endswith("#section_1.2~draft")
 
     def test_existing_percent_encoding_preserved(self) -> None:
         """既存の%エンコードが二重エンコードされないこと"""
-        result = _normalize_url(urlparse("https://example.com/path%20name"))
+        result = normalize_url(urlparse("https://example.com/path%20name"))
         assert "%20" in result
         assert "%2520" not in result  # 二重エンコード防止
 
     def test_single_quote_encoded_to_percent27(self) -> None:
         """シングルクォートがXSS防止のため%27にエンコードされること（RFC 3986 safe除外）"""
-        result = _normalize_url(urlparse("https://example.com/path/file'.jpg"))
+        result = normalize_url(urlparse("https://example.com/path/file'.jpg"))
         assert "%27" in result
         assert "'" not in result.split("//", 1)[1]  # ホスト以降にシングルクォートなし
 
@@ -2068,7 +2070,7 @@ class TestNormalizeUrl:
         parsed = urlparse("https://:8080/path")
         assert parsed.hostname is None, "前提条件: hostname が None であること"
         with pytest.raises(ValueError, match=re.escape("ホスト名の解決に失敗しました")):
-            _normalize_url(parsed)
+            normalize_url(parsed)
 
 
 class TestValidateSchemeLessUrl:
@@ -2079,26 +2081,26 @@ class TestValidateSchemeLessUrl:
     def test_rejects_incomplete_percent_encoding(self) -> None:
         """不完全なパーセントエンコード（%GG等）を拒否すること"""
         with pytest.raises(ValueError, match=re.escape("不完全なパーセントエンコード")):
-            _validate_scheme_less_url("example%GG.com")
+            validate_scheme_less_url("example%GG.com")
 
     def test_rejects_path_separator(self) -> None:
         """パス区切り（/）を含むURLを拒否すること"""
         with pytest.raises(ValueError, match=re.escape("パス")):
-            _validate_scheme_less_url("example.com/path")
+            validate_scheme_less_url("example.com/path")
 
     def test_rejects_fragment(self) -> None:
         """フラグメント（#）を含むURLを拒否すること"""
         with pytest.raises(ValueError, match=re.escape("フラグメント")):
-            _validate_scheme_less_url("example.com#section")
+            validate_scheme_less_url("example.com#section")
 
     def test_rejects_query(self) -> None:
         """クエリ（?）を含むURLを拒否すること"""
         with pytest.raises(ValueError, match=re.escape("クエリ")):
-            _validate_scheme_less_url("example.com?key=val")
+            validate_scheme_less_url("example.com?key=val")
 
     def test_accepts_valid_domain(self) -> None:
         """有効なドメイン名はエラーなしで通過すること"""
-        _validate_scheme_less_url("example.com")  # 例外なし = 成功
+        validate_scheme_less_url("example.com")  # 例外なし = 成功
 
 
 class TestExtraFieldsForbidden:

--- a/tests/unit/test_responses_models.py
+++ b/tests/unit/test_responses_models.py
@@ -227,7 +227,7 @@ class TestSanitizeUserContent:
             Pydantic field_validator は ValueError/AssertionError のみ
             ValidationError に変換するため、明示的に ValueError を raise する。
         """
-        with pytest.raises(ValueError, match=re.escape("文字列が必要です")):
+        with pytest.raises(ValueError, match=re.escape("String required")):
             sanitize_user_content(None)  # type: ignore[arg-type]
 
 
@@ -687,13 +687,13 @@ class TestUserModel:
         valid_user_data["website"] = schemeless
         with pytest.raises(
             ValidationError,
-            match=rf"URL補完後の長さが上限{max_len}文字を超過しています",
+            match=r"URL length after normalization exceeds limit",
         ):
             User(**valid_user_data)
 
         # max_len + 1 文字: ValidationError
         valid_user_data["website"] = base + "a" * (max_len + 1 - len(base))
-        with pytest.raises(ValidationError, match=r"URL補完後の長さが上限"):
+        with pytest.raises(ValidationError, match=r"URL length after normalization exceeds limit"):
             User(**valid_user_data)
 
     def test_user_website_is_not_html_escaped(self, valid_user_data: _UserData) -> None:
@@ -706,146 +706,142 @@ class TestUserModel:
     @pytest.mark.parametrize(
         ("dangerous_url", "expected_match"),
         [
-            pytest.param("javascript:alert(1)", "危険なURLスキームが検出されました", id="js_basic"),
-            pytest.param(
-                "JAVASCRIPT:alert(1)", "危険なURLスキームが検出されました", id="js_uppercase"
-            ),
-            pytest.param("javascript:void(0)", "危険なURLスキームが検出されました", id="js_void"),
+            pytest.param("javascript:alert(1)", "Dangerous URL scheme detected", id="js_basic"),
+            pytest.param("JAVASCRIPT:alert(1)", "Dangerous URL scheme detected", id="js_uppercase"),
+            pytest.param("javascript:void(0)", "Dangerous URL scheme detected", id="js_void"),
             pytest.param(
                 "data:text/html,<script>alert(1)</script>",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="data_html",
             ),
             pytest.param(
-                "Data:image/png;base64,abc", "危険なURLスキームが検出されました", id="data_image"
+                "Data:image/png;base64,abc", "Dangerous URL scheme detected", id="data_image"
             ),
-            pytest.param("vbscript:msgbox(1)", "危険なURLスキームが検出されました", id="vbscript"),
+            pytest.param("vbscript:msgbox(1)", "Dangerous URL scheme detected", id="vbscript"),
             pytest.param(
-                " javascript:alert(1)", "危険なURLスキームが検出されました", id="js_leading_space"
+                " javascript:alert(1)", "Dangerous URL scheme detected", id="js_leading_space"
             ),
             pytest.param(
-                "\tjavascript:void(0)", "危険なURLスキームが検出されました", id="js_leading_tab"
+                "\tjavascript:void(0)", "Dangerous URL scheme detected", id="js_leading_tab"
             ),
             pytest.param(
                 "\u200bjavascript:alert(1)",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="js_zwsp_prefix",
             ),
             pytest.param(
                 "java\u200bscript:alert(1)",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="js_zwsp_mid_scheme",
             ),
             pytest.param(
                 "\u202ejavascript:alert(1)",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="js_bidi_override",
             ),
             pytest.param(
                 "j\u00a0avascript:alert(1)",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="js_nbsp_mid_scheme",
             ),
             pytest.param(
                 "\u2060javascript:alert(1)",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="js_word_joiner_prefix",
             ),
             pytest.param(
-                "\u2066javascript:alert(1)", "危険なURLスキームが検出されました", id="js_lri_prefix"
+                "\u2066javascript:alert(1)", "Dangerous URL scheme detected", id="js_lri_prefix"
             ),
             pytest.param(
-                "\u2069javascript:alert(1)", "危険なURLスキームが検出されました", id="js_pdi_prefix"
+                "\u2069javascript:alert(1)", "Dangerous URL scheme detected", id="js_pdi_prefix"
             ),
             pytest.param(
                 "vbs\u200bcript:msgbox(1)",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="vbscript_zwsp_mid",
             ),
             pytest.param(
-                "da\u200bta:text/html,x", "危険なURLスキームが検出されました", id="data_zwsp_mid"
+                "da\u200bta:text/html,x", "Dangerous URL scheme detected", id="data_zwsp_mid"
             ),
             pytest.param(
                 "vbscript\u202e:msgbox(1)",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="vbscript_bidi_override",
             ),
             pytest.param(
                 "da\u200bta:image/png;base64,abc",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="data_zwsp_mid_image",
             ),
             pytest.param(
                 "java\u2028script:alert(1)",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="js_line_separator_mid",
             ),
             pytest.param(
                 "java\u2029script:alert(1)",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="js_paragraph_separator_mid",
             ),
-            pytest.param("ftp://evil.com", "危険なURLスキームが検出されました", id="ftp_scheme"),
+            pytest.param("ftp://evil.com", "Dangerous URL scheme detected", id="ftp_scheme"),
+            pytest.param("file:///etc/passwd", "Dangerous URL scheme detected", id="file_scheme"),
             pytest.param(
-                "file:///etc/passwd", "危険なURLスキームが検出されました", id="file_scheme"
+                "blob:https://evil.com/uuid", "Dangerous URL scheme detected", id="blob_scheme"
             ),
             pytest.param(
-                "blob:https://evil.com/uuid", "危険なURLスキームが検出されました", id="blob_scheme"
-            ),
-            pytest.param(
-                "javascript:0", "危険なURLスキームが検出されました", id="js_digit_after_colon"
+                "javascript:0", "Dangerous URL scheme detected", id="js_digit_after_colon"
             ),
             pytest.param(
                 "javascript:1+1",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="js_expression_after_colon",
             ),
             pytest.param(
-                "malicious.js:xyz", "危険なURLスキームが検出されました", id="dotted_scheme_non_port"
+                "malicious.js:xyz", "Dangerous URL scheme detected", id="dotted_scheme_non_port"
             ),
             pytest.param(
                 "a.b:evil",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="dotted_scheme_alpha_after_colon",
             ),
             # domain:portはRFC 3986スキーム正規表現(_SCHEME_RE)にマッチするため
             # 「危険なスキーム」パスに到達する（IPアドレスの場合はマッチしない）
             pytest.param(
-                "example.com:8080", "危険なURLスキームが検出されました", id="domain_port_no_scheme"
+                "example.com:8080", "Dangerous URL scheme detected", id="domain_port_no_scheme"
             ),
             pytest.param(
                 "sub.domain.com:443/path",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="subdomain_port_path_no_scheme",
             ),
             pytest.param(
                 "example.com:8080/path?query=1",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="domain_port_path_query_no_scheme",
             ),
             pytest.param(
                 "192.168.1.1:8080",
-                "スキームなしURLにポートは指定できません",
+                "Scheme-less URL cannot contain a port",
                 id="ip_port_no_scheme",
             ),
             pytest.param(
                 "10.0.0.1:3000/api",
-                "スキームなしURLにパスは指定できません",
+                "Scheme-less URL cannot contain a path",
                 id="ip_port_path_no_scheme",
             ),
             pytest.param(
                 "/path/only",
-                "スキームなしURLにパスは指定できません",
+                "Scheme-less URL cannot contain a path",
                 id="path_only_no_host",
             ),
             pytest.param(
                 "java\ufe00script:alert(1)",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="js_variation_selector_mn_bypass",
             ),
             pytest.param(
                 "java\U000e0100script:alert(1)",
-                "危険なURLスキームが検出されました",
+                "Dangerous URL scheme detected",
                 id="js_variation_selector_supplement_mn_bypass",
             ),
         ],
@@ -862,7 +858,7 @@ class TestUserModel:
         """User.website がプロトコル相対URLを明示的なエラーで拒否すること"""
         valid_user_data["website"] = "//cdn.example.com/image.jpg"
         with pytest.raises(
-            ValidationError, match=re.escape("プロトコル相対URLは許可されていません")
+            ValidationError, match=re.escape("Protocol-relative URLs are not allowed")
         ):
             User(**valid_user_data)
 
@@ -871,7 +867,7 @@ class TestUserModel:
     ) -> None:
         """全角文字によるスキームバイパスがNFKC正規化で検出されること"""
         valid_user_data["website"] = "ｊａｖａｓｃｒｉｐｔ:alert(1)"
-        with pytest.raises(ValidationError, match=re.escape("危険なURLスキームが検出されました")):
+        with pytest.raises(ValidationError, match=re.escape("Dangerous URL scheme detected")):
             User(**valid_user_data)
 
     @pytest.mark.parametrize(
@@ -886,7 +882,7 @@ class TestUserModel:
     ) -> None:
         """User.website が空のnetlocを拒否すること"""
         valid_user_data["website"] = empty_netloc_url
-        with pytest.raises(ValidationError, match=re.escape("有効なホスト名が含まれていません")):
+        with pytest.raises(ValidationError, match=re.escape("Valid hostname not found")):
             User(**valid_user_data)
 
     @pytest.mark.parametrize(
@@ -901,7 +897,7 @@ class TestUserModel:
     ) -> None:
         """User.website がホスト部のASCII空白を拒否すること."""
         valid_user_data["website"] = invalid_host_url
-        with pytest.raises(ValidationError, match=re.escape("ホスト名に空白文字が含まれています")):
+        with pytest.raises(ValidationError, match=re.escape("Hostname contains whitespace")):
             User(**valid_user_data)
 
     def test_user_website_wraps_overflowerror_in_validationerror(
@@ -939,7 +935,7 @@ class TestUserModel:
         monkeypatch.setattr(responses_module, "urlparse", fake_urlparse)
         valid_user_data["website"] = "https://example.com"
 
-        with pytest.raises(ValidationError, match=re.escape("URLのuserinfoパースに失敗しました")):
+        with pytest.raises(ValidationError, match=re.escape("Failed to parse userinfo from URL")):
             User(**valid_user_data)
 
     @pytest.mark.parametrize(
@@ -947,57 +943,57 @@ class TestUserModel:
         [
             pytest.param(
                 "https://example.com:abc/",
-                "ポートが無効",
+                "Invalid port",
                 id="invalid_port_string",
             ),
             pytest.param(
                 "%0d%0aevil.com",
-                "パーセントエンコードされた制御文字",
+                "percent-encoded control characters",
                 id="percent_encoded_crlf_injection",
             ),
             pytest.param(
                 "%0d%0a//evil.com",
-                "パーセントエンコードされた制御文字",
+                "percent-encoded control characters",
                 id="percent_encoded_crlf_slash_bypass",
             ),
             pytest.param(
                 "%7f",
-                "パーセントエンコードされた制御文字",
+                "percent-encoded control characters",
                 id="percent_encoded_del_character",
             ),
             pytest.param(
                 "%2f%2fevil.com",
-                "スキームなしURLにパスは指定できません",
+                "Scheme-less URL cannot contain a path",
                 id="percent_encoded_slash_bypass",
             ),
             pytest.param(
                 "example.com/path",
-                "スキームなしURLにパスは指定できません",
+                "Scheme-less URL cannot contain a path",
                 id="schemeless_with_path",
             ),
             pytest.param(
                 "example.com%2Fpath",
-                "スキームなしURLにパスは指定できません",
+                "Scheme-less URL cannot contain a path",
                 id="schemeless_with_encoded_path",
             ),
             pytest.param(
                 "https://evil<script>xss</script>.example.com/path",
-                "ホスト名に不正な文字が含まれています",
+                "Hostname contains invalid characters",
                 id="xss_metachar_in_netloc",
             ),
             pytest.param(
                 "Example.COM/path",
-                "スキームなしURLにパスは指定できません",
+                "Scheme-less URL cannot contain a path",
                 id="schemeless_uppercase_host_with_path",
             ),
             pytest.param(
                 "https://example.com%80",
-                "不正なパーセントエンコード",
+                "invalid percent-encoding",
                 id="invalid_utf8_percent_encoding_https",
             ),
             pytest.param(
                 "example.com%80",
-                "不正なパーセントエンコード",
+                "invalid percent-encoding",
                 id="invalid_utf8_percent_encoding",
             ),
         ],
@@ -1023,7 +1019,7 @@ class TestUserModel:
     ) -> None:
         """User.website が非文字列入力を拒否すること"""
         valid_user_data["website"] = non_str_input  # type: ignore[typeddict-item]
-        with pytest.raises(ValidationError, match=re.escape("文字列が必要です")):
+        with pytest.raises(ValidationError, match=re.escape("String required")):
             User(**valid_user_data)
 
     @pytest.mark.parametrize(
@@ -1116,7 +1112,7 @@ class TestUserModel:
     ) -> None:
         """制御文字のみのwebsiteはサニタイズ後に空文字列となりValidationErrorになること"""
         valid_user_data["website"] = control_only
-        with pytest.raises(ValidationError, match=re.escape("websiteが空になりました")):
+        with pytest.raises(ValidationError, match=re.escape("Website became empty")):
             User(**valid_user_data)
 
     @pytest.mark.parametrize(
@@ -1141,7 +1137,7 @@ class TestUserModel:
     ) -> None:
         """User.website がuserinfo付きURLを拒否すること（RFC 3986 userinfoバイパス防止）"""
         valid_user_data["website"] = userinfo_url
-        with pytest.raises(ValidationError, match=re.escape("URLにuserinfo")):
+        with pytest.raises(ValidationError, match=re.escape("URL cannot contain userinfo")):
             User(**valid_user_data)
 
     @pytest.mark.parametrize(
@@ -1201,7 +1197,26 @@ class TestUserModel:
         URLにuserinfoが含まれると判定しValidationErrorを発生させる。
         """
         valid_user_data["website"] = "https://user%40evil.com@host.example.com"
-        with pytest.raises(ValidationError, match=re.escape("URLにuserinfo")):
+        with pytest.raises(ValidationError, match=re.escape("URL cannot contain userinfo")):
+            User(**valid_user_data)
+
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            pytest.param("http://example.com/%GG", id="incomplete_pct_gg"),
+            pytest.param("http://example.com/path%", id="incomplete_pct_bare"),
+        ],
+    )
+    def test_user_website_rejects_incomplete_percent_encoding(
+        self, valid_user_data: _UserData, bad_url: str
+    ) -> None:
+        """不完全なパーセントエンコード（%GG・末尾%等）を含むURLを拒否すること.
+
+        %GG・末尾の裸%はいずれも_PERCENT_CTRL_RE（制御文字検出）にはマッチしないが、
+        _INCOMPLETE_PCT_RE（不完全%シーケンス検出）にマッチしValidationErrorを送出する。
+        """
+        valid_user_data["website"] = bad_url
+        with pytest.raises(ValidationError, match=re.escape("incomplete percent-encoding")):
             User(**valid_user_data)
 
 
@@ -1584,7 +1599,7 @@ class TestPhotoModel:
                 thumbnail_url="https://example.com/thumb.jpg",
             )
 
-        assert "URLはhttp://またはhttps://で始まる必要があります" in str(exc_info.value)
+        assert "URL must start with http:// or https://" in str(exc_info.value)
 
     def test_photo_rejects_data_url(self) -> None:
         """Photo モデルが data: スキームを拒否することを確認"""
@@ -1597,12 +1612,12 @@ class TestPhotoModel:
                 thumbnail_url="data:image/png;base64,iVBORw0KGgo=",
             )
 
-        assert "URLはhttp://またはhttps://で始まる必要があります" in str(exc_info.value)
+        assert "URL must start with http:// or https://" in str(exc_info.value)
 
     def test_photo_rejects_schemeless_url(self) -> None:
         """Photo.url がスキームなしURLを拒否すること"""
         with pytest.raises(
-            ValidationError, match=re.escape("URLはhttp://またはhttps://で始まる必要があります")
+            ValidationError, match=re.escape("URL must start with http:// or https://")
         ):
             Photo(
                 album_id=1,
@@ -1615,7 +1630,7 @@ class TestPhotoModel:
     def test_photo_rejects_schemeless_thumbnail_url(self) -> None:
         """Photo.thumbnail_url がスキームなしURLを拒否すること"""
         with pytest.raises(
-            ValidationError, match=re.escape("URLはhttp://またはhttps://で始まる必要があります")
+            ValidationError, match=re.escape("URL must start with http:// or https://")
         ):
             Photo(
                 album_id=1,
@@ -1631,19 +1646,19 @@ class TestPhotoModel:
             pytest.param(
                 "https://evil.com%0d%0aInjected",
                 "https://example.com/thumb.jpg",
-                "パーセントエンコードされた制御文字",
+                "percent-encoded control characters",
                 id="crlf_in_url",
             ),
             pytest.param(
                 "https://example.com/photo.jpg",
                 "https://evil.com%0aInjected",
-                "パーセントエンコードされた制御文字",
+                "percent-encoded control characters",
                 id="lf_in_thumbnail",
             ),
             pytest.param(
                 "https://example.com%0D%0A/photo.jpg",
                 "https://example.com/thumb.jpg",
-                "パーセントエンコードされた制御文字",
+                "percent-encoded control characters",
                 id="uppercase_crlf_in_url",
             ),
         ],
@@ -1669,7 +1684,7 @@ class TestPhotoModel:
     )
     def test_photo_rejects_incomplete_percent_encoding(self, field_key: str, bad_url: str) -> None:
         """Photo url/thumbnail_url が不完全なパーセントエンコードを拒否すること."""
-        with pytest.raises(ValidationError, match=re.escape("不完全なパーセントエンコード")):
+        with pytest.raises(ValidationError, match=re.escape("incomplete percent-encoding")):
             Photo.model_validate({**_PHOTO_BASE, field_key: bad_url})
 
     @pytest.mark.parametrize(
@@ -1689,7 +1704,7 @@ class TestPhotoModel:
     )
     def test_photo_rejects_control_char_only_url_fields(self, url: str, thumbnail_url: str) -> None:
         """制御文字のみのPhoto url/thumbnail_urlが空文字エラーで拒否されること"""
-        with pytest.raises(ValidationError, match=re.escape("URLが空になりました")):
+        with pytest.raises(ValidationError, match=re.escape("URL became empty")):
             Photo(album_id=1, id=1, title="Test", url=url, thumbnail_url=thumbnail_url)
 
     @pytest.mark.parametrize(
@@ -1702,7 +1717,7 @@ class TestPhotoModel:
     )
     def test_photo_url_rejects_empty_netloc(self, url: str) -> None:
         """Photo.url に netloc 空の URL が渡されたとき ValidationError を発生させること"""
-        with pytest.raises(ValidationError, match=re.escape("有効なホスト名が含まれていません")):
+        with pytest.raises(ValidationError, match=re.escape("Valid hostname not found")):
             Photo(
                 album_id=1,
                 id=1,
@@ -1720,7 +1735,7 @@ class TestPhotoModel:
     )
     def test_photo_thumbnail_url_rejects_empty_netloc(self, thumbnail_url: str) -> None:
         """Photo.thumbnail_url に netloc 空の URL が渡されたとき ValidationError を発生させること"""
-        with pytest.raises(ValidationError, match=re.escape("有効なホスト名が含まれていません")):
+        with pytest.raises(ValidationError, match=re.escape("Valid hostname not found")):
             Photo(
                 album_id=1,
                 id=1,
@@ -1733,7 +1748,7 @@ class TestPhotoModel:
     def test_photo_rejects_ascii_whitespace_in_host(self, field_name: str) -> None:
         """Photo の URL フィールドがホスト部のASCII空白を拒否すること."""
         key = "url" if field_name == "url" else "thumbnailUrl"
-        with pytest.raises(ValidationError, match=re.escape("ホスト名に空白文字が含まれています")):
+        with pytest.raises(ValidationError, match=re.escape("Hostname contains whitespace")):
             Photo.model_validate({**_PHOTO_BASE, key: "https://example .com/photo.jpg"})
 
     @pytest.mark.parametrize(
@@ -1749,7 +1764,7 @@ class TestPhotoModel:
     )
     def test_photo_url_rejects_userinfo(self, url: str) -> None:
         """Photo.url にuserinfo付きURLが渡されたとき ValidationError を発生させること"""
-        with pytest.raises(ValidationError, match=re.escape("URLにuserinfo")):
+        with pytest.raises(ValidationError, match=re.escape("URL cannot contain userinfo")):
             Photo(
                 album_id=1,
                 id=1,
@@ -1777,7 +1792,7 @@ class TestPhotoModel:
     )
     def test_photo_thumbnail_url_rejects_userinfo(self, thumbnail_url: str) -> None:
         """Photo.thumbnail_urlがuserinfo付きURLを拒否すること（RFC 3986バイパス防止）"""
-        with pytest.raises(ValidationError, match=re.escape("URLにuserinfo")):
+        with pytest.raises(ValidationError, match=re.escape("URL cannot contain userinfo")):
             Photo(
                 album_id=1,
                 id=1,
@@ -1803,7 +1818,7 @@ class TestPhotoModel:
     )
     def test_photo_rejects_invalid_port(self, url: str, thumbnail_url: str) -> None:
         """Photo url/thumbnail_url が無効なポート文字列を拒否すること"""
-        with pytest.raises(ValidationError, match=re.escape("ポートが無効")):
+        with pytest.raises(ValidationError, match=re.escape("Invalid port")):
             Photo(album_id=1, id=1, title="Test", url=url, thumbnail_url=thumbnail_url)
 
     # Photo URL危険ペイロード共通定数（両フィールド同一バリデータ共有のため再利用）
@@ -1837,7 +1852,7 @@ class TestPhotoModel:
         thumbnail_url 側は alias バインド確認のみ別テストで実施（保守性・二重メンテ防止）。
         """
         with pytest.raises(
-            ValidationError, match=re.escape("URLはhttp://またはhttps://で始まる必要があります")
+            ValidationError, match=re.escape("URL must start with http:// or https://")
         ):
             Photo(
                 album_id=1,
@@ -1863,7 +1878,7 @@ class TestPhotoModel:
         バリデータロジック検証は test_photo_url_rejects_invisible_char_dangerous_scheme に委譲。
         """
         with pytest.raises(
-            ValidationError, match=re.escape("URLはhttp://またはhttps://で始まる必要があります")
+            ValidationError, match=re.escape("URL must start with http:// or https://")
         ):
             # model_validate で外部入力（alias 名を含む辞書）をシミュレート
             Photo.model_validate(
@@ -1929,7 +1944,7 @@ class TestPhotoModel:
         min_length 制約がないため、空文字列は strip_invisible_chars → .strip() を通過後
         validate_url_scheme のガード節（if not sanitized）に到達する。
         """
-        with pytest.raises(ValidationError, match=re.escape("URLが空になりました")):
+        with pytest.raises(ValidationError, match=re.escape("URL became empty")):
             Photo(
                 album_id=1,
                 id=1,
@@ -1948,7 +1963,7 @@ class TestPhotoModel:
 
     def test_photo_thumbnail_url_rejects_empty_string(self) -> None:
         """Photo.thumbnail_url に空文字列を渡すと ValidationError が発生すること。"""
-        with pytest.raises(ValidationError, match=re.escape("URLが空になりました")):
+        with pytest.raises(ValidationError, match=re.escape("URL became empty")):
             Photo(
                 album_id=1,
                 id=1,
@@ -2000,7 +2015,7 @@ class TestPhotoModel:
         }
         with pytest.raises(
             ValidationError,
-            match=rf"URL補完後の長さが上限{WEBSITE_NORMALIZED_MAX_LENGTH}文字を超過しています",
+            match=r"URL length after normalization exceeds limit",
         ):
             Photo.model_validate(photo_data)
 
@@ -2010,7 +2025,7 @@ class TestPhotoModel:
         urlparse は "user%40evil.com@host.example.com" をuserinfoとして解析するため、
         URLにuserinfoが含まれると判定しValidationErrorを発生させる。
         """
-        with pytest.raises(ValidationError, match=re.escape("URLにuserinfo")):
+        with pytest.raises(ValidationError, match=re.escape("URL cannot contain userinfo")):
             Photo(**{**_PHOTO_BASE, "url": "https://user%40evil.com@host.example.com/path.jpg"})
 
     def test_photo_url_rejects_percent_encoded_at_in_host(self) -> None:
@@ -2024,7 +2039,7 @@ class TestPhotoModel:
 
     def test_photo_url_rejects_invalid_percent_encoding(self) -> None:
         """不正なパーセントエンコード（UTF-8として無効）をネットロック部に含むURLを拒否すること"""
-        with pytest.raises(ValidationError, match=re.escape("パーセントエンコード")):
+        with pytest.raises(ValidationError, match=re.escape("percent-encod")):
             Photo(**{**_PHOTO_BASE, "url": "https://exam%80ple.com/path.jpg"})
 
 
@@ -2069,7 +2084,7 @@ class TestNormalizeUrl:
         """hostname=None（netloc=':8080'）で ValueError が発生すること"""
         parsed = urlparse("https://:8080/path")
         assert parsed.hostname is None, "前提条件: hostname が None であること"
-        with pytest.raises(ValueError, match=re.escape("ホスト名の解決に失敗しました")):
+        with pytest.raises(ValueError, match=re.escape("Failed to resolve hostname")):
             normalize_url(parsed)
 
 
@@ -2080,22 +2095,22 @@ class TestValidateSchemeLessUrl:
 
     def test_rejects_incomplete_percent_encoding(self) -> None:
         """不完全なパーセントエンコード（%GG等）を拒否すること"""
-        with pytest.raises(ValueError, match=re.escape("不完全なパーセントエンコード")):
+        with pytest.raises(ValueError, match=re.escape("incomplete percent-encoding")):
             validate_scheme_less_url("example%GG.com")
 
     def test_rejects_path_separator(self) -> None:
         """パス区切り（/）を含むURLを拒否すること"""
-        with pytest.raises(ValueError, match=re.escape("パス")):
+        with pytest.raises(ValueError, match=re.escape("cannot contain a path")):
             validate_scheme_less_url("example.com/path")
 
     def test_rejects_fragment(self) -> None:
         """フラグメント（#）を含むURLを拒否すること"""
-        with pytest.raises(ValueError, match=re.escape("フラグメント")):
+        with pytest.raises(ValueError, match=re.escape("cannot contain a fragment")):
             validate_scheme_less_url("example.com#section")
 
     def test_rejects_query(self) -> None:
         """クエリ（?）を含むURLを拒否すること"""
-        with pytest.raises(ValueError, match=re.escape("クエリ")):
+        with pytest.raises(ValueError, match=re.escape("cannot contain a query")):
             validate_scheme_less_url("example.com?key=val")
 
     def test_accepts_valid_domain(self) -> None:


### PR DESCRIPTION
## 概要

 から URL サニタイゼーション、不可視文字除去、スキームバリデーションなどのヘルパー関数を  に分離しました。

## 変更内容

### 新規ファイル
- : サニタイゼーション関連ヘルパーを新規作成（225行）

### 変更ファイル
- : サニタイゼーションロジックを削除し、新モジュールからインポート（-282行 / +18行）
- : インポート元を新モジュールに更新

## 目的

1. **責務の分離**: レスポンスモデルからサニタイゼーションロジックを分離
2. **テスタビリティ向上**: サニタイゼーション関数を独立してテスト可能に
3. **再利用性**: 他のモデルやモジュールからもサニタイゼーション関数を利用可能
4. **保守性**: 単一責任原則に従い、各モジュールの関心事を明確化

## テスト結果

全ユニットテストがパスしています：
- : 272 tests passed

## ブランチ戦略

Git Flow に従い  ブランチから  へマージします。
Squash Merge でマージ予定。