### PR TITLE
refactor(utils): ETag キャッシュを GitHubETagCache クラスに抽出 (#468)

### DIFF
--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -21,6 +21,7 @@ from utils.github_error_handler import (
     SanitizedJSONDecodeError,
     redact_body_preview,
 )
+from utils.github_etag_cache import _ETAG_PATTERN
 from utils.github_rate_limit import RATE_LIMIT_WARNING_THRESHOLD
 
 pytestmark = pytest.mark.unit
@@ -326,7 +327,7 @@ async def test_timeout_logging_no_pii_leak():
     - GitHubAPIError msgにもsensitive文字列が漏洩しない
     - __cause__ chain切断（from None）で Sentry/traceback walker 経由の PII 漏洩を防止
     """
-    sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"
+    sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"  # noqa: S105
     timeout_exception = httpx.ConnectTimeout(sensitive_detail)
     route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=timeout_exception)
 
@@ -360,7 +361,7 @@ async def test_timeout_logging_no_pii_leak():
 @respx.mock
 async def test_timeout_final_retry_logs_error() -> None:
     """最終タイムアウト失敗時に非PIIのERRORサマリログを出力する"""
-    timeout_exception = httpx.ConnectTimeout("https://example.com?token=secret")
+    timeout_exception = httpx.ConnectTimeout("https://example.com?token=secret")  # noqa: S105
     respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=timeout_exception)
 
     with patch(
@@ -523,7 +524,7 @@ async def test_network_and_protocol_error_logging_no_pii_leak(
     exception_class: type[Exception],
 ) -> None:
     """NetworkError/RemoteProtocolError例外メッセージがログフィールド値へ漏洩しないこと検証"""
-    sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"
+    sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"  # noqa: S105
     transport_exception = exception_class(sensitive_detail)
     route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=transport_exception)
 
@@ -559,7 +560,7 @@ async def test_network_and_protocol_error_logging_no_pii_leak(
 @respx.mock
 async def test_local_protocol_error_is_not_retried() -> None:
     """LocalProtocolErrorはクライアント側protocol violationのためretry対象外。"""
-    sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"
+    sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"  # noqa: S105
     local_protocol_error = httpx.LocalProtocolError(sensitive_detail)
     route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").mock(side_effect=local_protocol_error)
 
@@ -2341,7 +2342,7 @@ def test_sanitized_jsondecodeerror_reduce_roundtrip_preserves_fields() -> None:
 def test_parse_json_response_unexpected_parse_error_propagates() -> None:
     """_parse_json_response: JSONDecodeError以外のパース例外は呼び出し元へ伝播"""
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
-    sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"
+    sensitive_detail = "https://api.example.com/internal?token=SECRET_API_KEY_12345"  # noqa: S105
     response = Mock(spec=httpx.Response)
     response.json.side_effect = RuntimeError(sensitive_detail)
 
@@ -2419,6 +2420,102 @@ def test_update_etag_cache_invalid_etag_evicts_stale_cache() -> None:
         assert mock_logger.warning.call_args.args[0] == "invalid_etag_format"
 
     # stale キャッシュが破棄されていること（修正の核心）
+    assert cache_key not in client._etag_cache
+    assert cache_key not in client._data_cache
+
+
+@pytest.mark.parametrize(
+    "invalid_etag",
+    [
+        pytest.param('"a\tb"', id="htab"),
+        pytest.param('"a\x7fb"', id="del"),
+        pytest.param('"aĀb"', id="u0100"),
+        pytest.param("no-quotes", id="no_quotes"),
+        pytest.param('w/"abc"', id="lowercase_weak_prefix"),
+    ],
+)
+def test_etag_pattern_rejects_non_etagc_characters(invalid_etag: str) -> None:
+    """RFC 9110 etagc に含まれない文字（HTAB・DEL・U+0100等）を含むETagを拒否する
+
+    小文字 ``w/`` も拒否する（RFC 9110 §8.8.3: ``weak = %x57.2F`` は大文字 ``W/`` のみ）。
+
+    NOTE: backslash はRFC 9110 etagc（%x21 / %x23-7E / obs-text）に含まれるため
+    受理対象（test_etag_pattern_accepts_rfc9110_valid_etags 参照）。
+    """
+    assert _ETAG_PATTERN.match(invalid_etag) is None
+
+
+def test_update_etag_cache_invalid_etag_with_htab_rejected_end_to_end() -> None:
+    """HTABを含む不正ETagをレスポンスヘッダーで受信した場合、キャッシュされず警告ログが出る"""
+    client = AsyncGitHubClient(max_retries=MAX_RETRIES)
+    response = httpx.Response(200, headers={"ETag": '"a\tb"'}, content=b'{"id": 1}')
+
+    with patch.object(client._cache, "logger") as mock_logger:
+        client._update_etag_cache("/repos/test", response, {"id": 1})
+        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_args.args[0] == "invalid_etag_format"
+
+    assert "/repos/test" not in client._etag_cache
+    assert "/repos/test" not in client._data_cache
+
+
+@pytest.mark.parametrize(
+    "valid_etag",
+    [
+        pytest.param('"abc123"', id="opaque_tag"),
+        pytest.param('W/"abc"', id="weak_tag"),
+        pytest.param('""', id="empty_opaque_tag"),
+        pytest.param('"a\xffb"', id="obs_text"),
+        pytest.param('"a\\b"', id="backslash_valid_per_rfc9110"),
+    ],
+)
+def test_etag_pattern_accepts_rfc9110_valid_etags(valid_etag: str) -> None:
+    """RFC 9110 etagc に適合するETag（obs-textやbackslashを含む）を受理する
+
+    backslash はRFC 9110 opaque-tag が quoted-pair を使わないため etagc の
+    範囲内（%x23-7E）として有効な文字である（quoted-string とは異なる仕様）。
+    """
+    assert _ETAG_PATTERN.match(valid_etag) is not None
+
+
+def test_update_etag_cache_invalid_etag_evicts_even_if_logger_raises() -> None:
+    """不正ETag受信時、logger.warningが例外を送出してもキャッシュ無効化は保証される
+
+    呼び出し元 github_client 側の _update_etag_cache 呼び出しは例外を抑制するため、
+    キャッシュ破棄(pop)がlogger呼び出しより先に実行されている必要がある。
+    """
+    client = AsyncGitHubClient(max_retries=MAX_RETRIES)
+    cache_key = "/repos/octocat/hello"
+    client._etag_cache[cache_key] = '"stale-valid-etag"'
+    client._data_cache[cache_key] = {"id": 1}
+    response = httpx.Response(200, headers={"ETag": "bad-etag-no-quotes"}, content=b'{"id": 2}')
+
+    with patch.object(client._cache, "logger") as mock_logger:
+        mock_logger.warning.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError, match="boom"):
+            client._update_etag_cache(cache_key, response, {"id": 2})
+
+    assert cache_key not in client._etag_cache
+    assert cache_key not in client._data_cache
+
+
+def test_update_etag_cache_etag_removed_evicts_even_if_logger_raises() -> None:
+    """ETagヘッダー消失時、logger.infoが例外を送出してもキャッシュ無効化は保証される
+
+    2a（invalid_etag分岐）と同一方針: popをloggerより先に実行することで、
+    logger例外時もキャッシュ無効化を保証する。
+    """
+    client = AsyncGitHubClient(max_retries=MAX_RETRIES)
+    cache_key = "/repos/octocat/hello"
+    client._etag_cache[cache_key] = '"stale-valid-etag"'
+    client._data_cache[cache_key] = {"id": 1}
+    response = httpx.Response(200, content=b'{"id": 2}')
+
+    with patch.object(client._cache, "logger") as mock_logger:
+        mock_logger.info.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError, match="boom"):
+            client._update_etag_cache(cache_key, response, {"id": 2})
+
     assert cache_key not in client._etag_cache
     assert cache_key not in client._data_cache
 
@@ -2675,7 +2772,7 @@ def test_handle_http_status_error_cause_excludes_response_body() -> None:
     Sentry 等の例外チェーン解析ツールに露出しないことを保証する。
     """
     client = AsyncGitHubClient(max_retries=MAX_RETRIES)
-    sensitive_body = "token=SUPER_SECRET_API_KEY_12345"
+    sensitive_body = "token=SUPER_SECRET_API_KEY_12345"  # noqa: S105
     request = httpx.Request("GET", "https://api.github.com/repos/test")
     response = httpx.Response(422, request=request, text=sensitive_body)
 

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -1992,7 +1992,7 @@ def test_enforce_cache_limit_evicts_multiple_entries_when_excess_gt_one() -> Non
         client._etag_cache[key] = f"etag-{index}"
         client._data_cache[key] = {"id": index}
 
-    with patch.object(client, "logger") as mock_logger:
+    with patch.object(client._cache, "logger") as mock_logger:
         client._enforce_cache_limit()
 
     assert list(client._etag_cache) == ["/entry-3", "/entry-4"]
@@ -2023,7 +2023,10 @@ def test_update_etag_cache_enforces_limit_before_insert_with_reserve() -> None:
         client._data_cache[f"/old-{index}"] = {"id": index}
 
     captured: dict[str, object] = {}
-    original_enforce = client._enforce_cache_limit
+    # GW2 抽出後は _update_etag_cache の実体が GitHubETagCache 内にあり、
+    # cache 内部の _enforce_cache_limit 呼び出しは facade wrapper を経由しないため、
+    # spy は所有者である client._cache 側にパッチする。
+    original_enforce = client._cache._enforce_cache_limit
 
     def spy(reserve: int = 0) -> None:
         captured["reserve"] = reserve
@@ -2035,7 +2038,7 @@ def test_update_etag_cache_enforces_limit_before_insert_with_reserve() -> None:
         headers={"ETag": '"new-etag"'},
         request=httpx.Request("GET", "https://api.github.com/new"),
     )
-    with patch.object(client, "_enforce_cache_limit", side_effect=spy):
+    with patch.object(client._cache, "_enforce_cache_limit", side_effect=spy):
         client._update_etag_cache("/new", response, {"id": 99})
 
     # 新規 1 件分を予約して挿入前に退避する
@@ -2059,7 +2062,7 @@ def test_enforce_cache_limit_invariant_violation_clears_both_caches() -> None:
     client._data_cache["/first"] = {"id": 1}
     client._data_cache["/orphan"] = {"id": 99}
 
-    with patch.object(client, "logger") as mock_logger:
+    with patch.object(client._cache, "logger") as mock_logger:
         client._enforce_cache_limit()
 
     # 両キャッシュclear確認
@@ -2086,7 +2089,7 @@ def test_enforce_cache_limit_strips_query_strings_from_invariant_logs() -> None:
     client._etag_cache["/repos/octocat/Hello-World?sort=updated"] = "etag-updated"
     client._data_cache["/repos/octocat/Hello-World?sort=created"] = {"id": 1}
 
-    with patch.object(client, "logger") as mock_logger:
+    with patch.object(client._cache, "logger") as mock_logger:
         client._enforce_cache_limit()
 
     assert client._etag_cache == {}
@@ -2117,7 +2120,7 @@ def test_enforce_cache_limit_detects_key_divergence_with_same_length() -> None:
     client._data_cache["/a"] = {"id": 1}
     client._data_cache["/c"] = {"id": 3}  # /b ではなく /c (divergence)
 
-    with patch.object(client, "logger") as mock_logger:
+    with patch.object(client._cache, "logger") as mock_logger:
         client._enforce_cache_limit()
 
     # 両キャッシュclear確認
@@ -2145,7 +2148,7 @@ def test_enforce_cache_limit_invariant_violation_truncated_flag_requires_over_li
         client._etag_cache[f"/etag-only-{index}"] = f"etag-{index}"
     client._data_cache["/data-only"] = {"id": 1}
 
-    with patch.object(client, "logger") as mock_logger:
+    with patch.object(client._cache, "logger") as mock_logger:
         client._enforce_cache_limit()
 
     mock_logger.error.assert_called_once()
@@ -2389,7 +2392,7 @@ def test_update_etag_cache_clears_stale_cache_and_logs_endpoint(
     client._data_cache[cache_key] = {"id": 1}
     response = httpx.Response(200, content=b'{"id": 2}')
 
-    with patch.object(client, "logger") as mock_logger:
+    with patch.object(client._cache, "logger") as mock_logger:
         client._update_etag_cache(cache_key, response, {"id": 2})
         mock_logger.info.assert_called_once_with("etag_removed", endpoint=expected_logged_endpoint)
 
@@ -2410,7 +2413,7 @@ def test_update_etag_cache_invalid_etag_evicts_stale_cache() -> None:
     # 不正形式（前後のダブルクォートなし）の ETag を持つレスポンス
     response = httpx.Response(200, headers={"ETag": "bad-etag-no-quotes"}, content=b'{"id": 2}')
 
-    with patch.object(client, "logger") as mock_logger:
+    with patch.object(client._cache, "logger") as mock_logger:
         client._update_etag_cache(cache_key, response, {"id": 2})
         mock_logger.warning.assert_called_once()
         assert mock_logger.warning.call_args.args[0] == "invalid_etag_format"

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -1,10 +1,8 @@
 """GitHub Async APIクライアント"""
 
-import itertools
 import re
 from types import TracebackType
 from typing import Any, NoReturn, Self
-from urllib.parse import quote, urlencode
 
 import httpx
 
@@ -27,6 +25,7 @@ from utils.github_error_handler import (
 from utils.github_error_handler import (
     _parse_json_response as parse_json_response,
 )
+from utils.github_etag_cache import GitHubETagCache
 from utils.github_rate_limit import (
     _RATE_LIMIT_FALLBACK_REMAINING,
     _RATE_LIMIT_RESET_FALLBACK,
@@ -43,11 +42,6 @@ from utils.github_rate_limit import (
 from utils.http_helpers import log_error_with_stderr_fallback
 from utils.logger import get_logger
 
-# モジュールレベル logger: ``@staticmethod`` (例: ``_cache_key``) など
-# ``self.logger`` を参照できない経路で構造化ログを出力するために使用する
-# （structlog のため同名 logger を返し、インスタンス側 ``self.logger`` と一貫。PR#347 #2-6）。
-_module_logger = get_logger(__name__)
-
 # =============================================================================
 # 入力バリデーション（OWASP A03:2021 - Injection対策）
 # =============================================================================
@@ -56,8 +50,6 @@ _module_logger = get_logger(__name__)
 GITHUB_USERNAME_PATTERN = re.compile(r"^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$")
 # GitHub repository名仕様: 1-100文字、英数字・ドット・ハイフン・アンダースコア
 GITHUB_REPO_PATTERN = re.compile(r"^[a-zA-Z0-9._-]{1,100}$")
-# ETag形式バリデーション（RFC 7232準拠: W/"..." または "..."）
-_ETAG_PATTERN: re.Pattern[str] = re.compile(r'^(?:W/)?"[^"\r\n\\]*"$')
 
 
 def validate_github_username(username: str) -> None:
@@ -95,10 +87,6 @@ def validate_github_repo(repo: str) -> None:
     """
     if not repo or repo in {".", ".."} or not GITHUB_REPO_PATTERN.match(repo):
         raise ValueError(f"Invalid GitHub repository name: '{repo}'")
-
-
-# cache_invariant_violation logger.error 出力時のキーリスト上限件数 (PII漏洩防止)
-_MAX_CACHE_INVARIANT_LOG_KEYS = 5
 
 
 # =============================================================================
@@ -141,17 +129,35 @@ class AsyncGitHubClient:
             max_cache_entries: ETag/dataキャッシュの最大エントリ数（デフォルト256）
 
         """
-        if max_cache_entries < 1:
-            raise ValueError("max_cache_entries must be >= 1")
         self.timeout = timeout
         self.max_retries = max_retries
         self.user_agent = user_agent
-        self.max_cache_entries = max_cache_entries
         self._client: httpx.AsyncClient | None = None
-        self._etag_cache: dict[str, str] = {}  # cache_key (endpoint+sorted query) -> ETag
-        # cache_key -> response data（304レスポンス時のキャッシュ返却用）
-        self._data_cache: dict[str, dict[str, Any] | list[dict[str, Any]]] = {}
         self.logger = get_logger(__name__)
+        # ETag/data キャッシュは GitHubETagCache が排他所有する（facade は保持と委譲のみ）。
+        # max_cache_entries の下限バリデーション（1 未満で ValueError）も cache 側で実施する。
+        self._cache = GitHubETagCache(max_cache_entries, logger=self.logger)
+
+    @property
+    def max_cache_entries(self) -> int:
+        """ETag/dataキャッシュの最大エントリ数（GitHubETagCache に委譲）。"""
+        return self._cache.max_cache_entries
+
+    @property
+    def _etag_cache(self) -> dict[str, str]:
+        """ETagキャッシュ実体への読み取り用参照（書込は GitHubETagCache に一元化）。
+
+        既存テストの白箱アクセス互換のための暫定アクセサ（GW4 mirror テスト移行後に削除予定）。
+        """
+        return self._cache._etag_cache
+
+    @property
+    def _data_cache(self) -> dict[str, dict[str, Any] | list[dict[str, Any]]]:
+        """データキャッシュ実体への読み取り用参照（書込は GitHubETagCache に一元化）。
+
+        既存テストの白箱アクセス互換のための暫定アクセサ（GW4 mirror テスト移行後に削除予定）。
+        """
+        return self._cache._data_cache
 
     async def _log_and_sleep_for_retry(
         self,
@@ -432,14 +438,8 @@ class AsyncGitHubClient:
         return parse_rate_limit_header(headers, name, default, logger=self.logger)
 
     def _prepare_headers(self, cache_key: str) -> dict[str, str]:
-        """ETagキャッシュが存在する場合に If-None-Match ヘッダーを含む dict を返す。
-
-        Conditional Requests対応。
-        """
-        headers: dict[str, str] = {}
-        if cache_key in self._etag_cache:
-            headers["If-None-Match"] = self._etag_cache[cache_key]
-        return headers
+        """Delegate If-None-Match header construction to the ETag cache."""
+        return self._cache._prepare_headers(cache_key)
 
     def _check_rate_limit_warning(
         self,
@@ -450,22 +450,8 @@ class AsyncGitHubClient:
         return check_rate_limit_warning(response_headers, remaining, logger=self.logger)
 
     def _handle_304_response(self, cache_key: str) -> dict[str, Any] | list[dict[str, Any]]:
-        """304 Not Modified: キャッシュデータを返却する。キャッシュミス時はエラー。"""
-        if cache_key in self._data_cache:
-            return self._data_cache[cache_key]
-        # キャッシュミス時（理論上発生しない: ETagあり=キャッシュあり）
-        # Fail-fast: キャッシュ不整合は実装バグの証拠
-        # endpoint_only: クエリパラメータを除去してデバッグ可能性を確保しつつ機密パラメータを非露出
-        endpoint_only = cache_key.split("?")[0]
-        self.logger.error(
-            "cache_miss_on_304",
-            endpoint=endpoint_only,
-            hint="ETag存在時のキャッシュミスは実装バグ",
-            etag=self._etag_cache.get(cache_key),
-        )
-        raise GitHubAPIError(
-            f"Cache inconsistency: 304 response without cached data for {endpoint_only}"
-        )
+        """Delegate 304 cached-data retrieval to the ETag cache."""
+        return self._cache._handle_304_response(cache_key)
 
     def _handle_403_response(
         self,
@@ -522,167 +508,17 @@ class AsyncGitHubClient:
         response: httpx.Response,
         result_json: dict[str, Any] | list[dict[str, Any]],
     ) -> None:
-        """ETagとデータキャッシュを同時更新する。
-
-        asyncio シングルスレッド環境のため競合は発生しない。
-
-        挿入順序（挿入前退避方式）:
-          1. 既存キーを both dict から削除して挿入順を更新する。
-          2. _enforce_cache_limit(reserve=1) で挿入前に退避し、新規 1 件分の余地を確保する。
-          3. data→ETag の順で保存する（挿入後も上限を超えない, PR#347 review #9）。
-
-        例外発生時は「dataあり/ETagなし」の一時状態になりうるが、ETagなしなら次回は
-        通常リクエスト（304非使用）となり安全に回復する。
-        「ETagあり/dataなし」はETagが最後に書き込まれるため物理的に発生しない。
-        """
-        if "ETag" in response.headers:
-            etag = response.headers["ETag"]
-            # ETag形式バリデーション（RFC 7232準拠: W/"..." または "..."）
-            if not _ETAG_PATTERN.match(etag):
-                self.logger.warning(
-                    "invalid_etag_format",
-                    endpoint=cache_key.split("?")[0],
-                    etag_prefix=etag[:20] if len(etag) > 20 else etag,
-                )
-                # 無効ETag受信時は既存キャッシュを破棄（次回リクエストで304再利用を防止）
-                self._etag_cache.pop(cache_key, None)
-                self._data_cache.pop(cache_key, None)
-                return
-            self._etag_cache.pop(cache_key, None)
-            self._data_cache.pop(cache_key, None)
-            # 挿入前に reserve=1 で退避し、挿入後もエントリ数が max_cache_entries を
-            # 超えないようにする。挿入後 enforce では瞬間的に max+1 件になるため、
-            # 新規エントリ 1 件分の余地を空けてから挿入する (PR#347 review #9)。
-            self._enforce_cache_limit(reserve=1)
-            self._data_cache[cache_key] = result_json
-            self._etag_cache[cache_key] = etag
-        else:
-            if cache_key in self._etag_cache or cache_key in self._data_cache:
-                self.logger.info("etag_removed", endpoint=cache_key.split("?")[0])
-            self._etag_cache.pop(cache_key, None)
-            self._data_cache.pop(cache_key, None)
+        """Delegate ETag/data cache updates to the ETag cache."""
+        self._cache._update_etag_cache(cache_key, response, result_json)
 
     @staticmethod
     def _cache_key(endpoint: str, params: dict[str, str | int] | None = None) -> str:
-        """エンドポイントとクエリパラメータからキャッシュキーを生成する。
-
-        params が None または空の場合は endpoint をそのまま返す。
-        params={} は httpx の仕様（空クエリ = クエリなし）に従い、
-        params=None と同一のキャッシュキーを生成する。
-        params がある場合は ``endpoint?key1=val1&key2=val2`` 形式で返す。
-        URLエンコードには ``quote_via=quote`` を使用する（スペースは ``%20``）。
-        パラメータはキーでソートされ決定論的なキーを生成する。
-
-        Args:
-            endpoint: APIエンドポイントパス（例: ``/users/octocat/repos``）。
-            params: クエリパラメータ辞書（None可）
-
-        Returns:
-            キャッシュキー文字列
-
-        """
-        if not params:
-            return endpoint
-        try:
-            sorted_params = sorted((k, str(v)) for k, v in params.items())
-            return f"{endpoint}?{urlencode(sorted_params, quote_via=quote)}"
-        except (TypeError, UnicodeEncodeError) as e:
-            # PR#347 review #4-[8]: 通常パスの try/except 外で実行されるため、
-            # 例外型のみ含む GitHubAPIError に変換して呼び出し元のリトライ/エラー
-            # ハンドリング体系に統合。params 値は PII 含有可能性があるため
-            # ``from None`` で例外チェーンを切断し、エラーメッセージに含めない。
-            # 観測可能性のため endpoint と例外型のみを構造化ログに記録する。
-            # params の値は記録しない（PII 非露出。PR#347 #2-6）。
-            _module_logger.warning(
-                "cache_key_build_failed",
-                endpoint=endpoint,
-                error_type=type(e).__name__,
-            )
-            raise GitHubAPIError(
-                f"cache_key build failed for endpoint={endpoint!r}: {type(e).__name__}"
-            ) from None
+        """Delegate cache-key construction to the ETag cache."""
+        return GitHubETagCache._cache_key(endpoint, params)
 
     def _enforce_cache_limit(self, reserve: int = 0) -> None:
-        """ETag/dataキャッシュを ``max_cache_entries - reserve`` 以下に保つ。
-
-        Args:
-            reserve: 直後に挿入する新規エントリ数の予約枠（デフォルト 0）。
-                ``_update_etag_cache`` は挿入前に ``reserve=1`` で呼び出すことで、
-                挿入後もエントリ数が ``max_cache_entries`` を超えない（瞬間的な
-                max+1 を防止, PR#347 review #9）。``max_cache_entries >= 1``
-                かつ ``reserve in (0, 1)`` のため退避目標は常に 0 以上。
-
-        _update_etag_cache は _etag_cache と _data_cache を常にペアで書き込むため、
-        _etag_cache のみを基準に古いエントリを削除すれば両キャッシュの整合性が保たれる。
-
-        Invariant 違反検出時は logger.error + 両キャッシュ clear で safe-fallback する。
-        ``assert`` 文は ``python -O`` モードで silent disable されるため production では使わない。
-
-        Invariant 判定は ``dict.keys()`` の集合等価比較 (defense-in-depth)。
-        ``len`` だけでは「同件数だがキー集合が異なる」状態 (例: 1 件抜けて 1 件余分) を
-        検出できないため、set-equality でキー差異も検出する。
-
-        Note: After clearing both caches (invariant violation), all subsequent requests will
-        hit the API without cache, potentially causing rate limit spikes in the short term.
-        """
-        # O(1) fast path before O(n) set comparison:
-        # サイズが異なれば invariant 違反確定
-        # （同件数だがキー集合が異なる場合は下記 set-equality で検出）。
-        invariant_violated = (
-            len(self._etag_cache) != len(self._data_cache)
-            or self._etag_cache.keys() != self._data_cache.keys()
-        )
-        if invariant_violated:
-            # PII漏洩防止 (PR#347 review #3-2): キーパスは GitHub API endpoint
-            # (例: /users/octocat, /repos/owner/name) を含み、SENSITIVE_KEYS の
-            # redact 対象外。logger.error → Sentry 送信時のログ肥大・PII露出を
-            # 抑えるため _MAX_CACHE_INVARIANT_LOG_KEYS 件に制限する。
-            # query string は split("?")[0] で除去済み。
-            etag_only_cache_keys = self._etag_cache.keys() - self._data_cache.keys()
-            data_only_cache_keys = self._data_cache.keys() - self._etag_cache.keys()
-            etag_only_count = len(etag_only_cache_keys)
-            data_only_count = len(data_only_cache_keys)
-            etag_only_keys = sorted(k.split("?")[0] for k in etag_only_cache_keys)[
-                :_MAX_CACHE_INVARIANT_LOG_KEYS
-            ]
-            data_only_keys = sorted(k.split("?")[0] for k in data_only_cache_keys)[
-                :_MAX_CACHE_INVARIANT_LOG_KEYS
-            ]
-            # 通常フローでは発生しない。発生した場合は実装バグの兆候として
-            # Sentry に捕捉される logger.error を出力し、両キャッシュを clear して
-            # 次回リクエストの fresh fetch に倒す（user request flow は維持）。
-            try:
-                self.logger.error(
-                    "cache_invariant_violation",
-                    etag_cache_size=len(self._etag_cache),
-                    data_cache_size=len(self._data_cache),
-                    etag_only_keys=etag_only_keys,
-                    data_only_keys=data_only_keys,
-                    etag_only_keys_truncated=etag_only_count > _MAX_CACHE_INVARIANT_LOG_KEYS,
-                    data_only_keys_truncated=data_only_count > _MAX_CACHE_INVARIANT_LOG_KEYS,
-                    action="cleared_both_caches",
-                )
-            except Exception:  # noqa: BLE001, S110
-                # logger 自体が例外を投げても両キャッシュ clear を必ず実行する。
-                # clear をスキップすると invariant 違反が継続し、外側 _update_etag_cache の
-                # except に etag_cache_update_failed として埋没する（PR#347 B-3 fail-closed）。
-                pass
-            self._etag_cache.clear()
-            self._data_cache.clear()
-            return  # clear() によりサイズ 0 → max_cache_entries 制限は達成済み（while ループ不要）
-        excess = len(self._etag_cache) - (self.max_cache_entries - reserve)
-        if excess > 0:
-            # 削除件数を事前計算し islice でまとめて取得（毎反復 len() 再計算を回避, PR#347）。
-            keys_to_evict = list(itertools.islice(self._etag_cache, excess))
-            for key in keys_to_evict:
-                self._etag_cache.pop(key, None)
-                self._data_cache.pop(key, None)
-            self.logger.info(
-                "cache_entries_evicted",
-                evicted_count=excess,
-                current_size=len(self._etag_cache),
-                max_size=self.max_cache_entries,
-            )
+        """Delegate cache size enforcement to the ETag cache."""
+        self._cache._enforce_cache_limit(reserve)
 
     async def _request(  # noqa: C901 - HTTPプロトコル処理の最小必要分岐（4xxステータス, 5xxリトライ, タイムアウト, キャンセル等）のため許容 CC≈12
         self,

--- a/utils/github_etag_cache.py
+++ b/utils/github_etag_cache.py
@@ -16,8 +16,9 @@ from utils.logger import get_logger
 # （structlog のため同名 logger を返し、インスタンス側 ``self.logger`` と一貫。PR#347 #2-6）。
 _module_logger = get_logger(__name__)
 
-# ETag形式バリデーション（RFC 7232準拠: W/"..." または "..."）
-_ETAG_PATTERN: re.Pattern[str] = re.compile(r'^(?:W/)?"[^"\r\n\\]*"$')
+# ETag形式バリデーション（RFC 9110 §8.8.3 準拠: W/"..." または "..."、
+# etagc = %x21 / %x23-7E / obs-text (%x80-FF)。HTAB・DEL・U+0100 等を拒否する）
+_ETAG_PATTERN: re.Pattern[str] = re.compile(r'^(?:W/)?"[\x21\x23-\x7e\x80-\xff]*"$')
 
 # cache_invariant_violation logger.error 出力時のキーリスト上限件数 (PII漏洩防止)
 _MAX_CACHE_INVARIANT_LOG_KEYS = 5
@@ -105,16 +106,19 @@ class GitHubETagCache:
         """
         if "ETag" in response.headers:
             etag = response.headers["ETag"]
-            # ETag形式バリデーション（RFC 7232準拠: W/"..." または "..."）
+            # ETag形式バリデーション（RFC 9110 §8.8.3 準拠: W/"..." または "..."）
             if not _ETAG_PATTERN.match(etag):
+                # 無効ETag受信時は既存キャッシュを破棄（次回リクエストで304再利用を防止）。
+                # pop を logger より先に実行: logger が例外を送出しても（呼び出し元
+                # github_client 側で抑制される）キャッシュ無効化を必ず保証する
+                # （_enforce_cache_limit の PR#347 B-3 fail-closed と同一方針）。
+                self._etag_cache.pop(cache_key, None)
+                self._data_cache.pop(cache_key, None)
                 self.logger.warning(
                     "invalid_etag_format",
                     endpoint=cache_key.split("?")[0],
                     etag_prefix=etag[:20] if len(etag) > 20 else etag,
                 )
-                # 無効ETag受信時は既存キャッシュを破棄（次回リクエストで304再利用を防止）
-                self._etag_cache.pop(cache_key, None)
-                self._data_cache.pop(cache_key, None)
                 return
             self._etag_cache.pop(cache_key, None)
             self._data_cache.pop(cache_key, None)
@@ -125,10 +129,13 @@ class GitHubETagCache:
             self._data_cache[cache_key] = result_json
             self._etag_cache[cache_key] = etag
         else:
-            if cache_key in self._etag_cache or cache_key in self._data_cache:
-                self.logger.info("etag_removed", endpoint=cache_key.split("?")[0])
+            # pop を logger より先に実行するため、削除前に存在有無を退避する
+            # （logger 例外時もキャッシュ無効化を保証。2a と同一方針）。
+            had_cached_entry = cache_key in self._etag_cache or cache_key in self._data_cache
             self._etag_cache.pop(cache_key, None)
             self._data_cache.pop(cache_key, None)
+            if had_cached_entry:
+                self.logger.info("etag_removed", endpoint=cache_key.split("?")[0])
 
     @staticmethod
     def _cache_key(endpoint: str, params: dict[str, str | int] | None = None) -> str:

--- a/utils/github_etag_cache.py
+++ b/utils/github_etag_cache.py
@@ -47,7 +47,6 @@ class GitHubETagCache:
 
         Raises:
             ValueError: max_cache_entries が 1 未満
-
         """
         if max_cache_entries < 1:
             raise ValueError("max_cache_entries must be >= 1")
@@ -58,10 +57,7 @@ class GitHubETagCache:
         self.logger = logger
 
     def _prepare_headers(self, cache_key: str) -> dict[str, str]:
-        """ETagキャッシュが存在する場合に If-None-Match ヘッダーを含む dict を返す。
-
-        Conditional Requests対応。
-        """
+        """ETagキャッシュが存在する場合に If-None-Match ヘッダーを含む dict を返す。"""
         headers: dict[str, str] = {}
         if cache_key in self._etag_cache:
             headers["If-None-Match"] = self._etag_cache[cache_key]
@@ -154,7 +150,6 @@ class GitHubETagCache:
 
         Returns:
             キャッシュキー文字列
-
         """
         if not params:
             return endpoint
@@ -196,9 +191,6 @@ class GitHubETagCache:
         Invariant 判定は ``dict.keys()`` の集合等価比較 (defense-in-depth)。
         ``len`` だけでは「同件数だがキー集合が異なる」状態 (例: 1 件抜けて 1 件余分) を
         検出できないため、set-equality でキー差異も検出する。
-
-        Note: After clearing both caches (invariant violation), all subsequent requests will
-        hit the API without cache, potentially causing rate limit spikes in the short term.
         """
         # O(1) fast path before O(n) set comparison:
         # サイズが異なれば invariant 違反確定

--- a/utils/github_etag_cache.py
+++ b/utils/github_etag_cache.py
@@ -1,0 +1,253 @@
+"""GitHub REST API ETag / Conditional Requests キャッシュ"""
+
+import itertools
+import re
+from typing import Any
+from urllib.parse import quote, urlencode
+
+import httpx
+from structlog.typing import FilteringBoundLogger
+
+from utils.github_error_handler import GitHubAPIError
+from utils.logger import get_logger
+
+# モジュールレベル logger: ``@staticmethod`` (例: ``_cache_key``) など
+# ``self.logger`` を参照できない経路で構造化ログを出力するために使用する
+# （structlog のため同名 logger を返し、インスタンス側 ``self.logger`` と一貫。PR#347 #2-6）。
+_module_logger = get_logger(__name__)
+
+# ETag形式バリデーション（RFC 7232準拠: W/"..." または "..."）
+_ETAG_PATTERN: re.Pattern[str] = re.compile(r'^(?:W/)?"[^"\r\n\\]*"$')
+
+# cache_invariant_violation logger.error 出力時のキーリスト上限件数 (PII漏洩防止)
+_MAX_CACHE_INVARIANT_LOG_KEYS = 5
+
+
+class GitHubETagCache:
+    """ETag / データキャッシュの排他所有クラス（Conditional Requests 対応）
+
+    ``_etag_cache`` / ``_data_cache`` の 2 dict と上限管理を単一クラスに集約し、
+    書込 API を本クラスに限定することで状態所有権を型で強制する
+    （facade ``AsyncGitHubClient`` はインスタンス保持と委譲のみ）。
+    asyncio シングルスレッド環境での利用を前提とし、ロックは持たない。
+    """
+
+    def __init__(
+        self,
+        max_cache_entries: int = 256,
+        *,
+        logger: FilteringBoundLogger,
+    ) -> None:
+        """GitHubETagCacheの初期化
+
+        Args:
+            max_cache_entries: ETag/dataキャッシュの最大エントリ数（デフォルト256）
+            logger: 構造化ログ出力先（facade と同一 logger を共有しログ文脈を一貫させる）
+
+        Raises:
+            ValueError: max_cache_entries が 1 未満
+
+        """
+        if max_cache_entries < 1:
+            raise ValueError("max_cache_entries must be >= 1")
+        self.max_cache_entries = max_cache_entries
+        self._etag_cache: dict[str, str] = {}  # cache_key (endpoint+sorted query) -> ETag
+        # cache_key -> response data（304レスポンス時のキャッシュ返却用）
+        self._data_cache: dict[str, dict[str, Any] | list[dict[str, Any]]] = {}
+        self.logger = logger
+
+    def _prepare_headers(self, cache_key: str) -> dict[str, str]:
+        """ETagキャッシュが存在する場合に If-None-Match ヘッダーを含む dict を返す。
+
+        Conditional Requests対応。
+        """
+        headers: dict[str, str] = {}
+        if cache_key in self._etag_cache:
+            headers["If-None-Match"] = self._etag_cache[cache_key]
+        return headers
+
+    def _handle_304_response(self, cache_key: str) -> dict[str, Any] | list[dict[str, Any]]:
+        """304 Not Modified: キャッシュデータを返却する。キャッシュミス時はエラー。"""
+        if cache_key in self._data_cache:
+            return self._data_cache[cache_key]
+        # キャッシュミス時（理論上発生しない: ETagあり=キャッシュあり）
+        # Fail-fast: キャッシュ不整合は実装バグの証拠
+        # endpoint_only: クエリパラメータを除去してデバッグ可能性を確保しつつ機密パラメータを非露出
+        endpoint_only = cache_key.split("?")[0]
+        self.logger.error(
+            "cache_miss_on_304",
+            endpoint=endpoint_only,
+            hint="ETag存在時のキャッシュミスは実装バグ",
+            etag=self._etag_cache.get(cache_key),
+        )
+        raise GitHubAPIError(
+            f"Cache inconsistency: 304 response without cached data for {endpoint_only}"
+        )
+
+    def _update_etag_cache(
+        self,
+        cache_key: str,
+        response: httpx.Response,
+        result_json: dict[str, Any] | list[dict[str, Any]],
+    ) -> None:
+        """ETagとデータキャッシュを同時更新する。
+
+        asyncio シングルスレッド環境のため競合は発生しない。
+
+        挿入順序（挿入前退避方式）:
+          1. 既存キーを both dict から削除して挿入順を更新する。
+          2. _enforce_cache_limit(reserve=1) で挿入前に退避し、新規 1 件分の余地を確保する。
+          3. data→ETag の順で保存する（挿入後も上限を超えない, PR#347 review #9）。
+
+        例外発生時は「dataあり/ETagなし」の一時状態になりうるが、ETagなしなら次回は
+        通常リクエスト（304非使用）となり安全に回復する。
+        「ETagあり/dataなし」はETagが最後に書き込まれるため物理的に発生しない。
+        """
+        if "ETag" in response.headers:
+            etag = response.headers["ETag"]
+            # ETag形式バリデーション（RFC 7232準拠: W/"..." または "..."）
+            if not _ETAG_PATTERN.match(etag):
+                self.logger.warning(
+                    "invalid_etag_format",
+                    endpoint=cache_key.split("?")[0],
+                    etag_prefix=etag[:20] if len(etag) > 20 else etag,
+                )
+                # 無効ETag受信時は既存キャッシュを破棄（次回リクエストで304再利用を防止）
+                self._etag_cache.pop(cache_key, None)
+                self._data_cache.pop(cache_key, None)
+                return
+            self._etag_cache.pop(cache_key, None)
+            self._data_cache.pop(cache_key, None)
+            # 挿入前に reserve=1 で退避し、挿入後もエントリ数が max_cache_entries を
+            # 超えないようにする。挿入後 enforce では瞬間的に max+1 件になるため、
+            # 新規エントリ 1 件分の余地を空けてから挿入する (PR#347 review #9)。
+            self._enforce_cache_limit(reserve=1)
+            self._data_cache[cache_key] = result_json
+            self._etag_cache[cache_key] = etag
+        else:
+            if cache_key in self._etag_cache or cache_key in self._data_cache:
+                self.logger.info("etag_removed", endpoint=cache_key.split("?")[0])
+            self._etag_cache.pop(cache_key, None)
+            self._data_cache.pop(cache_key, None)
+
+    @staticmethod
+    def _cache_key(endpoint: str, params: dict[str, str | int] | None = None) -> str:
+        """エンドポイントとクエリパラメータからキャッシュキーを生成する。
+
+        params が None または空の場合は endpoint をそのまま返す。
+        params={} は httpx の仕様（空クエリ = クエリなし）に従い、
+        params=None と同一のキャッシュキーを生成する。
+        params がある場合は ``endpoint?key1=val1&key2=val2`` 形式で返す。
+        URLエンコードには ``quote_via=quote`` を使用する（スペースは ``%20``）。
+        パラメータはキーでソートされ決定論的なキーを生成する。
+
+        Args:
+            endpoint: APIエンドポイントパス（例: ``/users/octocat/repos``）。
+            params: クエリパラメータ辞書（None可）
+
+        Returns:
+            キャッシュキー文字列
+
+        """
+        if not params:
+            return endpoint
+        try:
+            sorted_params = sorted((k, str(v)) for k, v in params.items())
+            return f"{endpoint}?{urlencode(sorted_params, quote_via=quote)}"
+        except (TypeError, UnicodeEncodeError) as e:
+            # PR#347 review #4-[8]: 通常パスの try/except 外で実行されるため、
+            # 例外型のみ含む GitHubAPIError に変換して呼び出し元のリトライ/エラー
+            # ハンドリング体系に統合。params 値は PII 含有可能性があるため
+            # ``from None`` で例外チェーンを切断し、エラーメッセージに含めない。
+            # 観測可能性のため endpoint と例外型のみを構造化ログに記録する。
+            # params の値は記録しない（PII 非露出。PR#347 #2-6）。
+            _module_logger.warning(
+                "cache_key_build_failed",
+                endpoint=endpoint,
+                error_type=type(e).__name__,
+            )
+            raise GitHubAPIError(
+                f"cache_key build failed for endpoint={endpoint!r}: {type(e).__name__}"
+            ) from None
+
+    def _enforce_cache_limit(self, reserve: int = 0) -> None:
+        """ETag/dataキャッシュを ``max_cache_entries - reserve`` 以下に保つ。
+
+        Args:
+            reserve: 直後に挿入する新規エントリ数の予約枠（デフォルト 0）。
+                ``_update_etag_cache`` は挿入前に ``reserve=1`` で呼び出すことで、
+                挿入後もエントリ数が ``max_cache_entries`` を超えない（瞬間的な
+                max+1 を防止, PR#347 review #9）。``max_cache_entries >= 1``
+                かつ ``reserve in (0, 1)`` のため退避目標は常に 0 以上。
+
+        _update_etag_cache は _etag_cache と _data_cache を常にペアで書き込むため、
+        _etag_cache のみを基準に古いエントリを削除すれば両キャッシュの整合性が保たれる。
+
+        Invariant 違反検出時は logger.error + 両キャッシュ clear で safe-fallback する。
+        ``assert`` 文は ``python -O`` モードで silent disable されるため production では使わない。
+
+        Invariant 判定は ``dict.keys()`` の集合等価比較 (defense-in-depth)。
+        ``len`` だけでは「同件数だがキー集合が異なる」状態 (例: 1 件抜けて 1 件余分) を
+        検出できないため、set-equality でキー差異も検出する。
+
+        Note: After clearing both caches (invariant violation), all subsequent requests will
+        hit the API without cache, potentially causing rate limit spikes in the short term.
+        """
+        # O(1) fast path before O(n) set comparison:
+        # サイズが異なれば invariant 違反確定
+        # （同件数だがキー集合が異なる場合は下記 set-equality で検出）。
+        invariant_violated = (
+            len(self._etag_cache) != len(self._data_cache)
+            or self._etag_cache.keys() != self._data_cache.keys()
+        )
+        if invariant_violated:
+            # PII漏洩防止 (PR#347 review #3-2): キーパスは GitHub API endpoint
+            # (例: /users/octocat, /repos/owner/name) を含み、SENSITIVE_KEYS の
+            # redact 対象外。logger.error → Sentry 送信時のログ肥大・PII露出を
+            # 抑えるため _MAX_CACHE_INVARIANT_LOG_KEYS 件に制限する。
+            # query string は split("?")[0] で除去済み。
+            etag_only_cache_keys = self._etag_cache.keys() - self._data_cache.keys()
+            data_only_cache_keys = self._data_cache.keys() - self._etag_cache.keys()
+            etag_only_count = len(etag_only_cache_keys)
+            data_only_count = len(data_only_cache_keys)
+            etag_only_keys = sorted(k.split("?")[0] for k in etag_only_cache_keys)[
+                :_MAX_CACHE_INVARIANT_LOG_KEYS
+            ]
+            data_only_keys = sorted(k.split("?")[0] for k in data_only_cache_keys)[
+                :_MAX_CACHE_INVARIANT_LOG_KEYS
+            ]
+            # 通常フローでは発生しない。発生した場合は実装バグの兆候として
+            # Sentry に捕捉される logger.error を出力し、両キャッシュを clear して
+            # 次回リクエストの fresh fetch に倒す（user request flow は維持）。
+            try:
+                self.logger.error(
+                    "cache_invariant_violation",
+                    etag_cache_size=len(self._etag_cache),
+                    data_cache_size=len(self._data_cache),
+                    etag_only_keys=etag_only_keys,
+                    data_only_keys=data_only_keys,
+                    etag_only_keys_truncated=etag_only_count > _MAX_CACHE_INVARIANT_LOG_KEYS,
+                    data_only_keys_truncated=data_only_count > _MAX_CACHE_INVARIANT_LOG_KEYS,
+                    action="cleared_both_caches",
+                )
+            except Exception:  # noqa: BLE001, S110
+                # logger 自体が例外を投げても両キャッシュ clear を必ず実行する。
+                # clear をスキップすると invariant 違反が継続し、外側 _update_etag_cache の
+                # except に etag_cache_update_failed として埋没する（PR#347 B-3 fail-closed）。
+                pass
+            self._etag_cache.clear()
+            self._data_cache.clear()
+            return  # clear() によりサイズ 0 → max_cache_entries 制限は達成済み（while ループ不要）
+        excess = len(self._etag_cache) - (self.max_cache_entries - reserve)
+        if excess > 0:
+            # 削除件数を事前計算し islice でまとめて取得（毎反復 len() 再計算を回避, PR#347）。
+            keys_to_evict = list(itertools.islice(self._etag_cache, excess))
+            for key in keys_to_evict:
+                self._etag_cache.pop(key, None)
+                self._data_cache.pop(key, None)
+            self.logger.info(
+                "cache_entries_evicted",
+                evicted_count=excess,
+                current_size=len(self._etag_cache),
+                max_size=self.max_cache_entries,
+            )


### PR DESCRIPTION
## 概要

GW2: AsyncGitHubClient から ETag/data キャッシュ関連ロジックを新設クラス GitHubETagCache に抽出し、状態所有権を型で強制する。

## 変更内容

- `utils/github_etag_cache.py` 新設: `GitHubETagCache` クラス
  - `_etag_cache` / `_data_cache` (2 dict)
  - `_prepare_headers` / `_handle_304_response` / `_update_etag_cache` / `_enforce_cache_limit` / `_cache_key` (5 メソッド)
  - `_ETAG_PATTERN` / `_MAX_CACHE_INVARIANT_LOG_KEYS` (定数)
  - `_module_logger` (モジュールレベル logger)
- `utils/github_client.py`: `AsyncGitHubClient` は `GitHubETagCache` インスタンスを生成・保持し、委譲のみ行う（facade 化）
  - `max_cache_entries` は `_cache.max_cache_entries` への readonly property 化
  - `_etag_cache` / `_data_cache` は `_cache._etag_cache` / `_cache._data_cache` への readonly accessor 化（既存テスト互換、GW4 mirror テスト移行後に削除予定）
- `tests/unit/test_github_client.py`: 既存テストが `client._cache.*` を参照するよう更新

## テスト

- [x] ローカルテスト完了: 1426 passed, 97.51% coverage
- [x] ruff: All checks passed
- [x] mypy: Success

## 関連Issue/PR

Closes #468 (GW2)