### PR TITLE
refactor(models): URL検証をsanitizationモジュールに抽出

### DIFF
--- a/models/responses.py
+++ b/models/responses.py
@@ -8,16 +8,13 @@ websiteはURL形式のためhtmlコンテキスト出力時は呼び出し元で
 """
 
 from typing import Annotated
-from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
 
-from . import sanitization as _sanitization
 from .sanitization import (
-    normalize_url,
     sanitize_user_content,
-    strip_invisible_chars,
-    validate_scheme_less_url,
+    validate_strict_url,
+    validate_website_url,
 )
 
 # =============================================================================
@@ -286,54 +283,8 @@ class User(BaseModel):
         """
         if not isinstance(v, str):
             raise ValueError(f"String required (received type: {type(v).__name__})")
-
-        sanitized = strip_invisible_chars(v).strip()
-        # min_length=1 は真の空文字列を、ここでは制御文字のみの文字列を捕捉（2段階チェック）
-        if not sanitized:
-            raise ValueError("Website became empty after control character removal")
-        # CRLF injection防止: パーセントエンコードされた制御文字を拒否（%00-%1f全範囲）
-        # strip_invisible_chars は実際の制御文字を除去するが、
-        # %0d%0a 等のエンコード形式はバイパスする
-        sanitized_lower = sanitized.lower()
-        if _sanitization._PERCENT_CTRL_RE.search(sanitized_lower):
-            raise ValueError("URL contains percent-encoded control characters")
-        # 不完全な%シーケンス検出（全ブランチ共通 — http/httpsおよびスキームなし両対応）
-        # validate_scheme_less_url でも同様にチェックするが多層防御として二重確認
-        if _sanitization._INCOMPLETE_PCT_RE.search(sanitized):
-            raise ValueError("URL contains incomplete percent-encoding")
-        # プロトコル相対URLを明示的に拒否（攻撃面削減）
-        if sanitized_lower.startswith("//"):
-            raise ValueError("Protocol-relative URLs are not allowed")
-        # urlparseは各分岐で1回のみ呼び出す
-        # （http/httpsブランチと補完ブランチで入力が異なるため共通化不可）
-        if sanitized_lower.startswith(("http://", "https://")):
-            # _validate_netloc / normalize_url の ValueError はそのまま伝播
-            # NOTE: sanitized（元の大文字混在）を使用 — スキーム小文字化は normalize_url に委譲
-            # （sanitized_lower は path/query の大文字を失うため使用不可）
-            parsed = urlparse(sanitized)
-            _sanitization._validate_netloc(parsed)
-            return _sanitization._ensure_website_max_length(normalize_url(parsed))
-        # RFC 3986スキーム検出: http/https以外のスキームが存在すれば拒否
-        # is_domain_portロジックを削除: domain:portはスキームなし扱いのため
-        # http(s)://を明示しない限り拒否（例: example.com:8080 → ValueError）
-        if _sanitization._SCHEME_RE.match(sanitized_lower):
-            raise ValueError("Dangerous URL scheme detected")
-        # スキームなし → https:// を補完して検証
-        # _validate_netloc / normalize_url の ValueError はそのまま伝播
-        # 設計意図: スキームなしURLはドメインのみ許可（パス付きURLは拒否）
-        # パーセントエンコード済み %2F によるバイパスも防止
-        validate_scheme_less_url(sanitized)
-        parsed = urlparse("https://" + sanitized)
-        _sanitization._validate_netloc(parsed)
-        # スキームなし補完後のポートチェック:
-        # IPアドレス:port形式（例: 192.168.1.1:8080）がここに到達する
-        # （ドメイン:port形式（例: example.com:8080）は _SCHEME_RE にマッチし
-        #  「危険なURLスキーム」として上流で拒否されるため、このチェックに到達しない）
-        if parsed.port is not None:
-            raise ValueError(
-                "Scheme-less URL cannot contain a port (explicitly use http:// or https://)"
-            )
-        return _sanitization._ensure_website_max_length(normalize_url(parsed))
+        # policy 本体は sanitization.validate_website_url に委譲（private 非依存）
+        return validate_website_url(v)
 
 
 # =============================================================================
@@ -472,19 +423,5 @@ class Photo(BaseModel):
             エスケープが必須。
 
         """
-        sanitized = strip_invisible_chars(v).strip()
-        if not sanitized:
-            raise ValueError("URL became empty after control character removal")
-        # CRLF injection防止: パーセントエンコードされた制御文字を拒否（%00-%1f全範囲）
-        sanitized_lower = sanitized.lower()
-        if _sanitization._PERCENT_CTRL_RE.search(sanitized_lower):
-            raise ValueError("URL contains percent-encoded control characters")
-        # 不完全な%シーケンス（%、%G、%GGなど）はunquoteがリテラル扱いするため個別チェック
-        if _sanitization._INCOMPLETE_PCT_RE.search(sanitized):
-            raise ValueError("URL contains incomplete percent-encoding")
-        if not sanitized_lower.startswith(("http://", "https://")):
-            raise ValueError("URL must start with http:// or https://")
-        # _validate_netloc / normalize_url の ValueError はそのまま伝播
-        parsed = urlparse(sanitized)
-        _sanitization._validate_netloc(parsed)
-        return _sanitization._ensure_website_max_length(normalize_url(parsed))
+        # policy 本体は sanitization.validate_strict_url に委譲（private 非依存）
+        return validate_strict_url(v)

--- a/models/sanitization.py
+++ b/models/sanitization.py
@@ -3,7 +3,7 @@
 import html
 import re
 import unicodedata
-from urllib.parse import ParseResult, quote, unquote, urlunparse
+from urllib.parse import ParseResult, quote, unquote, urlparse, urlunparse
 
 _SCHEME_RE: re.Pattern[str] = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 _HTML_META_RE: re.Pattern[str] = re.compile(r'[<>"\'&]')
@@ -240,3 +240,94 @@ def validate_scheme_less_url(sanitized: str) -> None:
         raise ValueError("Scheme-less URL cannot contain a fragment")
     if "?" in sanitized or "?" in decoded:
         raise ValueError("Scheme-less URL cannot contain a query")
+
+
+def _shared_url_prefix(raw: str, *, empty_message: str) -> str:
+    """URL 検証の共通 prefix: 不可視文字除去 → 空拒否 → percent-ctrl / incomplete-pct。
+
+    実装詳細（regex 定数）は private のまま隠蔽する。
+    """
+    sanitized = strip_invisible_chars(raw).strip()
+    if not sanitized:
+        raise ValueError(empty_message)
+    sanitized_lower = sanitized.lower()
+    # CRLF injection 防止: パーセントエンコードされた制御文字を拒否（%00-%1f および %7f）
+    if _PERCENT_CTRL_RE.search(sanitized_lower):
+        raise ValueError("URL contains percent-encoded control characters")
+    # 不完全な%シーケンス（%、%G、%GG など）は unquote がリテラル扱いするため個別チェック
+    if _INCOMPLETE_PCT_RE.search(sanitized):
+        raise ValueError("URL contains incomplete percent-encoding")
+    return sanitized
+
+
+def _finalize_http_url(sanitized: str) -> str:
+    """http(s) 共通 suffix: urlparse → netloc 検証 → 正規化 → 最大長チェック。"""
+    parsed = urlparse(sanitized)
+    _validate_netloc(parsed)
+    return _ensure_website_max_length(normalize_url(parsed))
+
+
+def validate_website_url(raw: str) -> str:
+    """User.website 用 URL 検証（scheme 任意 + https 補完）。
+
+    スキームなしドメインは ``https://`` を自動補完する。プロトコル相対 URL（//）と
+    危険スキームは拒否。スキームなし URL の port / path / query / fragment も拒否。
+
+    Args:
+        raw: 検証対象の URL 文字列（呼び出し元で str 型を保証すること）。
+
+    Returns:
+        正規化済み URL 文字列（最大 ``WEBSITE_NORMALIZED_MAX_LENGTH`` 文字）。
+
+    Raises:
+        ValueError: 空・危険スキーム・protocol-relative・netloc 不正・長すぎる場合など。
+    """
+    sanitized = _shared_url_prefix(
+        raw,
+        empty_message="Website became empty after control character removal",
+    )
+    sanitized_lower = sanitized.lower()
+    if sanitized_lower.startswith("//"):
+        raise ValueError("Protocol-relative URLs are not allowed")
+    # urlparse は各分岐で1回のみ（http/https と補完で入力が異なるため共通化不可）
+    if sanitized_lower.startswith(("http://", "https://")):
+        # NOTE: sanitized（元の大文字混在）を使用 — スキーム小文字化は normalize_url に委譲
+        return _finalize_http_url(sanitized)
+    # RFC 3986 スキーム検出: http/https 以外のスキームが存在すれば拒否
+    # domain:port はスキームなし扱いのため http(s):// を明示しない限り拒否
+    if _SCHEME_RE.match(sanitized_lower):
+        raise ValueError("Dangerous URL scheme detected")
+    # スキームなし → https:// を補完して検証
+    validate_scheme_less_url(sanitized)
+    parsed = urlparse("https://" + sanitized)
+    _validate_netloc(parsed)
+    # IPアドレス:port 形式（例: 192.168.1.1:8080）がここに到達する
+    # （ドメイン:port は _SCHEME_RE にマッチし上流で拒否される）
+    if parsed.port is not None:
+        raise ValueError(
+            "Scheme-less URL cannot contain a port (explicitly use http:// or https://)"
+        )
+    return _ensure_website_max_length(normalize_url(parsed))
+
+
+def validate_strict_url(raw: str) -> str:
+    """Photo.url / thumbnailUrl 用 URL 検証（http/https スキーム必須）。
+
+    スキームなしへの自動補完は行わない（外部 API 由来 URL のためスキーム必須）。
+
+    Args:
+        raw: 検証対象の URL 文字列。
+
+    Returns:
+        正規化済み URL 文字列（最大 ``WEBSITE_NORMALIZED_MAX_LENGTH`` 文字）。
+
+    Raises:
+        ValueError: 空・スキーム非 http(s)・netloc 不正・長すぎる場合など。
+    """
+    sanitized = _shared_url_prefix(
+        raw,
+        empty_message="URL became empty after control character removal",
+    )
+    if not sanitized.lower().startswith(("http://", "https://")):
+        raise ValueError("URL must start with http:// or https://")
+    return _finalize_http_url(sanitized)

--- a/tests/unit/test_responses.py
+++ b/tests/unit/test_responses.py
@@ -6,7 +6,6 @@ from typing import Any, Final, TypedDict
 import pytest
 from pydantic import BaseModel, ValidationError
 
-import models.responses as responses_module
 from models.responses import Address, Album, Comment, Company, Geo, Photo, Post, Todo, User
 from models.sanitization import WEBSITE_NORMALIZED_MAX_LENGTH
 from tests.types import _UserData  # noqa: PLC2701 - test-internal helper naming preserved
@@ -667,7 +666,8 @@ class TestUserModel:
         def fake_urlparse(_: str) -> _OverflowingParseResult:
             return _OverflowingParseResult()
 
-        monkeypatch.setattr(responses_module, "urlparse", fake_urlparse)
+        # URL 検証は models.sanitization に委譲済みのため、urlparse はそちらを patch する
+        monkeypatch.setattr("models.sanitization.urlparse", fake_urlparse)
         valid_user_data["website"] = "https://example.com"
 
         with pytest.raises(ValidationError, match=re.escape("Failed to parse userinfo from URL")):

--- a/tests/unit/test_sanitization.py
+++ b/tests/unit/test_sanitization.py
@@ -5,7 +5,12 @@ import re
 
 import pytest
 
-from models.sanitization import sanitize_user_content, strip_invisible_chars
+from models.sanitization import (
+    sanitize_user_content,
+    strip_invisible_chars,
+    validate_strict_url,
+    validate_website_url,
+)
 from tests.unit._response_test_vectors import XSS_TEST_VECTORS
 
 pytestmark = pytest.mark.unit
@@ -141,3 +146,67 @@ def test_strip_invisible_chars_preserves_combining_mark() -> None:
     """結合文字は保持され、NFD由来のホスト名をサイレントに改変しないこと。"""
     result = strip_invisible_chars("cafe\u0301.com")
     assert result == "café.com"
+
+
+class TestValidateWebsiteUrlFacade:
+    """validate_website_url() 公開 façade の契約テスト（Pydantic 非経由）。"""
+
+    def test_accepts_https_and_normalizes_host(self) -> None:
+        assert validate_website_url("HTTPS://Example.COM/Path") == "https://example.com/Path"
+
+    def test_scheme_less_complements_https(self) -> None:
+        assert validate_website_url("hildegard.org") == "https://hildegard.org"
+
+    def test_rejects_protocol_relative(self) -> None:
+        with pytest.raises(ValueError, match=re.escape("Protocol-relative")):
+            validate_website_url("//evil.example/phish")
+
+    def test_rejects_dangerous_scheme(self) -> None:
+        with pytest.raises(ValueError, match=re.escape("Dangerous URL scheme")):
+            validate_website_url("javascript:alert(1)")
+
+    def test_rejects_percent_encoded_control_chars(self) -> None:
+        with pytest.raises(ValueError, match=re.escape("percent-encoded control")):
+            validate_website_url("https://example.com/%0d%0aSet-Cookie:x")
+
+    def test_rejects_incomplete_percent_encoding(self) -> None:
+        with pytest.raises(ValueError, match=re.escape("incomplete percent-encoding")):
+            validate_website_url("https://example.com/path%")
+
+    def test_rejects_scheme_less_with_port(self) -> None:
+        with pytest.raises(ValueError, match=re.escape("cannot contain a port")):
+            validate_website_url("192.168.1.1:8080")
+
+    def test_rejects_control_char_only(self) -> None:
+        with pytest.raises(ValueError, match=re.escape("Website became empty")):
+            validate_website_url("\u200b\u200b")
+
+
+class TestValidateStrictUrlFacade:
+    """validate_strict_url() 公開 façade の契約テスト（Pydantic 非経由）。"""
+
+    def test_accepts_http_and_https(self) -> None:
+        assert validate_strict_url("http://example.com/a.jpg") == "http://example.com/a.jpg"
+        assert (
+            validate_strict_url("HTTPS://CDN.Example.COM/b.jpg") == "https://cdn.example.com/b.jpg"
+        )
+
+    def test_rejects_scheme_less(self) -> None:
+        with pytest.raises(ValueError, match=re.escape("must start with http:// or https://")):
+            validate_strict_url("example.com/a.jpg")
+
+    def test_rejects_dangerous_scheme(self) -> None:
+        with pytest.raises(ValueError, match=re.escape("must start with http:// or https://")):
+            validate_strict_url("javascript:alert(1)")
+
+    def test_rejects_percent_encoded_control_chars(self) -> None:
+        with pytest.raises(ValueError, match=re.escape("percent-encoded control")):
+            validate_strict_url("https://example.com/%0a/x.jpg")
+
+    def test_rejects_incomplete_percent_encoding(self) -> None:
+        with pytest.raises(ValueError, match=re.escape("incomplete percent-encoding")):
+            validate_strict_url("https://example.com/%GG/x.jpg")
+
+    def test_rejects_empty_after_strip(self) -> None:
+        with pytest.raises(ValueError, match=re.escape("URL became empty")):
+            validate_strict_url("   ")


### PR DESCRIPTION
## 概要

User.website / Photo.url のバリデーションロジックを models/sanitization.py に集約し、models/responses.py から委譲するリファクタリング。

## 変更内容

- models/sanitization.py に `validate_website_url` / `validate_strict_url` を追加
- models/responses.py の `User.validate_website_scheme` / `Photo.validate_url_scheme` からロジックを削除して委譲
- 共通前処理（`_shared_url_prefix`）を抽出
- テストを既存挙動維持のまま移行・追加

## テスト

- ✅ ローカルテスト完了: 1433 passed
- ✅ ruff: 0 errors
- ✅ mypy: 0 errors
- ✅ カバレッジ: 97.51%

## 影響範囲

- 🟡 委譲先変更のみ（挙動不変・全テスト通過確認済み）

---

このPRは /push-pr スキルで自動生成されました。