### PR TITLE
refactor(test): テストdocstring/commentを計画書基準に沿って整理 (U2)

### DIFF
--- a/.claude/rules/python/coding-standards.md
+++ b/.claude/rules/python/coding-standards.md
@@ -78,7 +78,7 @@ fixture・helper・テスト用classは、global stateの変更/復元、teardow
 uv run python scripts/check_docstring_refactor.py --self-test
 uv run python scripts/check_docstring_refactor.py --fixture-gate
 BASE_REF=$(git merge-base HEAD origin/develop)
-uv run python scripts/check_docstring_refactor.py "$BASE_REF" <changed-test-files...>
+uv run python scripts/check_docstring_refactor.py "$BASE_REF" tests/path/to/test_file.py
 ```
 
 ---

--- a/.claude/rules/python/coding-standards.md
+++ b/.claude/rules/python/coding-standards.md
@@ -66,6 +66,21 @@ def func(attempt: int) -> float:
 
 公開クラス・関数にdocstring必須、Args/Returns/Raises明記
 
+### 4.1 テストコードのdocstring/comment方針
+
+テスト関数のdocstringとインラインコメントは、テスト名・assert内容・手順を言い換えるだけなら削除する。短いdocstringを残すのは、テスト名だけでは非自明な失敗モード、複数モジュールを通る結合経路、不自然だが本質的な前提や順序、または関数名に入れると長すぎる背景を説明する場合だけにする。
+
+fixture・helper・テスト用classは、global stateの変更/復元、teardown順序、fake client/transport、network blocker、autouse fixture、環境変数上書き、後続テストへの状態リーク防止を説明するWHYを1〜3行で残す。
+
+コメント/docstringのみの整理では、実行ASTとfixture文書化契約を必ず確認する。
+
+```bash
+uv run python scripts/check_docstring_refactor.py --self-test
+uv run python scripts/check_docstring_refactor.py --fixture-gate
+BASE_REF=$(git merge-base HEAD origin/develop)
+uv run python scripts/check_docstring_refactor.py "$BASE_REF" <changed-test-files...>
+```
+
 ---
 
 ## 5. エラーハンドリング

--- a/scripts/check_docstring_refactor.py
+++ b/scripts/check_docstring_refactor.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import argparse
 import ast
+import re
 import shutil
 import subprocess
 import sys
+import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 
@@ -15,13 +18,36 @@ class CheckerError(Exception):
 
 
 _DOCSTRING_CONTAINERS = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+_FIXTURE_TODO_PATH = Path("scripts/fixture_docstring_todo.txt")
+_FIXTURE_HEADER_PATTERN = re.compile(r"^-+ fixtures defined from (?P<owner>.+?) -+$")
+_FIXTURE_OWNER_PATTERN = re.compile(r"^(?P<name>[A-Za-z_]\w*)\b.* -- (?P<source>.+)$")
+_NO_FIXTURE_DOCSTRING = "no docstring available"
+
+
+@dataclass(frozen=True)
+class _FixtureInventory:
+    undocumented: set[str]
+
+
+@dataclass(frozen=True)
+class _FixtureGateResult:
+    exit_code: int
+    message: str
+
+
+def _required_executable(name: str, label: str) -> str:
+    executable = shutil.which(name)
+    if executable is None:
+        raise CheckerError(f"{label} error: {name} executable was not found")
+    return executable
 
 
 def _git_executable() -> str:
-    executable = shutil.which("git")
-    if executable is None:
-        raise CheckerError("Git error: git executable was not found")
-    return executable
+    return _required_executable("git", "Git")
+
+
+def _uv_executable() -> str:
+    return _required_executable("uv", "Fixture gate")
 
 
 def _is_docstring(statement: ast.stmt) -> bool:
@@ -154,6 +180,161 @@ def _check_files(base_ref: str, paths: list[str]) -> int:
     return 1 if failed else 0
 
 
+def _is_tests_fixture_owner(owner: str | None, source: str) -> bool:
+    normalized_owner = _normalize_fixture_source(owner) if owner is not None else ""
+    normalized_source = _normalize_fixture_source(source)
+    owner_is_tests_fixture = normalized_owner.startswith(("tests/", "tests."))
+    return owner_is_tests_fixture and normalized_source.startswith("tests/")
+
+
+def _normalize_fixture_source(source: str) -> str:
+    normalized = source.replace("\\", "/")
+    normalized = re.sub(r"/+", "/", normalized)
+    normalized = re.sub(r":\d+(?::\d+)?$", "", normalized)
+    tests_marker = "/tests/"
+    if tests_marker in normalized:
+        return "tests/" + normalized.split(tests_marker, 1)[1]
+    return normalized
+
+
+def _parse_fixture_docstrings(output: str) -> _FixtureInventory:
+    owner: str | None = None
+    current_name: str | None = None
+    current_identifier: str | None = None
+    current_is_tests_fixture = False
+    undocumented: set[str] = set()
+
+    for line in output.splitlines():
+        header = _FIXTURE_HEADER_PATTERN.match(line)
+        if header is not None:
+            owner = header.group("owner")
+            current_name = None
+            current_identifier = None
+            current_is_tests_fixture = False
+            continue
+
+        fixture = _FIXTURE_OWNER_PATTERN.match(line)
+        if fixture is not None:
+            current_name = fixture.group("name")
+            source = fixture.group("source")
+            current_identifier = f"{_normalize_fixture_source(source)}::{current_name}"
+            current_is_tests_fixture = _is_tests_fixture_owner(owner, source)
+            continue
+
+        if current_is_tests_fixture and current_name and line.strip():
+            if line.strip() == _NO_FIXTURE_DOCSTRING:
+                undocumented.add(current_identifier or current_name)
+            current_name = None
+            current_identifier = None
+            current_is_tests_fixture = False
+
+    return _FixtureInventory(undocumented=undocumented)
+
+
+def _read_fixture_allowlist(path: Path) -> set[str]:
+    try:
+        return {
+            line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+        }
+    except OSError as exc:
+        raise CheckerError(f"Fixture gate error: cannot read allowlist {path}: {exc}") from exc
+
+
+def _evaluate_fixture_gate(
+    inventory: _FixtureInventory,
+    allowlist_path: Path,
+) -> _FixtureGateResult:
+    allowlist = _read_fixture_allowlist(allowlist_path)
+    missing = sorted(inventory.undocumented - allowlist)
+    stale = sorted(allowlist - inventory.undocumented)
+    failures: list[str] = []
+
+    if missing:
+        failures.append(f"missing undocumented fixture allowlist entries: {', '.join(missing)}")
+    if stale:
+        failures.append(f"stale fixture allowlist entries: {', '.join(stale)}")
+    if failures:
+        return _FixtureGateResult(exit_code=1, message="\n".join(failures))
+
+    return _FixtureGateResult(
+        exit_code=0,
+        message=(
+            f"fixture gate OK: {len(inventory.undocumented)} allowlisted undocumented fixtures"
+        ),
+    )
+
+
+def _run_fixture_gate() -> int:
+    try:
+        repo_root = _git_root()
+        uv = _uv_executable()
+        result = subprocess.run(
+            [uv, "run", "pytest", "--fixtures", "-v", "--no-header"],
+            check=False,
+            capture_output=True,
+            cwd=repo_root,
+            text=True,
+        )
+    except CheckerError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    except FileNotFoundError:
+        print("Fixture gate error: uv executable was not found", file=sys.stderr)
+        return 1
+
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "pytest --fixtures failed"
+        print(f"Fixture gate error: {detail}", file=sys.stderr)
+        return 1
+
+    try:
+        gate = _evaluate_fixture_gate(
+            _parse_fixture_docstrings(result.stdout),
+            repo_root / _FIXTURE_TODO_PATH,
+        )
+    except CheckerError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    stream = sys.stderr if gate.exit_code else sys.stdout
+    print(gate.message, file=stream)
+    return gate.exit_code
+
+
+def _fixture_gate_self_test() -> bool:
+    output = r"""
+--------- fixtures defined from tests.unit.test_sample ---------
+documented_fixture -- tests/unit/test_sample.py:10
+    A documented fixture.
+posix_undocumented_fixture -- /repo/tests/unit/test_sample.py:20
+    no docstring available
+--------- fixtures defined from C:\repo\tests\unit\test_sample.py ---------
+windows_undocumented_fixture -- C:\repo\tests\unit\test_sample.py:30
+    no docstring available
+"""
+    inventory = _parse_fixture_docstrings(output)
+    undocumented = {
+        "tests/unit/test_sample.py::posix_undocumented_fixture",
+        "tests/unit/test_sample.py::windows_undocumented_fixture",
+    }
+    if inventory.undocumented != undocumented:
+        return False
+
+    with tempfile.TemporaryDirectory() as directory:
+        allowlist_path = Path(directory) / "fixture_docstring_todo.txt"
+        allowlist_path.write_text("\n".join(undocumented) + "\n", encoding="utf-8")
+        if _evaluate_fixture_gate(inventory, allowlist_path).exit_code != 0:
+            return False
+
+        allowlist_path.write_text("tests/stale.py::stale_fixture\n", encoding="utf-8")
+        result = _evaluate_fixture_gate(inventory, allowlist_path)
+        return (
+            result.exit_code == 1
+            and "missing undocumented fixture allowlist entries" in result.message
+            and "stale fixture allowlist entries" in result.message
+        )
+
+
 def _self_test() -> int:
     cases: tuple[tuple[str, str, str, bool], ...] = (
         (
@@ -259,7 +440,15 @@ def test_renamed() -> None:
 
     print(f"positive {positive_passed}/{positive_total}")
     print(f"negative {negative_passed}/{negative_total}")
-    return 0 if positive_passed == positive_total and negative_passed == negative_total else 1
+    fixture_gate_passed = _fixture_gate_self_test()
+    print(f"fixture gate self-test: {'OK' if fixture_gate_passed else 'FAIL'}")
+    return (
+        0
+        if positive_passed == positive_total
+        and negative_passed == negative_total
+        and fixture_gate_passed
+        else 1
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -269,13 +458,24 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("base_ref", nargs="?")
     parser.add_argument("changed_files", nargs="*")
     parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--fixture-gate", action="store_true")
     args = parser.parse_args(argv)
+
+    if args.self_test and args.fixture_gate:
+        print("Argument error: choose only one checker mode", file=sys.stderr)
+        return 1
 
     if args.self_test:
         if args.base_ref is not None or args.changed_files:
             print("Argument error: --self-test does not accept file arguments", file=sys.stderr)
             return 1
         return _self_test()
+
+    if args.fixture_gate:
+        if args.base_ref is not None or args.changed_files:
+            print("Argument error: --fixture-gate does not accept file arguments", file=sys.stderr)
+            return 1
+        return _run_fixture_gate()
 
     if args.base_ref is None or not args.changed_files:
         print("Argument error: expected <BASE_REF> and at least one changed file", file=sys.stderr)

--- a/scripts/check_docstring_refactor.py
+++ b/scripts/check_docstring_refactor.py
@@ -183,8 +183,13 @@ def _check_files(base_ref: str, paths: list[str]) -> int:
 def _is_tests_fixture_owner(owner: str | None, source: str) -> bool:
     normalized_owner = _normalize_fixture_source(owner) if owner is not None else ""
     normalized_source = _normalize_fixture_source(source)
-    owner_is_tests_fixture = normalized_owner.startswith(("tests/", "tests."))
-    return owner_is_tests_fixture and normalized_source.startswith("tests/")
+
+    # ownerが "conftest" 単体になるケースを明示的に許容する
+    owner_is_valid = (
+        normalized_owner.startswith(("tests/", "tests.")) or normalized_owner == "conftest"
+    )
+
+    return owner_is_valid and normalized_source.startswith("tests/")
 
 
 def _normalize_fixture_source(source: str) -> str:
@@ -311,11 +316,17 @@ posix_undocumented_fixture -- /repo/tests/unit/test_sample.py:20
 --------- fixtures defined from C:\repo\tests\unit\test_sample.py ---------
 windows_undocumented_fixture -- C:\repo\tests\unit\test_sample.py:30
     no docstring available
+--------- fixtures defined from conftest ---------
+conftest_undocumented_fixture -- tests/conftest.py:15
+    no docstring available
 """
     inventory = _parse_fixture_docstrings(output)
     undocumented = {
         "tests/unit/test_sample.py::posix_undocumented_fixture",
         "tests/unit/test_sample.py::windows_undocumented_fixture",
+        # owner見出しが bare "conftest" でも tests/conftest.py の共通fixtureを
+        # 落とさないことを保証する回帰ケース（旧AND条件では除外されて失敗する）
+        "tests/conftest.py::conftest_undocumented_fixture",
     }
     if inventory.undocumented != undocumented:
         return False

--- a/scripts/fixture_docstring_todo.txt
+++ b/scripts/fixture_docstring_todo.txt
@@ -1,0 +1,2 @@
+tests/unit/test_http_helpers.py::mock_settings
+tests/unit/test_jsonplaceholder_base_sync.py::mock_settings

--- a/tests/integration/test_github_api.py
+++ b/tests/integration/test_github_api.py
@@ -19,14 +19,12 @@ async def test_get_user():
     async with AsyncGitHubClient() as client:
         user = await client.get_user("octocat")
 
-        # 必須フィールド確認
         assert user["login"] == "octocat"
         assert "name" in user
         assert "public_repos" in user
         assert "followers" in user
         assert "created_at" in user
 
-        # 型確認
         assert isinstance(user["login"], str)
         assert isinstance(user["public_repos"], int)
 
@@ -35,10 +33,8 @@ async def test_get_repos():
     async with AsyncGitHubClient() as client:
         repos = await client.get_repos("octocat", per_page=5, sort="updated")
 
-        # 取得件数確認
         assert len(repos) <= 5
 
-        # 必須フィールド確認
         for repo in repos:
             assert "name" in repo
             assert "full_name" in repo
@@ -52,7 +48,6 @@ async def test_get_repo():
     async with AsyncGitHubClient() as client:
         repo = await client.get_repo("octocat", "Hello-World")
 
-        # 必須フィールド確認
         assert repo["name"] == "Hello-World"
         assert repo["full_name"] == "octocat/Hello-World"
         assert "stargazers_count" in repo
@@ -60,7 +55,6 @@ async def test_get_repo():
         assert "open_issues_count" in repo
         assert "description" in repo
 
-        # 型確認
         assert isinstance(repo["stargazers_count"], int)
         assert isinstance(repo["forks_count"], int)
 

--- a/tests/integration/test_jsonplaceholder_posts.py
+++ b/tests/integration/test_jsonplaceholder_posts.py
@@ -29,6 +29,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.skipif(SKIP_INTEGRATION, reas
 
 
 def test_sync_get_nonexistent_post_raises_404() -> None:
+    """GET /posts の欠番だけが安定した 404 契約を返すことを固定する。"""
     # 到達性確認 — 接続障害時は skip（404 契約バグではない）
     try:
         with SyncJSONPlaceholderClient() as client:
@@ -64,9 +65,8 @@ async def test_async_create_post_response_parses_into_post_model() -> None:
 
 
 async def test_async_update_post_returns_sent_fields_as_dict() -> None:
-    # JSONPlaceholderのPUTはuserIdを返さないため、Postモデルではなくdictで検証する
+    # JSONPlaceholder の PUT は userId を返さないため、Post ではなく dict で検証する。
     async with AsyncJSONPlaceholderClient() as client:
-        # 既存投稿を更新（id=1 は常に存在する）
         updated = await client.update_post(
             post_id=1,
             title="Updated Title via Integration Test",
@@ -86,7 +86,6 @@ async def test_async_delete_post_completes_without_exception() -> None:
 
 async def test_async_post_crud_sequence_reuses_one_client() -> None:
     async with AsyncJSONPlaceholderClient() as client:
-        # Step 1: Create - 新規投稿作成
         post = await client.create_post(
             title="E2E Integration Test",
             body="Testing full CRUD flow with real API",
@@ -96,14 +95,12 @@ async def test_async_post_crud_sequence_reuses_one_client() -> None:
         assert post_id == 101  # JSONPlaceholder API の仕様
         assert post.title == "E2E Integration Test"
 
-        # 投稿一覧取得
         # JSONPlaceholder API の仕様: 新規作成データは永続化されないため、
         # 既存データ（id=1-100）を取得して確認
         posts = await client.get_posts(limit=10)
         assert len(posts) > 0
         assert isinstance(posts, list)
 
-        # Update - 既存投稿を更新（id=1）
         updated = await client.update_post(
             post_id=1,
             title="Updated in Integration Test",
@@ -112,12 +109,12 @@ async def test_async_post_crud_sequence_reuses_one_client() -> None:
         assert updated["id"] == 1
         assert updated["title"] == "Updated in Integration Test"
 
-        # Step 4: Delete - 投稿削除（id=1）
-        # delete_post() returns None, so just verify no exception raised
+        # DELETE は永続化されず応答も空のため、例外がないことだけを契約にする。
         await client.delete_post(post_id=1)
 
 
 async def test_async_get_nonexistent_post_raises_404() -> None:
+    """実在する欠番をGETで確認し、APIの404契約が壊れた回帰を検知する。"""
     # 到達性確認 — 接続障害時は skip（404 契約バグではない）
     try:
         async with AsyncJSONPlaceholderClient() as client:

--- a/tests/integration/test_jsonplaceholder_users.py
+++ b/tests/integration/test_jsonplaceholder_users.py
@@ -18,17 +18,17 @@ pytestmark = [pytest.mark.integration, pytest.mark.skipif(SKIP_INTEGRATION, reas
 
 
 async def test_async_user_nested_models_parsed() -> None:
+    """Alias解決の回帰を検知するため、3段の入れ子モデルを実APIで検証する。"""
     async with AsyncJSONPlaceholderClient() as client:
         user = await client.get_user(1)
 
     assert isinstance(user, User)
     assert user.id == 1
 
-    # Address → Geo（2段目・3段目の入れ子が構築されている）
     assert user.address.city
     assert isinstance(user.address.geo.lat, str)
 
-    # Company（alias catchPhrase → catch_phrase の解決が効いている）
+    # catchPhrase はモデル側の alias で catch_phrase に変換される。
     assert user.company.catch_phrase
 
 
@@ -41,7 +41,6 @@ async def test_async_get_user_data_parallel_aggregation() -> None:
     assert isinstance(data["user"], User)
     assert data["user"].id == user_id
 
-    # 各キーが「空でない」「期待する型」「全件が該当ユーザー」の3条件を満たすこと
     assert data["posts"]
     assert all(isinstance(post, Post) for post in data["posts"])
     assert all(post.user_id == user_id for post in data["posts"])

--- a/tests/integration/test_sentry_logging.py
+++ b/tests/integration/test_sentry_logging.py
@@ -123,14 +123,13 @@ def test_logger_error_forwards_to_sentry_with_pii_scrubbed(
     # event全体をシリアライズし、ネストした任意の場所へのPII漏洩を検査する
     serialized = json.dumps(captured_events, default=str)
 
-    # Assert 2: PII 値がどの event にも含まれない
     # （_before_send スクラブが実 logger パスで効く証明）。
     assert "super-secret-value" not in serialized, (
         "PII 値 'super-secret-value' が capture event にリークしている"
         "（_before_send のスクラブが実 logger 経路で機能していない）"
     )
 
-    # Assert 3: スクラブ後も非機密のイベント名は残る（過剰スクラブで全消ししていないことの証明）。
+    # スクラブ後も非機密のイベント名は残る（過剰スクラブで全消ししていないことの証明）。
     assert "integration_test_error" in serialized, (
         "非機密のイベント名 'integration_test_error' が失われている（過剰スクラブの疑い）"
     )

--- a/tests/integration/test_sentry_logging.py
+++ b/tests/integration/test_sentry_logging.py
@@ -84,7 +84,7 @@ def captured_events(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[dict[str, 
     reload_settings()
     _reset_sentry_sdk_client_for_test()
 
-    assert init_sentry() is True, "fake DSN での Sentry 初期化に失敗"
+    assert init_sentry() is True, "Failed to initialize Sentry with the fake DSN."
 
     transport = _CapturingTransport()
     client = sentry_sdk.get_client()
@@ -102,7 +102,7 @@ def captured_events(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[dict[str, 
     # これを欠くと captured_events が空のまま PII 検証が vacuously true となり
     # サイレントにリークを見逃す（sentry-sdk 内部 API のバージョン差異対策）。
     # クリーンアップ後に assert することで、失敗してもセッション状態は復元済みにする。
-    assert not captured_errors, f"capturing transport で payload 抽出に失敗: {captured_errors}"
+    assert not captured_errors, f"Failed to extract captured payload: {captured_errors}"
 
 
 def test_logger_error_forwards_to_sentry_with_pii_scrubbed(
@@ -116,22 +116,19 @@ def test_logger_error_forwards_to_sentry_with_pii_scrubbed(
 
     # 空リストに対するvacuous passを防ぐため、capture成功を先に検証する
     assert len(captured_events) >= 1, (
-        f"ERROR ログが Sentry へ転送されていない（captured={len(captured_events)} 件）。"
-        " transport 差し替えタイミング / flush / structlog level routing を確認すること"
+        "Expected at least one captured Sentry event. "
+        "Check transport replacement timing, flush(), and structlog routing."
     )
 
     # event全体をシリアライズし、ネストした任意の場所へのPII漏洩を検査する
     serialized = json.dumps(captured_events, default=str)
 
-    # （_before_send スクラブが実 logger パスで効く証明）。
-    assert "super-secret-value" not in serialized, (
-        "PII 値 'super-secret-value' が capture event にリークしている"
-        "（_before_send のスクラブが実 logger 経路で機能していない）"
-    )
+    # _before_send スクラブが実 logger パスで効く証明。
+    assert "super-secret-value" not in serialized, "PII leaked into the captured Sentry event."
 
     # スクラブ後も非機密のイベント名は残る（過剰スクラブで全消ししていないことの証明）。
     assert "integration_test_error" in serialized, (
-        "非機密のイベント名 'integration_test_error' が失われている（過剰スクラブの疑い）"
+        "Non-sensitive event name 'integration_test_error' was removed unexpectedly."
     )
 
 
@@ -145,7 +142,7 @@ def test_logger_warning_does_not_forward_to_sentry(
     sentry_sdk.flush()
 
     assert len(captured_events) == events_before, (
-        "WARNING ログが Sentry event として送信されている（レベルルーティングが誤っている）"
+        "WARNING log was forwarded to Sentry unexpectedly."
     )
 
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,4 +1,4 @@
-"""Exception hierarchy tests for utils.exceptions."""
+"""例外階層の契約テスト。"""
 
 from collections.abc import Callable
 from unittest.mock import Mock
@@ -23,15 +23,7 @@ MockResponseFactory = Callable[[object | None], Mock]
 
 @pytest.fixture()
 def mock_response_factory() -> MockResponseFactory:
-    """テスト用 Mock(spec=httpx.Response) を生成する factory fixture
-
-    テスト間で mock 生成ロジックを集約し、httpx.Response 仕様変更時の
-    修正を1箇所に限定する。
-
-    Returns:
-        payload（省略可）を受け取り、json.return_value を設定した
-        Mock(spec=httpx.Response) を返す callable
-    """
+    """mock生成を集約し、httpx.Response互換の修正点を1箇所に閉じ込める。"""
 
     def _factory(payload: object | None = None) -> Mock:
         response = Mock(spec=httpx.Response)
@@ -43,7 +35,6 @@ def mock_response_factory() -> MockResponseFactory:
 
 
 def test_exception_hierarchy() -> None:
-    """例外クラスの継承関係確認"""
     assert issubclass(APIConnectionError, APIClientError)
     assert issubclass(APITimeoutError, APIClientError)
     assert issubclass(APIHTTPError, APIClientError)
@@ -55,7 +46,6 @@ def test_exception_hierarchy() -> None:
 def test_http_error_status_preservation(
     mock_response_factory: MockResponseFactory,
 ) -> None:
-    """APIHTTPError がステータスコードを保持することを確認"""
     mock_response = mock_response_factory()
     mock_response.status_code = 404
 
@@ -67,13 +57,11 @@ def test_http_error_status_preservation(
 
 
 def test_retry_error_message() -> None:
-    """APIRetryError のメッセージ確認"""
     error = APIRetryError("Max retries exceeded")
     assert str(error) == "Max retries exceeded"
 
 
 def test_api_json_decode_error_init(mock_response_factory: MockResponseFactory) -> None:
-    """APIJSONDecodeErrorのコンストラクタテスト"""
     mock_response = mock_response_factory()
     error = APIJSONDecodeError("Parse error", response=mock_response)
 
@@ -82,7 +70,6 @@ def test_api_json_decode_error_init(mock_response_factory: MockResponseFactory) 
 
 
 def test_api_json_decode_error_without_response() -> None:
-    """APIJSONDecodeError: responseなしでも動作"""
     error = APIJSONDecodeError("Parse error")
 
     assert str(error) == "Parse error"


### PR DESCRIPTION
## 概要

U2 パイロット実装 + KTD5 コーディング規約更新 + 参考実装完成。

## 変更内容

- `.claude/rules/python/coding-standards.md`: テストコードのdocstring/comment方針をセクション4.1として追記
- `scripts/check_docstring_refactor.py`: ASTチェッカーを拡張（fixture gate対応等）
- `scripts/fixture_docstring_todo.txt`: fixture docstring未記載追跡リストを新規作成
- `tests/integration/*.py`: 自明コメント削除、非自明なWHYのみ1行で残す、アサートメッセージ一部英語化
- `tests/unit/test_exceptions.py`: モジュール/fixture docstring圧縮、自明コメント削除

## テスト

- ✅ pytest 1420 passed (unit + integration)
- ✅ ruff check / ruff format
- ✅ mypy: Success
- ✅ ASTチェッカー self-test: OK