### PR TITLE
refactor(test): テストdocstring/commentを計画書基準に沿って整理 (U4: 2ファイル)

### DIFF
--- a/.serena/memories/test_strategy_details.md
+++ b/.serena/memories/test_strategy_details.md
@@ -1,6 +1,6 @@
 # テスト戦略・詳細実装ガイド
 
-*最終更新: 2026年06月07日*
+*最終更新: 2026年07月17日*
 
 > **概要版**: @memory:test_strategy を参照
 
@@ -240,7 +240,7 @@ async with AsyncJSONPlaceholderClient() as client:
 ### 8.1 テストコード品質
 - **DRY**: Factory Pattern活用
 - **命名**: `test_[機能]_[ケース]`
-- **docstring必須**: 検証項目明記
+- **docstring方針**: 言い換えは削除、WHY のみ残す（coding-standards.md §4.1）
 
 ### 8.2 技術的負債管理
 ```python

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -63,10 +63,7 @@ def deterministic_ssrf_validator_dns(monkeypatch: pytest.MonkeyPatch) -> Iterato
 
 
 class TestAPIConfigBaseUrlDependencyInjection:
-    """base_url検証の許可ドメイン注入テスト。"""
-
     def test_validate_base_url_accepts_injected_allowed_domain(self) -> None:
-        """ALLOWED_DOMAINSのモンキーパッチなしで許可ドメインを注入できる。"""
         result = _validate_base_url_with_allowed_domains(
             "https://example.com/",
             frozenset({"example.com"}),
@@ -77,7 +74,6 @@ class TestAPIConfigBaseUrlDependencyInjection:
     def test_validate_base_url_rejects_domain_missing_from_injected_allowlist(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """注入された許可リスト外のドメインは拒否される。"""
         # このテストは DNS/private-IP 判定経路を使わず、
         # allowlist 分岐だけを決定的に検証する。
         monkeypatch.setattr(socket, "gethostbyname", lambda _: "1.2.3.4")
@@ -88,7 +84,6 @@ class TestAPIConfigBaseUrlDependencyInjection:
             )
 
     def test_validate_base_url_rejects_missing_hostname(self) -> None:
-        """hostname が取れない URL は拒否される。"""
         with pytest.raises(ValueError, match="Invalid URL: hostname not found"):
             _validate_base_url_with_allowed_domains(
                 "https://",
@@ -100,7 +95,6 @@ class TestAPIConfigBaseUrlDependencyInjection:
         caplog: pytest.LogCaptureFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """許可ドメイン不一致時はALLOWED_DOMAINS確認をログへ残す。"""
         # このテストは DNS/private-IP 判定経路を使わず、
         # allowlist 分岐だけを決定的に検証する。
         monkeypatch.setattr(socket, "gethostbyname", lambda _: "1.2.3.4")
@@ -120,7 +114,6 @@ class TestAPIConfigBaseUrlDependencyInjection:
     def test_validate_base_url_logs_warning_for_domain_not_in_allowlist(
         self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """許可ドメイン外アクセス試行時にSSRFセキュリティ証跡が記録される。"""
         monkeypatch.setattr(socket, "gethostbyname", lambda _: "1.2.3.4")
         with caplog.at_level(logging.WARNING, logger="config.settings"):
             with pytest.raises(ValueError, match="Domain not in allowlist"):
@@ -135,14 +128,6 @@ class TestAPIConfigBaseUrlDependencyInjection:
 
 
 class TestAPIConfigBoundaryValues:
-    """APIConfig数値フィールドの境界値テスト（P1-Critical）
-
-    Pydantic Fieldのge/le制約を検証:
-    - timeout: ge=1.0, le=300.0
-    - retry_count: ge=0, le=10
-    - retry_delay: ge=0.1, le=60.0
-    """
-
     @pytest.mark.parametrize(
         ("field", "value", "should_pass"),
         [
@@ -169,12 +154,6 @@ class TestAPIConfigBoundaryValues:
         value: float,
         should_pass: bool,
     ) -> None:
-        """数値フィールドの境界値検証
-
-        Note:
-            動的kwargs展開のため type: ignore を使用。
-            parametrizedテストの設計上、静的型チェックの限界。
-        """
         if should_pass:
             config = APIConfig(**{field: value})  # type: ignore[arg-type]
             assert getattr(config, field) == value
@@ -184,53 +163,41 @@ class TestAPIConfigBoundaryValues:
 
 
 class TestAPIConfigValidation:
-    """APIConfig.validate_base_url のテスト (lines 73-77)"""
-
     def test_base_url_without_scheme_raises_error(self):
-        """スキーム(http/https)なしのURLでエラー発生"""
         with pytest.raises(ValidationError) as exc_info:
             APIConfig(base_url="example.com")
         assert "Base URL must start with http:// or https://" in str(exc_info.value)
 
     def test_base_url_with_ftp_scheme_raises_error(self):
-        """ftp://スキームでエラー発生"""
         with pytest.raises(ValidationError) as exc_info:
             APIConfig(base_url="ftp://example.com")
         assert "Base URL must start with http:// or https://" in str(exc_info.value)
 
     def test_base_url_with_trailing_slash_removed(self):
-        """末尾のスラッシュが削除される (line 76-77)"""
         config = APIConfig(base_url="https://example.com/")
         assert config.base_url == "https://example.com"
         assert not config.base_url.endswith("/")
 
     def test_base_url_with_multiple_trailing_slashes_removed(self):
-        """複数の末尾スラッシュが削除される"""
         config = APIConfig(base_url="https://example.com///")
         assert config.base_url == "https://example.com"
 
     def test_base_url_http_scheme_valid(self):
-        """http://スキームが有効（SSRF対応: 許可ドメインを使用）"""
         config = APIConfig(base_url="http://httpbin.org")
         assert config.base_url == "http://httpbin.org"
 
     def test_base_url_https_scheme_valid(self):
-        """https://スキームが有効（DNS解決可能なドメインを使用）"""
         # Note: example.com系はDNS解決失敗でFail-Closedブロック
         config = APIConfig(base_url="https://api.github.com")
         assert config.base_url == "https://api.github.com"
 
 
 class TestLogConfigValidation:
-    """LogConfig.validate_log_file のテスト (lines 105-109)"""
-
     def test_log_file_none_handling(self):
-        """file=None の場合の処理 (line 105)"""
         config = LogConfig(file=None)
         assert config.file is None
 
     def test_log_file_directory_creation(self, tmp_path: Path) -> None:
-        """存在しないディレクトリが自動作成される (lines 106-108)"""
         log_file = tmp_path / "logs" / "subdir" / "app.log"
         assert not log_file.parent.exists()
 
@@ -241,7 +208,6 @@ class TestLogConfigValidation:
         assert log_file.parent.is_dir()
 
     def test_log_file_existing_directory(self, tmp_path: Path) -> None:
-        """既存ディレクトリの場合もエラーなし"""
         log_dir = tmp_path / "existing_logs"
         log_dir.mkdir(parents=True, exist_ok=True)
         log_file = log_dir / "app.log"
@@ -250,15 +216,12 @@ class TestLogConfigValidation:
         assert config.file == str(log_file)
 
     def test_log_file_deep_nested_directory_creation(self, tmp_path: Path) -> None:
-        """深くネストされたディレクトリの作成"""
         log_file = tmp_path / "a" / "b" / "c" / "d" / "app.log"
         _ = LogConfig(file=str(log_file))
         assert log_file.parent.exists()
 
 
 class TestSettingsEnvironmentValidation:
-    """Settings.validate_environment のテスト (lines 192-194)"""
-
     @pytest.mark.parametrize(
         ("env_input", "expected", "needs_secret"),
         [
@@ -274,14 +237,7 @@ class TestSettingsEnvironmentValidation:
         expected: Environment,
         needs_secret: bool,
     ) -> None:
-        """環境設定バリデーション: 文字列→小文字変換、Enum直接指定
-
-        Note:
-            Pydantic field_validatorが実行時に文字列→Enum変換を行うため、
-            str | Environment を受け入れる。静的型チェックとの差異あり。
-            本番・ステージング環境はシークレット必須かつHTTPS強制のため、
-            needs_secret=Trueの場合はHTTPS URLも合わせて指定する。
-        """
+        """Pydanticのstr→Enum実行時変換により、静的型との差異を許容する契約を検証する。"""
         if needs_secret:
             settings = Settings(
                 environment=env_input,  # type: ignore[arg-type]
@@ -301,7 +257,6 @@ class TestSettingsEnvironmentValidation:
         ],
     )
     def test_environment_validation_strips_whitespace(self, env_input: str) -> None:
-        """validate_environment: 前後スペースを除去してから正規化する"""
         stripped = env_input.strip().lower()
         expected = Environment(stripped)
         needs_secret = expected in {Environment.PRODUCTION, Environment.STAGING}
@@ -324,12 +279,10 @@ class TestSettingsEnvironmentValidation:
         ],
     )
     def test_environment_validation_empty_raises(self, empty_input: str) -> None:
-        """validate_environment: 空文字列・スペースのみ・タブのみはValidationErrorを発生させる"""
         with pytest.raises(ValidationError):
             Settings(environment=empty_input)  # type: ignore[arg-type]
 
     def test_environment_validation_invalid_string_raises(self) -> None:
-        """validate_environment: タイポなど無効な文字列はValidationErrorを発生させる"""
         with pytest.raises(ValidationError) as exc_info:
             Settings(environment="producton")  # type: ignore[arg-type]
         # エラーメッセージに有効値リストが含まれることを検証（契約の明示的保護）
@@ -337,7 +290,6 @@ class TestSettingsEnvironmentValidation:
         assert any("有効な値" in str(e["msg"]) for e in exc_info.value.errors())
 
     def test_environment_validation_invalid_type_raises(self) -> None:
-        """validate_environment: str/Environment以外の型はValidationErrorを発生させる"""
         with pytest.raises(ValidationError):
             Settings(environment=123)  # type: ignore[arg-type]
 
@@ -351,36 +303,21 @@ class TestSettingsEnvironmentValidation:
         ],
     )
     def test_environment_validation_short_forms_raise(self, short_form: str) -> None:
-        """validate_environment: 短縮形 (dev/test/stg/prod) は ValidationError を発生させる.
-
-        .env.example および docker-compose.yml で「Pydantic Environment enum は
-        development/testing/staging/production の 4 値のみ。短縮形は不可」と明示している。
-        本テストはその契約を保護する。
-
-        Note:
-            dev/test/stg/prod は互換マッピングせず、Pydantic層で常に reject される。
-            本テストは「直接 python から Settings を instantiate する」シナリオ
-            (CI script, smoke test 等) を検証する。
-        """
+        """.env.example/docker-compose.ymlで明示された「短縮形不可」契約を、直接Settingsをinstantiateして保護する。"""
         with pytest.raises(ValidationError):
             Settings(environment=short_form)  # type: ignore[arg-type]
 
 
 class TestSettingsEnvironmentMethods:
-    """Settings環境判定メソッドのテスト (lines 198, 202, 206, 210)"""
-
     def test_is_development_true(self):
-        """is_development() がTrueを返す (line 198)"""
         settings = Settings(environment=Environment.DEVELOPMENT)
         assert settings.is_development() is True
 
     def test_is_testing_true(self):
-        """is_testing() がTrueを返す (line 202)"""
         settings = Settings(environment=Environment.TESTING)
         assert settings.is_testing() is True
 
     def test_is_production_true(self):
-        """is_production() がTrueを返す (line 206)"""
         # 本番環境ではシークレットが必須
         settings = Settings(
             environment=Environment.PRODUCTION,
@@ -398,7 +335,6 @@ class TestSettingsEnvironmentMethods:
         ],
     )
     def test_is_staging(self, env: Environment, expected: bool) -> None:
-        """is_staging() がステージング環境のみTrueを返す"""
         kwargs: dict[str, Any] = {"environment": env}
         if env in {Environment.PRODUCTION, Environment.STAGING}:
             kwargs["security"] = SecurityConfig(api_key=SecretStr("test-key"))
@@ -415,7 +351,6 @@ class TestSettingsEnvironmentMethods:
         ],
     )
     def test_is_production_like(self, env: Environment, expected: bool) -> None:
-        """is_production_like() が本番相当環境を正しく判定"""
         kwargs: dict[str, Any] = {"environment": env}
         if env in {Environment.PRODUCTION, Environment.STAGING}:
             kwargs["security"] = SecurityConfig(api_key=SecretStr("test-key"))
@@ -433,23 +368,18 @@ class TestSettingsEnvironmentMethods:
         ],
     )
     def test_get_log_level_mapping(self, log_level: LogLevel, expected: int) -> None:
-        """get_log_level() がLogLevel Enumを正しくlogging定数にマッピング"""
         settings = Settings()
         settings.log.level = log_level
         assert settings.get_log_level() == expected
 
 
 class TestProductionSecretValidation:
-    """本番・ステージング環境でのシークレット検証テスト"""
-
     def test_production_without_secrets_raises_error(self):
-        """本番環境でシークレット未設定時にエラー"""
         with pytest.raises(ValidationError) as exc_info:
             Settings(environment=Environment.PRODUCTION)
         assert "SECURITY__API_KEY or SECURITY__JWT_SECRET" in str(exc_info.value)
 
     def test_production_with_api_key_valid(self):
-        """本番環境でapi_key設定時は有効"""
         settings = Settings(
             environment=Environment.PRODUCTION,
             security=SecurityConfig(api_key=SecretStr("test-key")),
@@ -457,7 +387,6 @@ class TestProductionSecretValidation:
         assert settings.is_production() is True
 
     def test_production_with_jwt_secret_valid(self):
-        """本番環境でjwt_secret設定時は有効"""
         settings = Settings(
             environment=Environment.PRODUCTION,
             security=SecurityConfig(jwt_secret=SecretStr("test-secret")),
@@ -465,12 +394,11 @@ class TestProductionSecretValidation:
         assert settings.is_production() is True
 
     def test_development_without_secrets_valid(self):
-        """開発環境ではシークレット不要"""
         settings = Settings(environment=Environment.DEVELOPMENT)
         assert settings.is_development() is True
 
     def test_staging_without_secrets_raises_error(self):
-        """ステージング環境でシークレット未設定時にエラー (STAGING=本番同等ポリシー)"""
+        """TestProductionSecretValidationクラスだがSTAGINGも本番同等のシークレット必須ポリシーを検証する。"""
         with pytest.raises(ValidationError, match="SECURITY__API_KEY or SECURITY__JWT_SECRET"):
             Settings(
                 environment=Environment.STAGING,
@@ -478,7 +406,6 @@ class TestProductionSecretValidation:
             )
 
     def test_staging_with_api_key_valid(self):
-        """ステージング環境でapi_key設定時は有効"""
         settings = Settings(
             environment=Environment.STAGING,
             security=SecurityConfig(api_key=SecretStr("test-key")),
@@ -487,7 +414,6 @@ class TestProductionSecretValidation:
         assert settings.environment == Environment.STAGING
 
     def test_staging_with_jwt_secret_valid(self):
-        """ステージング環境でjwt_secret設定時は有効"""
         settings = Settings(
             environment=Environment.STAGING,
             security=SecurityConfig(jwt_secret=SecretStr("test-secret")),
@@ -498,10 +424,7 @@ class TestProductionSecretValidation:
 
 
 class TestProductionHTTPSValidation:
-    """本番環境でのHTTPS強制テスト"""
-
     def test_production_http_raises_error(self):
-        """本番環境でHTTP URLはエラー"""
         with pytest.raises(ValidationError) as exc_info:
             Settings(
                 environment=Environment.PRODUCTION,
@@ -511,7 +434,6 @@ class TestProductionHTTPSValidation:
         assert "requires HTTPS" in str(exc_info.value)
 
     def test_production_https_valid(self):
-        """本番環境でHTTPS URLは有効"""
         settings = Settings(
             environment=Environment.PRODUCTION,
             security=SecurityConfig(api_key=SecretStr("test-key")),
@@ -520,7 +442,7 @@ class TestProductionHTTPSValidation:
         assert settings.api.base_url == "https://jsonplaceholder.typicode.com"
 
     def test_staging_http_raises_error(self):
-        """ステージング環境でHTTP URLはエラー (OWASP A02)"""
+        """ステージング環境のHTTPS強制をOWASP A02（暗号化の失敗）対策として検証する。"""
         with pytest.raises(ValidationError) as exc_info:
             Settings(
                 environment=Environment.STAGING,
@@ -530,7 +452,6 @@ class TestProductionHTTPSValidation:
         assert "requires HTTPS" in str(exc_info.value)
 
     def test_staging_https_valid(self):
-        """ステージング環境でHTTPS URLは有効"""
         settings = Settings(
             environment=Environment.STAGING,
             security=SecurityConfig(api_key=SecretStr("test-key")),
@@ -539,7 +460,6 @@ class TestProductionHTTPSValidation:
         assert settings.api.base_url == "https://jsonplaceholder.typicode.com"
 
     def test_development_http_valid(self):
-        """開発環境ではHTTP URLを許可"""
         settings = Settings(
             environment=Environment.DEVELOPMENT,
             api=APIConfig(base_url="http://jsonplaceholder.typicode.com"),
@@ -548,10 +468,7 @@ class TestProductionHTTPSValidation:
 
 
 class TestSettingsSecretMasking:
-    """Settings.to_dict() のシークレットマスキングテスト (lines 214-225)"""
-
     def test_to_dict_with_secret_masking_enabled(self):
-        """exclude_secrets=True でシークレットがマスクされる (lines 217-223)"""
         settings = Settings()
         # テスト専用ダミー値（本番では使用されない）
         settings.security.api_key = SecretStr("test-api-key-12345")
@@ -563,7 +480,6 @@ class TestSettingsSecretMasking:
         assert result["security"]["jwt_secret"] == "***MASKED***"  # noqa: S105 - テスト用マスク文字列
 
     def test_to_dict_with_secret_masking_disabled(self):
-        """exclude_secrets=False でシークレットがそのまま出力される (line 216)"""
         settings = Settings()
         # テスト専用ダミー値（本番では使用されない）
         settings.security.api_key = SecretStr("test-api-key-12345")
@@ -577,7 +493,6 @@ class TestSettingsSecretMasking:
         assert "jwt_secret" in result["security"]
 
     def test_to_dict_model_dump_called(self):
-        """model_dump() が呼び出される (line 215)"""
         settings = Settings()
         result = settings.to_dict()
 
@@ -590,7 +505,6 @@ class TestSettingsSecretMasking:
         assert "security" in result
 
     def test_to_dict_api_key_none_not_masked(self):
-        """api_keyがNoneの場合はマスク処理がスキップされる (line 220)"""
         settings = Settings()
         settings.security.api_key = None
 
@@ -600,7 +514,6 @@ class TestSettingsSecretMasking:
         assert result["security"]["api_key"] is None
 
     def test_to_dict_jwt_secret_none_not_masked(self):
-        """jwt_secretがNoneの場合はマスク処理がスキップされる (line 222)"""
         settings = Settings()
         settings.security.jwt_secret = None
 
@@ -609,7 +522,6 @@ class TestSettingsSecretMasking:
         assert result["security"]["jwt_secret"] is None
 
     def test_to_dict_sentry_dsn_masked(self):
-        """Sentry DSN設定時にマスクされる (lines 385-389)"""
         from pydantic import SecretStr
 
         settings = Settings()
@@ -622,7 +534,7 @@ class TestSettingsSecretMasking:
         assert result["sentry"]["dsn"] == "***MASKED***"
 
     def test_to_dict_sentry_dsn_empty_also_masked(self):
-        """空DSNもマスクされる（model_dump後は文字列として扱われる）"""
+        """空のSecretStrもmodel_dump後は文字列化されマスク対象になる仕様を検証する。"""
         settings = Settings()
         # デフォルトは空SecretStr、model_dump()後は'**********'文字列
 
@@ -632,7 +544,6 @@ class TestSettingsSecretMasking:
         assert result["sentry"]["dsn"] == "***MASKED***"
 
     def test_sentry_config_default_factory(self):
-        """SentryConfigがdefault_factoryで作成される"""
         settings = Settings()
 
         assert isinstance(settings.sentry, SentryConfig)
@@ -641,7 +552,7 @@ class TestSettingsSecretMasking:
 
 
 class TestSettingsSingleton:
-    """シングルトンパターンのテスト (lines 239-248)"""
+    """シングルトン状態のリークを防ぐため、autouse fixtureでリセットし再生成契約を検証する。"""
 
     @pytest.fixture(autouse=True)
     def reset_singleton(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -651,20 +562,17 @@ class TestSettingsSingleton:
         monkeypatch.setattr(config.settings, "_settings", None)
 
     def test_get_settings_creates_instance_first_time(self) -> None:
-        """get_settings() が初回呼び出しで新インスタンスを作成 (lines 239-241)"""
         settings1 = get_settings()
         assert settings1 is not None
         assert isinstance(settings1, Settings)
 
     def test_get_settings_returns_same_instance(self) -> None:
-        """get_settings() が2回目以降は同じインスタンスを返す"""
         settings1 = get_settings()
         settings2 = get_settings()
 
         assert settings1 is settings2
 
     def test_reload_settings_creates_new_instance(self) -> None:
-        """reload_settings() が新しいインスタンスを作成 (lines 247-248)"""
         settings1 = get_settings()
         settings2 = reload_settings()
 
@@ -673,7 +581,6 @@ class TestSettingsSingleton:
         assert isinstance(settings2, Settings)
 
     def test_reload_settings_updates_global_variable(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """reload_settings() がグローバル変数を更新 (line 247)"""
         # 最初のインスタンス作成
         settings1 = get_settings()
         _ = settings1.project_name
@@ -693,8 +600,6 @@ class TestSettingsSingleton:
 
 
 class TestNestedConfigDefaults:
-    """ネスト設定のデフォルトファクトリーテスト"""
-
     @pytest.mark.parametrize(
         ("attr", "expected_type"),
         [
@@ -705,14 +610,11 @@ class TestNestedConfigDefaults:
         ],
     )
     def test_nested_config_type(self, attr: str, expected_type: type) -> None:
-        """各サブ設定がdefault_factoryで正しい型として初期化される"""
         settings = Settings()
         assert isinstance(getattr(settings, attr), expected_type)
 
 
 class TestTestConfigDefaults:
-    """TestConfig のデフォルト値テスト"""
-
     @pytest.mark.parametrize(
         ("attr", "expected"),
         [
@@ -723,16 +625,12 @@ class TestTestConfigDefaults:
         ],
     )
     def test_test_config_boolean_defaults(self, attr: str, expected: bool) -> None:
-        """TestConfig の bool デフォルトが退行しないことを保護する"""
         config = SettingsTestConfig()
         assert getattr(config, attr) is expected
 
 
 class TestEnvironmentVariableLoading:
-    """環境変数からの設定読み込みテスト"""
-
     def test_nested_environment_variable_loading(self, monkeypatch):
-        """ネスト記法（API__BASE_URL）での環境変数読み込み"""
         # Note: DNS解決可能なドメインを使用（example.com系はFail-Closedでブロック）
         monkeypatch.setenv("API__BASE_URL", "https://httpbin.org")
         import config.settings
@@ -743,7 +641,6 @@ class TestEnvironmentVariableLoading:
         assert settings.api.base_url == "https://httpbin.org"
 
     def test_case_insensitive_environment_variables(self, monkeypatch):
-        """大小文字を区別しない環境変数読み込み (case_sensitive=False)"""
         monkeypatch.setenv("project_name", "Test Project")
         import config.settings
 
@@ -753,7 +650,6 @@ class TestEnvironmentVariableLoading:
         assert settings.project_name == "Test Project"
 
     def test_debug_mode_from_environment(self, monkeypatch):
-        """DEBUG環境変数からのdebugモード設定"""
         monkeypatch.setenv("DEBUG", "false")
         import config.settings
 
@@ -764,11 +660,7 @@ class TestEnvironmentVariableLoading:
 
 
 class DNSCacheClearMixin:
-    """DNS解決キャッシュクリアの共通fixture
-
-    TestSSRFPrevention と TestResolveHostname で共有する。
-    autouse=True により各テスト前後にキャッシュをクリアし、テスト間の干渉を防止。
-    """
+    """TestSSRFPreventionとTestResolveHostnameでDNSキャッシュ汚染によるテスト間干渉を防ぐ共通fixtureを提供する。"""
 
     @pytest.fixture(autouse=True)
     def clear_dns_cache(self) -> Iterator[None]:
@@ -779,13 +671,7 @@ class DNSCacheClearMixin:
 
 
 class TestSSRFPrevention(DNSCacheClearMixin):
-    """SSRF攻撃防止のセキュリティテスト
-
-    OWASP API Security Top 10 - API7:2023 Server Side Request Forgery (SSRF)
-    - プライベートIP/ループバックアドレスのブロック
-    - 許可ドメインリストによるアクセス制御
-    - DNS解決失敗時のフェイルクローズド動作
-    """
+    """OWASP API7:2023 SSRF対策としてprivate IP・ドメイン外・DNS失敗時の防御を検証する。"""
 
     @pytest.mark.parametrize(
         ("malicious_url", "description"),
@@ -823,13 +709,6 @@ class TestSSRFPrevention(DNSCacheClearMixin):
         ],
     )
     def test_ssrf_private_ip_blocked(self, malicious_url: str, description: str) -> None:
-        """SSRF Prevention: プライベート/ループバックIPをブロック
-
-        Security Rationale:
-            内部ネットワークへのアクセスを防止し、
-            AWSメタデータ、ルーター設定、内部サービスへの
-            不正アクセスを防ぐ。
-        """
         with pytest.raises(ValidationError) as exc_info:
             APIConfig(base_url=malicious_url)
 
@@ -859,19 +738,7 @@ class TestSSRFPrevention(DNSCacheClearMixin):
         ],
     )
     def test_ssrf_domain_allowlist_enforced(self, unauthorized_url: str, domain: str) -> None:
-        """SSRF Prevention: 許可ドメインリスト外のドメインをブロック
-
-        Security Rationale:
-            許可されたドメイン（jsonplaceholder.typicode.com、
-            api.github.com等）のみアクセス可能とし、
-            任意のURLへのアクセスを防止。
-
-        Note:
-            設定バリデータは allowlist-only で判定し、DNS 解決や
-            private-IP 判定は行わない。
-            許可リスト外のホストは
-            「SSRF Prevention: Domain not in allowlist」でブロックされる。
-        """
+        """このvalidatorはallowlist判定のみでDNS解決やprivate-IP判定を行わない契約を検証する。"""
         with pytest.raises(ValidationError) as exc_info:
             APIConfig(base_url=unauthorized_url)
 
@@ -896,30 +763,14 @@ class TestSSRFPrevention(DNSCacheClearMixin):
         ],
     )
     def test_is_private_ip_detection(self, ip_address: str, expected_private: bool) -> None:
-        """is_private_ip()がプライベートIPを正しく検出
-
-        Security Rationale:
-            RFC 1918（プライベートIP）、RFC 3927（リンクローカル）、
-            RFC 5735（ループバック）を正しく識別し、
-            内部ネットワークへのSSRF攻撃を防止。
-        """
+        """RFC 1918/3927/5735のプライベート/リンクローカル/ループバック範囲の識別を検証する。"""
         result = is_private_ip(ip_address)
         assert result == expected_private, (
             f"Expected is_private_ip({ip_address}) == {expected_private}"
         )
 
     def test_is_private_ip_dns_failure_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """DNS解決失敗時はTrueを返す（Fail-Closed動作）
-
-        Security Rationale (CRITICAL):
-            DNS解決が失敗した場合、攻撃者が制御する
-            DNSサーバーを介したSSRF攻撃を防ぐため、
-            安全側に倒す（ブロック）。
-
-            Fail-Open（False返却）は、以下の攻撃を許容してしまう:
-            - DNS rebinding attack
-            - Malicious DNS server による内部IP解決
-        """
+        """DNS rebinding攻撃を防ぐため、DNS解決失敗時はFail-ClosedでTrueを返す契約を検証する。"""
         import socket
 
         # DNS解決を常に失敗させる
@@ -935,12 +786,7 @@ class TestSSRFPrevention(DNSCacheClearMixin):
     def test_is_private_ip_invalid_dns_response_returns_true(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """DNS解決結果が不正なIPアドレス形式の場合、Fail-Closedでブロック（True）を返す
-
-        Security:
-            異常なDNS応答（IPアドレス形式でない文字列）に対するSSRF防止の最終砦。
-            _logger.warning()でセキュリティ証跡を記録することも検証する。
-        """
+        """不正なDNS応答に対するFail-Closed最終防御と、warningログ記録の両方を検証する。"""
         monkeypatch.setattr(socket, "gethostbyname", lambda _: "not-an-ip-address")
 
         with caplog.at_level(logging.WARNING, logger="config.settings"):
@@ -962,14 +808,6 @@ class TestSSRFPrevention(DNSCacheClearMixin):
         ],
     )
     def test_allowed_domains_accepted(self, allowed_domain: str) -> None:
-        """許可ドメインリスト内のドメインは受け入れられる
-
-        Note:
-            これらはテスト用・デモ用に許可されたドメイン。
-            本番環境では環境変数ALLOWED_DOMAINSで制限可能。
-            設定バリデータは allowlist-only で判定し、
-            DNS 解決や private-IP 判定は行わない（純粋関数）。
-        """
         config = APIConfig(base_url=allowed_domain)
         assert config.base_url == allowed_domain.rstrip("/")
 
@@ -991,12 +829,7 @@ class TestSSRFPrevention(DNSCacheClearMixin):
         ],
     )
     def test_is_private_ip_ipv6_detection(self, ipv6_address: str, expected_private: bool) -> None:
-        """IPv6プライベートIPの検出
-
-        Security Rationale:
-            IPv4-mapped IPv6（::ffff:x.x.x.x）を使ったSSRFバイパス攻撃を防止。
-            例: ::ffff:192.168.1.1 は実質的に192.168.1.1と同じ。
-        """
+        """IPv4-mapped IPv6（::ffff:x.x.x.x）によるSSRFバイパス攻撃を防止できることを検証する。"""
         result = is_private_ip(ipv6_address)
         assert result == expected_private, (
             f"Expected is_private_ip({ipv6_address}) == {expected_private}"
@@ -1042,12 +875,6 @@ class TestSSRFPrevention(DNSCacheClearMixin):
         expected_private: bool,
         description: str,
     ) -> None:
-        """プライベートIP範囲の境界値テスト
-
-        Security Rationale:
-            境界付近のIPアドレスで正しくプライベート/パブリックを
-            判定できることを確認し、Off-by-oneエラーを防止。
-        """
         result = is_private_ip(boundary_ip)
         assert result == expected_private, (
             f"Boundary test failed for {description}: "
@@ -1057,12 +884,6 @@ class TestSSRFPrevention(DNSCacheClearMixin):
     def test_validate_base_url_ssrf_block_logs_warning(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """SSRF Prevention: 許可ドメイン外のURLブロック時にwarningログを出力する
-
-        Security Rationale:
-            SSRF防止ブロックは重要なセキュリティイベントであるため、
-            warningレベルのログで監査証跡を残す。
-        """
         with caplog.at_level(logging.WARNING, logger="config.settings"):
             with pytest.raises(ValidationError):
                 APIConfig(base_url="https://evil.attacker.com/api")
@@ -1073,19 +894,9 @@ class TestSSRFPrevention(DNSCacheClearMixin):
 
 
 class TestResolveHostname(DNSCacheClearMixin):
-    """_resolve_hostname/_resolve_hostname_cached関数のDNS解決テスト
-
-    Security Rationale:
-        DNS解決結果のキャッシュ動作とエラーハンドリングを検証し、
-        ネットワーク障害時の安全なフォールバック（None返却）を保証する。
-
-    Design Note:
-        _resolve_hostname: ラッパー関数。失敗時にNoneを返す公開インターフェース。
-        _resolve_hostname_cached: LRUキャッシュ付き内部関数。成功時のみキャッシュ。
-    """
+    """DNS解決結果のキャッシュ動作を検証し、ネットワーク障害時にNoneへ安全にフォールバックする契約を保護する。"""
 
     def test_resolve_hostname_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """DNS解決成功時に正しいIPアドレス文字列を返す"""
         monkeypatch.setattr(socket, "gethostbyname", lambda _: "93.184.216.34")
 
         result = _resolve_hostname("example.com")
@@ -1093,12 +904,7 @@ class TestResolveHostname(DNSCacheClearMixin):
         assert result == "93.184.216.34"
 
     def test_resolve_hostname_failure_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """DNS解決失敗（OSError）時にNoneを返す（キャッシュされないこと含む）
-
-        設計保証: lru_cacheは例外をキャッシュしないため、一時的なDNS障害後に
-        再試行が可能であることを call_count == 2 で明示的に検証する。
-        これにより「成功のみキャッシュ」設計の回帰防止テストとなる。
-        """
+        """lru_cacheは例外をキャッシュしないため、DNS障害後も再試行できる「成功のみキャッシュ」設計を保護する。"""
         call_count = 0
 
         def raise_os_error(hostname: str) -> str:
@@ -1121,7 +927,6 @@ class TestResolveHostname(DNSCacheClearMixin):
         )
 
     def test_resolve_hostname_cache_hit(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """2回目の呼び出しでキャッシュヒット（socket.gethostbynameが1回しか呼ばれない）"""
         call_count = 0
 
         def counting_resolver(hostname: str) -> str:
@@ -1141,7 +946,6 @@ class TestResolveHostname(DNSCacheClearMixin):
         )
 
     def test_resolve_hostname_cache_clear(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """cache_clear()後に再度DNS解決が実行される"""
         call_count = 0
 
         def counting_resolver(hostname: str) -> str:
@@ -1179,13 +983,7 @@ class TestResolveHostname(DNSCacheClearMixin):
         caplog: pytest.LogCaptureFixture,
         exc_factory: Callable[[], Exception],
     ) -> None:
-        """SSRF攻撃的ホスト名による例外発生時にSSRF証跡ログが出力される
-
-        Security Rationale:
-            UnicodeDecodeError/UnicodeEncodeError/TypeError/OverflowErrorは攻撃的な入力パターン（SSRF試行）を
-            示すため、セキュリティインシデントの事後調査に必要なwarningレベルログを出力する。
-            一時的なDNS障害（OSError）とはログレベルで明確に区別する。
-        """
+        """Unicode/Type/OverflowErrorは攻撃的ホスト名の兆候として、一時的なOSErrorと区別してwarningログに残す契約を検証する。"""
 
         def raise_exc(hostname: str) -> str:
             raise exc_factory()
@@ -1225,14 +1023,7 @@ class TestResolveHostname(DNSCacheClearMixin):
         exc_factory: Callable[[], Exception],
         expected_log_message: str,
     ) -> None:
-        """ネットワーク関連例外時にwarningレベルでログが出力されNoneを返す
-
-        Design Rationale:
-            socket.gaierror/herror（DNS解決失敗）と汎用OSError（ネットワーク障害）は
-            いずれもNone返却+warningログ出力だが、ログメッセージで区別する。
-            各例外型を個別ケースとしてテストし、将来のリファクタリングで
-            except節から誤って除外されないことを保証する（退行防止）。
-        """
+        """gaierror/herror/OSErrorが個別exceptとして誤って除外されない回帰防止のため、ログメッセージ差異を検証する。"""
 
         def raise_exc(hostname: str) -> str:
             raise exc_factory()
@@ -1250,13 +1041,6 @@ class TestResolveHostname(DNSCacheClearMixin):
 
 
 class TestTestConfigBoundaryValues:
-    """TestConfig 数値フィールドの境界値テスト.
-
-    SettingsTestConfig フィールド検証:
-    - slow_test_threshold: ge=0.1 (float)
-    - max_concurrent_requests: ge=1, le=50 (int)
-    """
-
     @pytest.mark.parametrize(
         ("value", "expected_valid"),
         [
@@ -1266,7 +1050,6 @@ class TestTestConfigBoundaryValues:
         ],
     )
     def test_slow_test_threshold_boundary(self, value: float, expected_valid: bool) -> None:
-        """slow_test_threshold: ge=0.1 境界値検証"""
         if expected_valid:
             config = SettingsTestConfig(slow_test_threshold=value)
             assert config.slow_test_threshold == value
@@ -1284,7 +1067,6 @@ class TestTestConfigBoundaryValues:
         ],
     )
     def test_max_concurrent_requests_boundary(self, value: int, expected_valid: bool) -> None:
-        """max_concurrent_requests: ge=1, le=50 境界値検証"""
         if expected_valid:
             config = SettingsTestConfig(max_concurrent_requests=value)
             assert config.max_concurrent_requests == value
@@ -1294,29 +1076,10 @@ class TestTestConfigBoundaryValues:
 
 
 class TestAllowedDomainsEnvOverride:
-    """ALLOWED_DOMAINS 環境変数 override テスト.
-
-    _get_allowed_domains() は環境変数 ALLOWED_DOMAINS を参照し、
-    カンマ区切りで許可ドメインを上書き可能。
-
-    重要な制約 (開発者向け注意):
-        モジュールレベル変数 ALLOWED_DOMAINS (config/settings.py L59)
-        は module import 時に _get_allowed_domains() の戻り値で確定する。
-        validate_base_url() は ALLOWED_DOMAINS 変数を参照するため、
-        起動後 (= import 後) の monkeypatch.setenv による環境変数変更は
-        validate_base_url() の挙動に反映されない。
-
-        テストで動的に変更する場合は以下のいずれかを使う:
-        1. _get_allowed_domains() を直接呼ぶ (本クラスの既存テスト方式)
-        2. importlib.reload(config.settings) でモジュール再読み込み
-        3. モジュールインポート前に環境変数を設定 (pytest-env 等)
-
-        本制約の保護テストは test_allowed_domains_override_does_not_affect_validate_base_url
-        を参照。
-    """
+    """ALLOWED_DOMAINSはmodule import時に一度だけ確定するため、起動後のmonkeypatch.setenvが
+    validate_base_url()に反映されない制約を検証する。"""
 
     def test_allowed_domains_env_override(self, monkeypatch):
-        """環境変数 ALLOWED_DOMAINS で許可ドメインを上書き"""
         from config.settings import _get_allowed_domains
 
         monkeypatch.setenv("ALLOWED_DOMAINS", "custom.example.com,api.custom.com")
@@ -1325,7 +1088,6 @@ class TestAllowedDomainsEnvOverride:
         assert result == frozenset({"custom.example.com", "api.custom.com"})
 
     def test_allowed_domains_env_empty_returns_default(self, monkeypatch):
-        """環境変数未設定時はデフォルトドメインを返す"""
         from config.settings import _get_allowed_domains
 
         monkeypatch.delenv("ALLOWED_DOMAINS", raising=False)
@@ -1350,7 +1112,7 @@ class TestAllowedDomainsEnvOverride:
     def test_allowed_domains_blank_env_entries_return_empty_set(
         self, monkeypatch: pytest.MonkeyPatch, value: str
     ) -> None:
-        """空白・空要素のみの ALLOWED_DOMAINS は deny-all (空セット) を返す"""
+        """空白のみのALLOWED_DOMAINSはdeny-all（空セット）として扱われるfail-safe仕様を検証する。"""
         from config.settings import _get_allowed_domains
 
         monkeypatch.setenv("ALLOWED_DOMAINS", value)
@@ -1360,15 +1122,7 @@ class TestAllowedDomainsEnvOverride:
     def test_allowed_domains_override_does_not_affect_validate_base_url(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """ALLOWED_DOMAINS 動的変更は validate_base_url() に反映されない契約を保護する.
-
-        config.settings.ALLOWED_DOMAINS は module-level で _get_allowed_domains() の戻り値で
-        確定する (module import 時に1度のみ評価)。validate_base_url() は ALLOWED_DOMAINS を
-        参照するため、起動後の monkeypatch.setenv("ALLOWED_DOMAINS", ...) は反映されない。
-
-        本テストは「monkeypatch で custom ドメインを追加しても、APIConfig(base_url=) の
-        バリデーションで ValidationError が出る」ことを確認し、この重要な制約を退行から保護する。
-        """
+        """ALLOWED_DOMAINSのimport時確定という制約を、setenv後もValidationErrorが出ることで保護する。"""
         # custom.example.com を ALLOWED_DOMAINS に追加しても、
         # モジュールは既に評価済みのため反映されない
         monkeypatch.setenv("ALLOWED_DOMAINS", "custom.example.com")

--- a/tests/unit/test_responses.py
+++ b/tests/unit/test_responses.py
@@ -1,4 +1,4 @@
-"""Pydantic レスポンスモデル テスト"""
+"""Pydanticレスポンスモデルの契約テスト。"""
 
 import re
 from typing import Any, Final, TypedDict
@@ -34,16 +34,9 @@ _COMMENT_BASE: Final[_CommentBaseData] = {
 
 
 class TestGeoModel:
-    """Geo モデルのテスト
-
-    XSS サニタイゼーション: Geo.lat フィールドが html.escape() でサニタイズされることを確認。
-    XSS カバレッジ（OWASP Cheat Sheetベース・プロジェクト独自分類）:
-        Cat.1 Script Tags / Cat.2 Event Handlers / Cat.3 URI Schemes /
-        Cat.4 Attribute Injection / Cat.6 Special Characters
-    """
+    """Geo.lat/lngのhtml.escape()サニタイズをOWASP Cheat Sheetベースの独自分類で検証する。"""
 
     def test_geo_basic_creation(self) -> None:
-        """基本的な Geo モデル作成"""
         geo = Geo(lat="-37.3159", lng="81.1496")
 
         assert geo.lat == "-37.3159"
@@ -54,7 +47,6 @@ class TestGeoModel:
         _XSS_MODEL_PARAMS,
     )
     def test_geo_sanitizes_xss(self, dirty: str, expected: str) -> None:
-        """Geo.lat フィールドの XSS サニタイゼーション（OWASP Cheat Sheetベース・独自5分類）"""
         geo = Geo(lat=dirty, lng="normal")
         assert geo.lat == expected
 
@@ -63,12 +55,10 @@ class TestGeoModel:
         _XSS_MODEL_PARAMS,
     )
     def test_geo_lng_sanitizes_xss(self, dirty: str, expected: str) -> None:
-        """Geo.lng フィールドの XSS サニタイゼーション（OWASP Cheat Sheetベース・独自5分類）"""
         geo = Geo(lat="0", lng=dirty)
         assert geo.lng == expected
 
     def test_geo_extra_fields_forbidden(self) -> None:
-        """Geo モデルが extra フィールドを拒否することを確認"""
         with pytest.raises(ValidationError) as exc_info:
             Geo(lat="0", lng="0", extra="not allowed")  # type: ignore[call-arg]
 
@@ -83,7 +73,6 @@ class TestGeoModel:
         ],
     )
     def test_geo_lat_lng_boundary_values(self, lat: str, lng: str) -> None:
-        """Geo.lat/lng の max_length=50 境界値（上限）で正常作成できること"""
         geo = Geo(lat=lat, lng=lng)
         assert geo.lat == lat
         assert geo.lng == lng
@@ -96,7 +85,6 @@ class TestGeoModel:
         ],
     )
     def test_geo_lat_lng_exceeds_max_length(self, field: str) -> None:
-        """Geo.lat/lng が 51 文字（max_length=50 超過）で ValidationError が発生すること"""
         kwargs = {"lat": "0", "lng": "0"}
         kwargs[field] = "x" * 51
         with pytest.raises(ValidationError, match=field):
@@ -104,13 +92,7 @@ class TestGeoModel:
 
 
 class TestAddressModel:
-    """Address モデルのテスト
-
-    XSS サニタイゼーション: Address.street フィールドが html.escape() でサニタイズされることを確認。
-    XSS カバレッジ（OWASP Cheat Sheetベース・プロジェクト独自分類）:
-        Cat.1 Script Tags / Cat.2 Event Handlers / Cat.3 URI Schemes /
-        Cat.4 Attribute Injection / Cat.6 Special Characters
-    """
+    """Address.streetのhtml.escape()サニタイズをOWASP Cheat Sheetベースの独自分類で検証する。"""
 
     @pytest.fixture
     def valid_geo(self) -> Geo:
@@ -118,7 +100,6 @@ class TestAddressModel:
         return Geo(lat="0", lng="0")
 
     def test_address_basic_creation(self) -> None:
-        """基本的な Address モデル作成"""
         geo = Geo(lat="-37.3159", lng="81.1496")
         address = Address(
             street="Kulas Light",
@@ -137,7 +118,6 @@ class TestAddressModel:
         _XSS_MODEL_PARAMS,
     )
     def test_address_sanitizes_xss(self, valid_geo: Geo, dirty: str, expected: str) -> None:
-        """Address.street の XSS サニタイゼーション（OWASP CS・独自5分類）"""
         address = Address(street=dirty, suite="Test", city="City", zipcode="12345", geo=valid_geo)
         assert address.street == expected
 
@@ -149,7 +129,6 @@ class TestAddressModel:
     def test_address_sanitizes_xss_all_fields(
         self, valid_geo: Geo, dirty: str, expected: str, field: str
     ) -> None:
-        """Address の suite/city フィールドの XSS サニタイゼーション"""
         kwargs: dict[str, Any] = {
             "street": "Normal",
             "suite": "Normal",
@@ -173,17 +152,13 @@ class TestAddressModel:
         ],
     )
     def test_address_zipcode_sanitizes_xss(self, valid_geo: Geo, dirty: str, expected: str) -> None:
-        """Address.zipcode の XSS サニタイゼーション（max_length=20制約内）"""
+        """Address.zipcodeのXSSサニタイズを、max_length=20制約に収まるpayloadのみで検証する。"""
         address = Address(
             street="Normal", suite="Normal", city="Normal", zipcode=dirty, geo=valid_geo
         )
         assert address.zipcode == expected
 
     def test_address_boundary_values(self, valid_geo: Geo) -> None:
-        """Address フィールドの max_length 境界値（上限）で正常作成できること
-
-        street=200, suite=100, city=100, zipcode=20 が各フィールドの上限。
-        """
         address = Address(
             street="a" * 200,
             suite="b" * 100,
@@ -206,7 +181,6 @@ class TestAddressModel:
         ],
     )
     def test_address_exceeds_max_length(self, valid_geo: Geo, field: str, max_len: int) -> None:
-        """Address フィールドが max_length 超過で ValidationError が発生すること"""
         kwargs: dict[str, str | Geo] = {
             "street": "Normal",
             "suite": "Normal",
@@ -220,16 +194,9 @@ class TestAddressModel:
 
 
 class TestCompanyModel:
-    """Company モデルのテスト
-
-    XSS サニタイゼーション: Company.name フィールドが html.escape() でサニタイズされることを確認。
-    XSS カバレッジ（OWASP Cheat Sheetベース・プロジェクト独自分類）:
-        Cat.1 Script Tags / Cat.2 Event Handlers / Cat.3 URI Schemes /
-        Cat.4 Attribute Injection / Cat.6 Special Characters
-    """
+    """Company.nameのhtml.escape()サニタイズをOWASP Cheat Sheetベースの独自分類で検証する。"""
 
     def test_company_basic_creation(self) -> None:
-        """基本的な Company モデル作成"""
         company = Company(
             name="Romaguera-Crona",
             catch_phrase="Multi-layered client-server neural-net",
@@ -240,7 +207,6 @@ class TestCompanyModel:
         assert company.catch_phrase == "Multi-layered client-server neural-net"
 
     def test_company_alias_working(self) -> None:
-        """Company モデルの alias (catchPhrase → catch_phrase) が機能することを確認"""
         # mypy: pydantic.mypy plugin は alias kwarg を field として認識しないため抑制
         # validate_by_name=True により runtime は正常 (alias 動作の意図的検証)
         company = Company(
@@ -256,7 +222,6 @@ class TestCompanyModel:
         _XSS_MODEL_PARAMS,
     )
     def test_company_sanitizes_xss(self, dirty: str, expected: str) -> None:
-        """Company.name フィールドの XSS サニタイゼーション（OWASP Cheat Sheetベース・独自5分類）"""
         company = Company(name=dirty, catch_phrase="Normal", bs="Normal")
         assert company.name == expected
 
@@ -266,7 +231,6 @@ class TestCompanyModel:
     )
     @pytest.mark.parametrize("field", ["catch_phrase", "bs"])
     def test_company_sanitizes_xss_all_fields(self, dirty: str, expected: str, field: str) -> None:
-        """Company の catch_phrase/bs フィールドの XSS サニタイゼーション"""
         alias_map = {"catch_phrase": "catchPhrase", "bs": "bs"}
         kwargs: dict[str, Any] = {
             "name": "Normal",
@@ -279,15 +243,8 @@ class TestCompanyModel:
 
 
 class TestUserModel:
-    """User モデルのテスト
-
-    XSS サニタイゼーション: User.name, username, phone フィールドが
-    html.escape() でサニタイズされることを確認。
-    websiteフィールドは危険スキーム（javascript:, data:, vbscript:）バリデーション。
-    XSS カバレッジ（OWASP Cheat Sheetベース・プロジェクト独自分類）:
-        Cat.1 Script Tags / Cat.2 Event Handlers / Cat.3 URI Schemes /
-        Cat.4 Attribute Injection / Cat.6 Special Characters
-    """
+    """User.name/username/phoneのhtml.escape()サニタイズと、websiteの危険スキーム
+    （javascript:/data:/vbscript:）バリデーションをOWASP Cheat Sheetベースの独自分類で検証する。"""
 
     @pytest.fixture
     def valid_user_data(self) -> _UserData:
@@ -314,7 +271,6 @@ class TestUserModel:
         }
 
     def test_user_basic_creation(self, valid_user_data: _UserData) -> None:
-        """基本的な User モデル作成"""
         user = User(**valid_user_data)
 
         assert user.id == 1
@@ -323,7 +279,6 @@ class TestUserModel:
         assert user.company.name == "Romaguera-Crona"
 
     def test_user_nested_models(self, valid_user_data: _UserData) -> None:
-        """User モデルのネストされたモデル (Address, Company) が正しく解析されることを確認"""
         user = User(**valid_user_data)
 
         assert isinstance(user.address, Address)
@@ -341,18 +296,15 @@ class TestUserModel:
     def test_user_sanitizes_xss(
         self, valid_user_data: _UserData, field: str, dirty: str, expected: str
     ) -> None:
-        """User name/username/phone フィールドの XSS サニタイゼーション"""
         user = User(**{**valid_user_data, field: dirty})
         assert getattr(user, field) == expected
 
     def test_user_validate_by_name(self, valid_user_data: _UserData) -> None:
-        """User モデルの validate_by_name が有効であることを確認"""
         # User モデルは validate_by_name=True なので、alias で値を設定可能
         user = User(**valid_user_data)
         assert user.company.catch_phrase == "Multi-layered client-server neural-net"
 
     def test_user_extra_fields_forbidden(self, valid_user_data: _UserData) -> None:
-        """User モデルが extra フィールドを拒否することを確認"""
         valid_user_data["extra_field"] = "not allowed"  # type: ignore[typeddict-unknown-key]
 
         with pytest.raises(ValidationError) as exc_info:
@@ -361,7 +313,6 @@ class TestUserModel:
         assert exc_info.value.errors()[0]["type"] == "extra_forbidden"
 
     def test_user_email_must_be_valid_format(self, valid_user_data: _UserData) -> None:
-        """User.email が EmailStr 型により無効なメールアドレスを拒否すること"""
         valid_user_data["email"] = "not-an-email"
         with pytest.raises(ValidationError, match=r"email"):
             User(**valid_user_data)
@@ -380,20 +331,17 @@ class TestUserModel:
     def test_user_email_rejects_rfc_noncompliant(
         self, valid_user_data: _UserData, invalid_email: str
     ) -> None:
-        """User.email が RFC 5322 非準拠メールアドレスを拒否すること"""
         valid_user_data["email"] = invalid_email
         with pytest.raises(ValidationError, match=r"email"):
             User(**valid_user_data)
 
     def test_user_email_max_length_valid(self, valid_user_data: _UserData) -> None:
-        """User.email=100文字（max_length 上限）で正常作成できること"""
         # 52 + "@"(1) + 35 + ".example.com"(12) = 100文字（local≤64: RFC5321準拠）
         valid_user_data["email"] = "a" * 52 + "@" + "b" * 35 + ".example.com"
         user = User(**valid_user_data)
         assert len(user.email) == 100
 
     def test_user_email_max_length_invalid(self, valid_user_data: _UserData) -> None:
-        """User.email=101文字（max_length 超過）で ValidationError が発生すること"""
         # 52 + "@"(1) + 36 + ".example.com"(12) = 101文字（local≤64: RFC5321準拠）
         # emailフィールドのloc確認で検証（email-validatorバージョン依存のmatch文字列を回避）
         valid_user_data["email"] = "a" * 52 + "@" + "b" * 36 + ".example.com"
@@ -405,7 +353,6 @@ class TestUserModel:
         )
 
     def test_user_website_max_length_boundary(self, valid_user_data: _UserData) -> None:
-        """website の正規化後URL長 WEBSITE_NORMALIZED_MAX_LENGTH(2048) 境界値テスト."""
         max_len = WEBSITE_NORMALIZED_MAX_LENGTH  # 2048
         base = "https://example.com/"
         # ちょうど max_len 文字: 正常
@@ -431,7 +378,6 @@ class TestUserModel:
             User(**valid_user_data)
 
     def test_user_website_is_not_html_escaped(self, valid_user_data: _UserData) -> None:
-        """websiteはhtml.escape対象外（URL内の&がエスケープされない）"""
         value = "https://example.com/page?a=1&b=2"
         valid_user_data["website"] = value
         user = User(**valid_user_data)
@@ -583,13 +529,11 @@ class TestUserModel:
     def test_user_website_rejects_dangerous_scheme(
         self, valid_user_data: _UserData, dangerous_url: str, expected_match: str
     ) -> None:
-        """User.website が危険なURLスキームを拒否すること（エラーメッセージも検証）"""
         valid_user_data["website"] = dangerous_url
         with pytest.raises(ValidationError, match=expected_match):
             User(**valid_user_data)
 
     def test_user_website_rejects_protocol_relative_url(self, valid_user_data: _UserData) -> None:
-        """User.website がプロトコル相対URLを明示的なエラーで拒否すること"""
         valid_user_data["website"] = "//cdn.example.com/image.jpg"
         with pytest.raises(
             ValidationError, match=re.escape("Protocol-relative URLs are not allowed")
@@ -599,7 +543,7 @@ class TestUserModel:
     def test_user_website_rejects_fullwidth_javascript_scheme(
         self, valid_user_data: _UserData
     ) -> None:
-        """全角文字によるスキームバイパスがNFKC正規化で検出されること"""
+        """全角文字によるスキームバイパスをNFKC正規化で検出し拒否することを検証する。"""
         valid_user_data["website"] = "ｊａｖａｓｃｒｉｐｔ:alert(1)"
         with pytest.raises(ValidationError, match=re.escape("Dangerous URL scheme detected")):
             User(**valid_user_data)
@@ -614,7 +558,6 @@ class TestUserModel:
     def test_user_website_rejects_empty_netloc(
         self, valid_user_data: _UserData, empty_netloc_url: str
     ) -> None:
-        """User.website が空のnetlocを拒否すること"""
         valid_user_data["website"] = empty_netloc_url
         with pytest.raises(ValidationError, match=re.escape("Valid hostname not found")):
             User(**valid_user_data)
@@ -629,7 +572,6 @@ class TestUserModel:
     def test_user_website_rejects_ascii_whitespace_in_host(
         self, valid_user_data: _UserData, invalid_host_url: str
     ) -> None:
-        """User.website がホスト部のASCII空白を拒否すること."""
         valid_user_data["website"] = invalid_host_url
         with pytest.raises(ValidationError, match=re.escape("Hostname contains whitespace")):
             User(**valid_user_data)
@@ -637,8 +579,6 @@ class TestUserModel:
     def test_user_website_wraps_overflowerror_in_validationerror(
         self, valid_user_data: _UserData, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """parsed.username/password アクセス時の OverflowError が ValidationError になること."""
-
         class _OverflowingParseResult:
             scheme = "https"
             netloc = "example.com"
@@ -736,7 +676,6 @@ class TestUserModel:
     def test_user_website_rejects_security_bypass_patterns(
         self, valid_user_data: _UserData, dangerous_url: str, expected_match: str
     ) -> None:
-        """User.website がセキュリティバイパスパターンを拒否すること"""
         valid_user_data["website"] = dangerous_url
         with pytest.raises(ValidationError, match=expected_match):
             User(**valid_user_data)
@@ -752,7 +691,6 @@ class TestUserModel:
     def test_user_website_rejects_non_str_input(
         self, valid_user_data: _UserData, non_str_input: object
     ) -> None:
-        """User.website が非文字列入力を拒否すること"""
         valid_user_data["website"] = non_str_input  # type: ignore[typeddict-item]
         with pytest.raises(ValidationError, match=re.escape("String required")):
             User(**valid_user_data)
@@ -776,7 +714,6 @@ class TestUserModel:
     def test_user_website_allows_safe_url(
         self, valid_user_data: _UserData, input_url: str, expected_url: str
     ) -> None:
-        """User.website が安全なURL形式を受け入れること（スキームなしはhttps://に補完）"""
         valid_user_data["website"] = input_url
         user = User(**valid_user_data)
         assert user.website == expected_url
@@ -805,7 +742,6 @@ class TestUserModel:
     def test_user_website_normalizes_scheme_and_host(
         self, valid_user_data: _UserData, input_url: str, expected_url: str
     ) -> None:
-        """スキームとホストが小文字正規化されることを検証する（RFC 3986準拠）"""
         valid_user_data["website"] = input_url
         user = User(**valid_user_data)
         assert user.website == expected_url
@@ -825,7 +761,6 @@ class TestUserModel:
     def test_user_website_sanitizes_control_chars_in_safe_url(
         self, valid_user_data: _UserData, dirty_safe_url: str, expected: str
     ) -> None:
-        """User.website が安全なURLに含まれる制御文字を除去して返却すること"""
         valid_user_data["website"] = dirty_safe_url
         user = User(**valid_user_data)
         assert user.website == expected
@@ -845,7 +780,7 @@ class TestUserModel:
     def test_user_website_control_char_only_raises(
         self, valid_user_data: _UserData, control_only: str
     ) -> None:
-        """制御文字のみのwebsiteはサニタイズ後に空文字列となりValidationErrorになること"""
+        """制御文字のみのwebsiteはサニタイズ後に空文字列となるため、ValidationErrorになることを検証する。"""
         valid_user_data["website"] = control_only
         with pytest.raises(ValidationError, match=re.escape("Website became empty")):
             User(**valid_user_data)
@@ -918,7 +853,6 @@ class TestUserModel:
     def test_user_website_encodes_special_chars(
         self, valid_user_data: _UserData, input_url: str, expected_url: str
     ) -> None:
-        """_normalize_url の quote() によるパス・クエリ・フラグメントのエンコード動作を検証する."""
         valid_user_data["website"] = input_url
         user = User(**valid_user_data)
         assert user.website == expected_url
@@ -926,11 +860,7 @@ class TestUserModel:
     def test_user_website_rejects_percent_encoded_at_with_literal_at(
         self, valid_user_data: _UserData
     ) -> None:
-        """%40エンコード済み@と@リテラル混在のuserinfoバイパスを拒否すること.
-
-        urlparse は "user%40evil.com@host.example.com" をuserinfoとして解析するため、
-        URLにuserinfoが含まれると判定しValidationErrorを発生させる。
-        """
+        """urlparseが%40エンコード済み@と@リテラル混在をuserinfoと解釈しバイパスされることを防ぐ契約を検証する。"""
         valid_user_data["website"] = "https://user%40evil.com@host.example.com"
         with pytest.raises(ValidationError, match=re.escape("URL cannot contain userinfo")):
             User(**valid_user_data)
@@ -945,28 +875,20 @@ class TestUserModel:
     def test_user_website_rejects_incomplete_percent_encoding(
         self, valid_user_data: _UserData, bad_url: str
     ) -> None:
-        """不完全なパーセントエンコード（%GG・末尾%等）を含むURLを拒否すること.
-
-        %GG・末尾の裸%はいずれも_PERCENT_CTRL_RE（制御文字検出）にはマッチしないが、
-        _INCOMPLETE_PCT_RE（不完全%シーケンス検出）にマッチしValidationErrorを送出する。
-        """
+        """%GGや末尾%は_PERCENT_CTRL_REでなく_INCOMPLETE_PCT_REにマッチしてValidationErrorになる契約を検証する。"""
         valid_user_data["website"] = bad_url
         with pytest.raises(ValidationError, match=re.escape("incomplete percent-encoding")):
             User(**valid_user_data)
 
 
 class TestPostModel:
-    """Post モデルのテスト"""
-
     def test_post_basic_creation(self) -> None:
-        """基本的な Post モデル作成"""
         post = Post(user_id=1, id=1, title="Test Title", body="Test Body")
 
         assert post.user_id == 1
         assert post.title == "Test Title"
 
     def test_post_alias_working(self) -> None:
-        """Post モデルの alias (userId → user_id) が機能することを確認"""
         # mypy: pydantic.mypy plugin は alias kwarg を field として認識しないため抑制
         # validate_by_name=True により runtime は正常 (alias 動作の意図的検証)
         post = Post(userId=5, id=1, title="Test", body="Test")  # type: ignore[call-arg]
@@ -974,11 +896,7 @@ class TestPostModel:
         assert post.user_id == 5
 
     def test_post_alias_compatibility(self) -> None:
-        """Post モデルの model_validate と model_dump(by_alias=True) が整合すること
-
-        Pydantic 移行の検証: dict→モデル→dict のラウンドトリップで
-        alias（userId）→Python属性（user_id）→alias（userId）が正しく動作する。
-        """
+        """Pydantic移行時のalias⇄属性ラウンドトリップ退行を防ぐため、userId⇄user_idの往復変換を検証する。"""
         data = {"userId": 1, "id": 1, "title": "title", "body": "body"}
         post = Post.model_validate(data)
 
@@ -990,7 +908,6 @@ class TestPostModel:
         _XSS_MODEL_PARAMS,
     )
     def test_post_title_sanitizes_xss(self, dirty: str, expected: str) -> None:
-        """Post.title フィールドの XSS サニタイゼーション（OWASP Cheat Sheetベース・独自5分類）"""
         post = Post(user_id=1, id=1, title=dirty, body="Normal body")
         assert post.title == expected
 
@@ -999,7 +916,6 @@ class TestPostModel:
         _XSS_MODEL_PARAMS,
     )
     def test_post_body_sanitizes_xss(self, dirty: str, expected: str) -> None:
-        """Post.body フィールドの XSS サニタイゼーション（OWASP Cheat Sheetベース・独自5分類）"""
         post = Post(user_id=1, id=1, title="Normal title", body=dirty)
         assert post.body == expected
 
@@ -1011,26 +927,22 @@ class TestPostModel:
         ],
     )
     def test_post_invalid_id_raises_validation_error(self, invalid_id: int) -> None:
-        """id が ge=1 制約（id は1以上）に違反した場合 ValidationError が発生する"""
         with pytest.raises(ValidationError) as exc_info:
             Post(id=invalid_id, user_id=1, title="Test", body="Body")
         errors = exc_info.value.errors()
         assert any(e["loc"] == ("id",) and e["type"] == "greater_than_equal" for e in errors)
 
     def test_post_title_max_length_valid(self) -> None:
-        """title=200文字（max_length 上限）で正常作成できること"""
         post = Post(id=1, user_id=1, title="a" * 200, body="Body")
         assert len(post.title) == 200
 
     def test_post_title_max_length_invalid(self) -> None:
-        """title=201文字（max_length 超過）で ValidationError が発生すること"""
         with pytest.raises(ValidationError) as exc_info:
             Post(id=1, user_id=1, title="a" * 201, body="Body")
         errors = exc_info.value.errors()
         assert any(e["loc"] == ("title",) and e["type"] == "string_too_long" for e in errors)
 
     def test_post_body_exceeds_max_length_raises_validation_error(self) -> None:
-        """body>5000文字でValidationErrorが発生する（境界値テスト: max_length=5000）"""
         long_body = "a" * 5001
         with pytest.raises(ValidationError) as exc_info:
             Post(id=1, user_id=1, title="Test", body=long_body)
@@ -1038,23 +950,14 @@ class TestPostModel:
         assert any(e["loc"] == ("body",) and e["type"] == "string_too_long" for e in errors)
 
     def test_post_body_max_length_valid(self) -> None:
-        """body=5000文字（max_length 上限）で正常作成できること（境界値: ちょうど上限）"""
         post = Post(title="T", body="a" * 5000, user_id=1, id=1)
         assert len(post.body) == 5000
 
 
 class TestCommentModel:
-    """Comment モデルのテスト
-
-    XSS サニタイゼーション: Comment の name/body 2フィールドが
-                    html.escape() でサニタイズされることを確認。
-    XSS カバレッジ（OWASP Cheat Sheetベース・プロジェクト独自分類）:
-        Cat.1 Script Tags / Cat.2 Event Handlers / Cat.3 URI Schemes /
-        Cat.4 Attribute Injection / Cat.6 Special Characters
-    """
+    """Comment.name/bodyのhtml.escape()サニタイズをOWASP Cheat Sheetベースの独自分類で検証する。"""
 
     def test_comment_basic_creation(self) -> None:
-        """基本的な Comment モデル作成"""
         comment = Comment(
             post_id=1,
             id=1,
@@ -1067,11 +970,7 @@ class TestCommentModel:
         assert comment.email == "test@example.com"
 
     def test_comment_alias_compatibility(self) -> None:
-        """Comment モデルの model_validate と model_dump(by_alias=True) が整合すること
-
-        Pydantic 移行の検証: dict→モデル→dict のラウンドトリップで
-        alias（postId）→Python属性（post_id）→alias（postId）が正しく動作する。
-        """
+        """Pydantic移行時のalias⇄属性ラウンドトリップ退行を防ぐため、postId⇄post_idの往復変換を検証する。"""
         data = {
             "postId": 1,
             "id": 1,
@@ -1093,25 +992,21 @@ class TestCommentModel:
         ],
     )
     def test_comment_sanitizes_xss(self, field: str, dirty: str, expected: str) -> None:
-        """Comment XSS サニタイゼーション（name/body x OWASP CS・独自5分類）"""
         data: dict[str, str | int] = {**_COMMENT_BASE, field: dirty}  # type: ignore[dict-item]
         comment = Comment.model_validate(data)
         assert getattr(comment, field) == expected
 
     def test_comment_email_must_be_valid_format(self) -> None:
-        """Comment.email が EmailStr 型により無効なメールアドレスを拒否すること"""
         with pytest.raises(ValidationError, match=r"email"):
             Comment(post_id=1, id=1, name="Name", email="not-an-email", body="Body")
 
     def test_comment_email_max_length_valid(self) -> None:
-        """Comment.email=100文字（max_length 上限）で正常作成できること"""
         # 52 + "@"(1) + 35 + ".example.com"(12) = 100文字（local≤64: RFC5321準拠）
         long_email = "a" * 52 + "@" + "b" * 35 + ".example.com"
         comment = Comment(post_id=1, id=1, name="Name", email=long_email, body="Body")
         assert len(comment.email) == 100
 
     def test_comment_email_max_length_invalid(self) -> None:
-        """Comment.email=101文字（max_length 超過）で ValidationError が発生すること"""
         # 52 + "@"(1) + 36 + ".example.com"(12) = 101文字（local≤64: RFC5321準拠）
         # emailフィールドのloc確認で検証（email-validatorバージョン依存のmatch文字列を回避）
         long_email = "a" * 52 + "@" + "b" * 36 + ".example.com"
@@ -1123,17 +1018,13 @@ class TestCommentModel:
         )
 
     def test_comment_email_with_ampersand_accepted_by_emailstr(self) -> None:
-        """EmailStr は & を含むローカルパートを受理し、html.escape を適用しないこと。
-
-        email-validator は RFC 5321 の dot-atom で & を許容する。
-        動作変更時はこのテストが失敗するため、設計の再評価が必要。
-        """
+        """email-validatorがRFC 5321 dot-atomで&を許容しhtml.escapeが非適用となる仕様を保護する。"""
         comment = Comment(post_id=1, id=1, name="Name", email="user&tag@example.com", body="Body")
         # html.escape は適用されないため & は &amp; に変換されない
         assert comment.email == "user&tag@example.com"
 
     def test_comment_email_rejects_html_meta_chars(self) -> None:
-        """EmailStrが<>を含むアドレスを拒否することを確認（html.escape非適用の安全根拠）."""
+        """EmailStrが<>を含むアドレスを拒否するため、html.escapeを適用しなくても安全である根拠を検証する。"""
         with pytest.raises(ValidationError):
             Comment(post_id=1, id=1, name="Name", email="<xss>@evil.com", body="Body")
         with pytest.raises(ValidationError):
@@ -1141,10 +1032,7 @@ class TestCommentModel:
 
 
 class TestTodoModel:
-    """Todo モデルのテスト"""
-
     def test_todo_basic_creation(self) -> None:
-        """基本的な Todo モデル作成"""
         todo = Todo(user_id=1, id=1, title="Test TODO", completed=False)
 
         assert todo.user_id == 1
@@ -1156,16 +1044,12 @@ class TestTodoModel:
         _XSS_MODEL_PARAMS,
     )
     def test_todo_title_sanitizes_xss(self, dirty: str, expected: str) -> None:
-        """Todo.title フィールドの XSS サニタイゼーション（OWASP Cheat Sheetベース・独自5分類）"""
         todo = Todo(user_id=1, id=1, title=dirty, completed=False)
         assert todo.title == expected
 
 
 class TestAlbumModel:
-    """Album モデルのテスト"""
-
     def test_album_basic_creation(self) -> None:
-        """基本的な Album モデル作成"""
         album = Album(user_id=1, id=1, title="Test Album")
 
         assert album.user_id == 1
@@ -1176,14 +1060,11 @@ class TestAlbumModel:
         _XSS_MODEL_PARAMS,
     )
     def test_album_title_sanitizes_xss(self, dirty: str, expected: str) -> None:
-        """Album.title フィールドの XSS サニタイゼーション（OWASP Cheat Sheetベース・独自5分類）"""
         album = Album(user_id=1, id=1, title=dirty)
         assert album.title == expected
 
 
 class TestExtraFieldsForbidden:
-    """全モデルの extra="forbid" 設定確認"""
-
     @pytest.mark.parametrize(
         ("model_class", "valid_data", "extra_field"),
         [
@@ -1286,7 +1167,6 @@ class TestExtraFieldsForbidden:
         valid_data: dict[str, Any],
         extra_field: dict[str, Any],
     ) -> None:
-        """全モデルが extra フィールドを拒否することを確認"""
         invalid_data = {**valid_data, **extra_field}
 
         with pytest.raises(ValidationError) as exc_info:


### PR DESCRIPTION
## 概要
Issue #500（計画書 claudedocs/plans/2026-07-13-001-refactor-test-docstring-comments-plan.md）のU4ユニットとして、tests/unit/test_config_settings.py と tests/unit/test_responses.py のdocstring/commentを整理。あわせて、canonと矛盾していたserenaメモリの旧方針をポインタ参照に修正。

## 変更内容
- test_config_settings.py / test_responses.py: テスト名・assert・手順を言い換えるだけのdocstring/commentを削除し、非自明な失敗モード・fixtureのWHYのみ保持
- .serena/memories/test_strategy_details.md: 旧docstring方針（canonと矛盾）をcoding-standards.md §4.1へのポインタに置換（権威の二重化を解消）

## 検証
- AST等価チェッカーで振る舞い不変を確認（scripts/check_docstring_refactor.py）
- 厳密レビュー（/review:review-local-changes + Steel-manning）で全修正を検証、revert 0件
- pytest 1420 passed / coverage 97.51%、ruff 0 errors、mypy 0 errors

## テスト
- [x] ローカルテスト完了（品質ゲート全合格）
- [ ] CI/CD パイプライン確認

## 関連Issue
Closes #500 (Issue)

---
このPRは /push-pr スキルで自動生成されました。