### PR TITLE
feat(github-client): secondary rate limitの検出・処理を追加

### DIFF
--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -21,13 +21,22 @@ from utils.github_error_handler import (
     SanitizedJSONDecodeError,
     redact_body_preview,
 )
-from utils.github_rate_limit import RATE_LIMIT_WARNING_THRESHOLD
+from utils.github_rate_limit import (
+    RATE_LIMIT_WARNING_THRESHOLD,
+    SECONDARY_RATE_LIMIT_FALLBACK_RETRY_AFTER,
+)
 
 pytestmark = pytest.mark.unit
 # @pytest.mark.asyncio: asyncio_mode = "auto" (pyproject.toml) のため、@pytest.mark.asyncio は不要
 # pytest-asyncio が async テストを自動検出する
 
 GITHUB_API_BASE_URL = "https://api.github.com"
+
+# octokit issue #566 が記録した実レスポンスの body message。
+# secondary rate limit はヘッダーでは primary と区別できないため、この文言が唯一の判定材料になる。
+SECONDARY_RATE_LIMIT_MESSAGE = (
+    "You have exceeded a secondary rate limit. Please wait a few minutes before you try again."
+)
 MAX_RETRIES = 3
 
 
@@ -1511,6 +1520,32 @@ async def test_invalid_rate_limit_header_403():
 
 
 @respx.mock
+async def test_invalid_rate_limit_header_429_secondary_logs_warning_once():
+    """429の secondary 判定でも X-RateLimit-Remaining を二重パースしない。
+
+    403 は _handle_403_response にパース済みの値を渡して重複を避けており
+    (test_invalid_rate_limit_header_403)、429 も同じ不変条件「1レスポンスにつき warning 1件」
+    を満たす必要がある。secondary 判定を後付けした際、この注入を忘れると warning が 2 件になる。
+    """
+    respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        status_code=429,
+        json={"message": SECONDARY_RATE_LIMIT_MESSAGE},
+        headers={"X-RateLimit-Remaining": "invalid"},
+    )
+
+    with capture_logs() as log_output:
+        async with AsyncGitHubClient() as client:
+            with pytest.raises(RateLimitError) as exc_info:
+                await client.get_user("octocat")
+
+    warning_logs = [log for log in log_output if log.get("event") == "invalid_rate_limit_header"]
+    assert len(warning_logs) == 1
+    assert warning_logs[0]["header"] == "X-RateLimit-Remaining"
+    # 不正値は fallback (0以外) に倒れるため primary 枯渇とは判定されず、既定60秒が載る。
+    assert exc_info.value.retry_after == SECONDARY_RATE_LIMIT_FALLBACK_RETRY_AFTER
+
+
+@respx.mock
 async def test_invalid_rate_limit_reset_header_low_remaining():
     """remaining<10かつX-RateLimit-Resetが不正値の場合、2つのwarningログを出力して処理継続
 
@@ -1701,10 +1736,11 @@ def test_sanitized_jsondecodeerror_reduce_roundtrip_preserves_fields() -> None:
 
 @respx.mock
 async def test_429_response_raises_rate_limit_error() -> None:
-    """429 Too Many RequestsはRateLimitErrorに変換される（_requestレベル・通常パス）
+    """secondary の message を含まない 429 では retry_after が None のままになる。
 
-    GitHub Secondary Rate LimitはHTTP 429を返す。_requestは429を検出し、
-    X-RateLimit-ResetヘッダーからリセットタイムをパースしてRateLimitErrorを発生させる。
+    429 は primary / secondary の両方で返る。両者を区別しないと secondary 向けの
+    60秒フォールバックが primary にも適用され、reset まで待つ仕様に反する待機時間を
+    呼び出し側へ渡す。
     """
     route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
         429,
@@ -1716,6 +1752,7 @@ async def test_429_response_raises_rate_limit_error() -> None:
             await client.get_user("octocat")
 
     assert exc_info.value.reset_time == 1700000000
+    assert exc_info.value.retry_after is None
     assert route.call_count == 1
 
 
@@ -1778,6 +1815,290 @@ async def test_httpx_status_error_429_missing_reset_header_falls_back_to_zero() 
 
     assert exc_info.value.reset_time == 0
     assert "unknown" in str(exc_info.value)  # else分岐のメッセージ内容を保護
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_httpx_status_error_429_secondary_rate_limit_sets_retry_after() -> None:
+    """防御的パスの429でも secondary を検出し retry_after を載せる。
+
+    通常パスの429とは別関数（_handle_http_status_error）が処理するため、
+    片方だけ実装・修正しても気付けない。両経路を独立に固定する。
+    """
+    request = httpx.Request("GET", f"{GITHUB_API_BASE_URL}/users/octocat")
+    response_429 = httpx.Response(
+        429,
+        request=request,
+        headers={"Retry-After": "45"},
+        json={"message": SECONDARY_RATE_LIMIT_MESSAGE},
+    )
+    error_429 = httpx.HTTPStatusError(
+        "429 Too Many Requests", request=request, response=response_429
+    )
+
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat")
+    route.side_effect = [error_429]
+
+    async with AsyncGitHubClient() as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.get_user("octocat")
+
+    assert exc_info.value.retry_after == 45
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_httpx_status_error_429_secondary_falls_back_to_default_retry_after() -> None:
+    """防御的パス(429)で Retry-After 欠損・remaining!=0 なら既定60秒へ倒す。"""
+    request = httpx.Request("GET", f"{GITHUB_API_BASE_URL}/users/octocat")
+    response_429 = httpx.Response(
+        429,
+        request=request,
+        headers={"X-RateLimit-Remaining": "25"},
+        json={"message": SECONDARY_RATE_LIMIT_MESSAGE},
+    )
+    error_429 = httpx.HTTPStatusError(
+        "429 Too Many Requests", request=request, response=response_429
+    )
+
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat")
+    route.side_effect = [error_429]
+
+    async with AsyncGitHubClient() as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.get_user("octocat")
+
+    assert exc_info.value.retry_after == SECONDARY_RATE_LIMIT_FALLBACK_RETRY_AFTER
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_httpx_status_error_429_secondary_with_exhausted_primary_defers_to_reset() -> None:
+    """防御的パス(429)でも remaining=0 の secondary で既定60秒へ倒さない。
+
+    通常パスと防御的パスは別関数が待機秒数を決めるため、片方だけ修正しても気付けない。
+    実際この組み合わせは、通常パス側を直した時点では防御的パス側が未固定のままだった。
+    """
+    request = httpx.Request("GET", f"{GITHUB_API_BASE_URL}/users/octocat")
+    response_429 = httpx.Response(
+        429,
+        request=request,
+        headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1700000000"},
+        json={"message": SECONDARY_RATE_LIMIT_MESSAGE},
+    )
+    error_429 = httpx.HTTPStatusError(
+        "429 Too Many Requests", request=request, response=response_429
+    )
+
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat")
+    route.side_effect = [error_429]
+
+    async with AsyncGitHubClient() as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.get_user("octocat")
+
+    assert exc_info.value.retry_after is None
+    assert exc_info.value.reset_time == 1700000000
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_httpx_status_error_429_secondary_invalid_remaining_logs_warning_once() -> None:
+    """防御的パスの429でも不正 remaining は warning 1件で既定60秒へ倒す。
+
+    通常パス側の同名不変条件は test_invalid_rate_limit_header_429_secondary_logs_warning_once
+    が固定しているが、防御的パスは _handle_http_status_error が独立に remaining を解決するため
+    別テストが要る。この分岐が 403 側のように remaining を先読みして
+    _resolve_rate_limit_retry_after への注入を忘れると warning が 2 件になる。
+    """
+    request = httpx.Request("GET", f"{GITHUB_API_BASE_URL}/users/octocat")
+    response_429 = httpx.Response(
+        429,
+        request=request,
+        headers={"X-RateLimit-Remaining": "invalid"},
+        json={"message": SECONDARY_RATE_LIMIT_MESSAGE},
+    )
+    error_429 = httpx.HTTPStatusError(
+        "429 Too Many Requests", request=request, response=response_429
+    )
+
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat")
+    route.side_effect = [error_429]
+
+    with capture_logs() as log_output:
+        async with AsyncGitHubClient() as client:
+            with pytest.raises(RateLimitError) as exc_info:
+                await client.get_user("octocat")
+
+    warning_logs = [log for log in log_output if log.get("event") == "invalid_rate_limit_header"]
+    assert len(warning_logs) == 1
+    assert warning_logs[0]["header"] == "X-RateLimit-Remaining"
+    # 不正値は fallback (0以外) に倒れるため primary 枯渇とは判定されず、既定60秒が載る。
+    assert exc_info.value.retry_after == SECONDARY_RATE_LIMIT_FALLBACK_RETRY_AFTER
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_403_secondary_rate_limit_falls_back_to_default_retry_after() -> None:
+    """secondary rate limit は remaining != 0 かつ Retry-After 欠損でも RateLimitError にする。
+
+    primary 超過と違い remaining は 0 にならず Retry-After も付かないことがあるため、
+    ヘッダーだけでは通常の 403 Forbidden と区別できない。ヘッダー値は octokit issue #566 が
+    記録した実レスポンス（remaining=25 / Retry-After なし）をそのまま再現している。
+    """
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        403,
+        headers={
+            "X-RateLimit-Limit": "30",
+            "X-RateLimit-Remaining": "25",
+            "X-RateLimit-Reset": "1675318655",
+        },
+        json={"message": SECONDARY_RATE_LIMIT_MESSAGE},
+    )
+
+    async with AsyncGitHubClient() as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.get_user("octocat")
+
+    assert exc_info.value.retry_after == SECONDARY_RATE_LIMIT_FALLBACK_RETRY_AFTER
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_403_secondary_rate_limit_uses_retry_after_header() -> None:
+    """GitHub が Retry-After を明示した secondary では既定60秒でなくその値を使う。"""
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        403,
+        headers={"X-RateLimit-Remaining": "25", "Retry-After": "30"},
+        json={"message": SECONDARY_RATE_LIMIT_MESSAGE},
+    )
+
+    async with AsyncGitHubClient() as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.get_user("octocat")
+
+    assert exc_info.value.retry_after == 30
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_403_secondary_rate_limit_http_date_retry_after_falls_back() -> None:
+    """RFC 9110 は Retry-After に HTTP-date も許すため、秒数パース失敗を許容値として扱う。"""
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        403,
+        headers={
+            "X-RateLimit-Remaining": "25",
+            "Retry-After": "Wed, 21 Oct 2015 07:28:00 GMT",
+        },
+        json={"message": SECONDARY_RATE_LIMIT_MESSAGE},
+    )
+
+    async with AsyncGitHubClient() as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.get_user("octocat")
+
+    assert exc_info.value.retry_after == SECONDARY_RATE_LIMIT_FALLBACK_RETRY_AFTER
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_403_secondary_rate_limit_non_positive_retry_after_falls_back() -> None:
+    """非正の Retry-After は待機時間として無意味なため既定へ倒す。
+
+    HTTP-date のテストは int() が失敗して既定へ倒れるのに対し、こちらは int() が成功した上で
+    値が非正になる経路を通る。行き先は同じ既定だが到達経路が異なるため両方を固定する。
+    """
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        403,
+        headers={"X-RateLimit-Remaining": "25", "Retry-After": "0"},
+        json={"message": SECONDARY_RATE_LIMIT_MESSAGE},
+    )
+
+    async with AsyncGitHubClient() as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.get_user("octocat")
+
+    assert exc_info.value.retry_after == SECONDARY_RATE_LIMIT_FALLBACK_RETRY_AFTER
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_403_non_json_body_is_not_detected_as_secondary_rate_limit() -> None:
+    """body が JSON でない 403（プロキシの HTML エラー等）で誤検出も例外送出もしない。"""
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        403,
+        headers={"X-RateLimit-Remaining": "25"},
+        content=b"<html>secondary rate limit</html>",
+    )
+
+    async with AsyncGitHubClient() as client:
+        with pytest.raises(GitHubAPIError) as exc_info:
+            await client.get_user("octocat")
+
+    assert not isinstance(exc_info.value, RateLimitError)
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_429_secondary_rate_limit_uses_retry_after_header() -> None:
+    """通常パス(429)でも Retry-After を明示した secondary はその値を使う。"""
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        429,
+        headers={"X-RateLimit-Remaining": "25", "Retry-After": "45"},
+        json={"message": SECONDARY_RATE_LIMIT_MESSAGE},
+    )
+
+    async with AsyncGitHubClient() as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.get_user("octocat")
+
+    assert exc_info.value.retry_after == 45
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_429_secondary_rate_limit_falls_back_to_default_retry_after() -> None:
+    """通常パス(429)で Retry-After 欠損・remaining!=0 なら既定60秒へ倒す。
+
+    既定60秒は 403 経路にもテストがあるが、429 通常パスの配線は別関数なので独立に固定する。
+    """
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        429,
+        headers={"X-RateLimit-Remaining": "25"},
+        json={"message": SECONDARY_RATE_LIMIT_MESSAGE},
+    )
+
+    async with AsyncGitHubClient() as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.get_user("octocat")
+
+    assert exc_info.value.retry_after == SECONDARY_RATE_LIMIT_FALLBACK_RETRY_AFTER
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_429_secondary_rate_limit_with_exhausted_primary_defers_to_reset() -> None:
+    """primary quota 枯渇中(remaining=0)の secondary で既定60秒へ倒さない。
+
+    GitHub docs の待機時間の優先順位は Retry-After → remaining == 0 なら reset → 最低1分。
+    ここで60秒を返すと quota 枯渇のまま再送させ、docs が警告する BAN を招く。
+
+    retry_after is None は「secondary と判定されなかった」場合にも成立するため、本テスト単体
+    では検出が働いたことまでは示せない（それは Retry-After 系のテストが担う）。ここで固定する
+    のは remaining == 0 のとき 60 を返さないことに限る。
+    """
+    route = respx.get(f"{GITHUB_API_BASE_URL}/users/octocat").respond(
+        429,
+        headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1700000000"},
+        json={"message": SECONDARY_RATE_LIMIT_MESSAGE},
+    )
+
+    async with AsyncGitHubClient() as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.get_user("octocat")
+
+    assert exc_info.value.retry_after is None
+    assert exc_info.value.reset_time == 1700000000
     assert route.call_count == 1
 
 

--- a/tests/unit/test_github_error_handler.py
+++ b/tests/unit/test_github_error_handler.py
@@ -298,6 +298,36 @@ def test_parse_json_response_raises_github_api_error_on_invalid_json() -> None:
     assert logger.error.call_args.kwargs["endpoint"] == "/test"
 
 
+def test_parse_json_response_malformed_utf8_keeps_body_out_of_cause() -> None:
+    """不正 UTF-8 body でも生の UnicodeDecodeError を漏らさず body を cause から締め出す。
+
+    httpx の response.json() は bytes を直接デコードするため、不正 UTF-8 では
+    JSONDecodeError ではなく UnicodeDecodeError が飛ぶ（両者に継承関係はない）。
+    UnicodeDecodeError.object は JSONDecodeError.doc と同様に生 body を保持するため、
+    捕捉しないと Sentry へ body が届き SanitizedJSONDecodeError を設けた意味がなくなる。
+    行・列の概念を持たない型なので lineno/colno は -1（該当なし）で写す。
+    """
+    logger = MagicMock()
+    response = httpx.Response(200, content=b'{"token": "ghp_secret_leaked_value" \xff}')
+
+    with pytest.raises(GitHubAPIError) as exc_info:
+        _parse_json_response(
+            response=response,
+            endpoint="/test",
+            logger=logger,
+        )
+
+    assert "Invalid JSON response" in str(exc_info.value)
+    cause = exc_info.value.__cause__
+    assert isinstance(cause, SanitizedJSONDecodeError)
+    assert not isinstance(cause, UnicodeDecodeError)
+    assert b"ghp_secret_leaked_value" not in repr(cause).encode()
+    assert cause.error_type == "builtins.UnicodeDecodeError"
+    assert (cause.lineno, cause.colno) == (-1, -1)
+    assert exc_info.value.__context__ is None
+    assert logger.error.call_args.kwargs["error_type"] == "UnicodeDecodeError"
+
+
 def test_parse_json_response_logs_on_decode_error() -> None:
     mock_response = MagicMock(spec=httpx.Response)
     mock_response.json.side_effect = json.JSONDecodeError("Expecting value", "bad", 0)
@@ -401,6 +431,35 @@ def test_handle_403_response_no_json_log() -> None:
     assert logger.warning.call_args.args[0] == "failed_to_parse_error_message"
     assert logger.warning.call_args.kwargs["status_code"] == 403
     assert logger.warning.call_args.kwargs["error_type"] == "JSONDecodeError"
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+
+
+def test_handle_403_response_malformed_utf8_body_stays_forbidden() -> None:
+    """不正 UTF-8 の secondary rate limit body は素通りせず Forbidden へ落ちる。
+
+    httpx は不正 UTF-8 に対し UnicodeDecodeError を送出する（JSONDecodeError ではない）。
+    捕捉しないと 403 整形が例外で抜け、呼び出し側が GitHubAPIError ではなく生の
+    UnicodeDecodeError を受け取る（.object が body を保持したまま）。
+    body をデコードできない以上 secondary 判定は不能なので、message 抽出不能の他ケースと
+    同じく Forbidden に倒すのが正しい。RateLimitError に昇格しないことを固定する。
+    """
+    response = httpx.Response(
+        403,
+        headers={"X-RateLimit-Remaining": "50", "X-RateLimit-Reset": "0"},
+        content=b'{"message": "You have exceeded a secondary rate limit \xff"}',
+    )
+    logger = MagicMock()
+    with pytest.raises(GitHubAPIError) as exc_info:
+        _handle_403_response(response, logger=logger)
+    assert not isinstance(exc_info.value, RateLimitError)
+    logger.warning.assert_called_once()
+    assert logger.warning.call_args.args[0] == "failed_to_parse_error_message"
+    assert logger.warning.call_args.kwargs["status_code"] == 403
+    assert logger.warning.call_args.kwargs["error_type"] == "UnicodeDecodeError"
+    # UnicodeDecodeError.start（不正バイト位置）が error_pos へ写ることを固定する。
+    assert logger.warning.call_args.kwargs["error_pos"] == 54
+    assert "error_lineno" not in logger.warning.call_args.kwargs
     assert exc_info.value.__cause__ is None
     assert exc_info.value.__context__ is None
 

--- a/tests/unit/test_github_error_handler.py
+++ b/tests/unit/test_github_error_handler.py
@@ -398,10 +398,174 @@ def test_handle_403_response_no_json_log() -> None:
     with pytest.raises(GitHubAPIError) as exc_info:
         _handle_403_response(response, logger=logger)
     logger.warning.assert_called_once()
-    assert logger.warning.call_args.args[0] == "failed_to_parse_403_message"
+    assert logger.warning.call_args.args[0] == "failed_to_parse_error_message"
+    assert logger.warning.call_args.kwargs["status_code"] == 403
     assert logger.warning.call_args.kwargs["error_type"] == "JSONDecodeError"
     assert exc_info.value.__cause__ is None
     assert exc_info.value.__context__ is None
+
+
+def test_handle_403_response_empty_body_logs_no_warning() -> None:
+    """空 body は「パース失敗」ではなく「message なし」として warning なしで扱う。
+
+    body を持たない 429 が同じ抽出関数を通るようになったため、空 body を
+    パース失敗として警告すると常態がノイズになる。この意図的な挙動変更を固定する
+    （test_handle_403_response_no_json_log の非空・不正 JSON とは別経路）。
+    """
+    response = httpx.Response(
+        403,
+        headers={"X-RateLimit-Remaining": "50", "X-RateLimit-Reset": "0"},
+        content=b"",
+    )
+    logger = MagicMock()
+    with pytest.raises(GitHubAPIError) as exc_info:
+        _handle_403_response(response, logger=logger)
+    logger.warning.assert_not_called()
+    assert not isinstance(exc_info.value, RateLimitError)
+
+
+def test_handle_http_status_error_429_parse_failure_logs_status_code_429() -> None:
+    """パース失敗 warning は 429 由来なら status_code=429 を載せる。
+
+    このイベントは 403 と 429 の両経路から発火するため、status_code だけが由来の判別材料になる。
+    403 側のテスト (test_handle_403_response_no_json_log) は status_code を 403 に
+    固定実装しても通ってしまい、フィールドの存在意義そのものを検証できない。
+    """
+    response = httpx.Response(
+        429,
+        headers={"X-RateLimit-Remaining": "50", "X-RateLimit-Reset": "1700000000"},
+        content=b"not json",
+    )
+    logger = MagicMock()
+    with pytest.raises(RateLimitError):
+        _handle_http_status_error(
+            response=response,
+            endpoint="/test",
+            method="GET",
+            logger=logger,
+        )
+    logger.warning.assert_called_once()
+    assert logger.warning.call_args.args[0] == "failed_to_parse_error_message"
+    assert logger.warning.call_args.kwargs["status_code"] == 429
+
+
+_EXHAUSTED_PRIMARY_WITH_BOTH_HEADERS = {
+    "X-RateLimit-Remaining": "0",
+    "X-RateLimit-Reset": "1700000000",
+    "Retry-After": "45",
+}
+
+
+def test_handle_403_exhausted_primary_keeps_retry_after_and_reset() -> None:
+    """primary 枯渇の 403 でも Retry-After と Reset の両方を例外に保持する。
+
+    GitHub docs は「Retry-After 経過まで再試行しない」と「remaining == 0 なら reset まで
+    再試行しない」を独立条件として課すため、片方を破棄すると消費者が
+    max(now + retry_after, reset_time) を計算できない。remaining == 0 では body を
+    読まないため、非 JSON body でも warning が出ないことも同時に固定する。
+    """
+    response = httpx.Response(
+        403,
+        headers=_EXHAUSTED_PRIMARY_WITH_BOTH_HEADERS,
+        content=b"not json",
+    )
+    logger = MagicMock()
+    with pytest.raises(RateLimitError) as exc_info:
+        _handle_403_response(response, logger=logger)
+    assert exc_info.value.retry_after == 45
+    assert exc_info.value.reset_time == 1700000000
+    logger.warning.assert_not_called()
+
+
+def test_handle_http_status_error_429_exhausted_primary_keeps_retry_after_and_reset() -> None:
+    """primary 枯渇の 429 は 403 と同じ判定規則で両ヘッダーを保持する。
+
+    403 側 (test_handle_403_exhausted_primary_keeps_retry_after_and_reset) と同一ヘッダーで
+    同一の (retry_after, reset_time) になることを固定し、経路間の非対称の再発を防ぐ。
+    remaining == 0 で body を読まないため、非 JSON body でも warning は出ない。
+    """
+    response = httpx.Response(
+        429,
+        headers=_EXHAUSTED_PRIMARY_WITH_BOTH_HEADERS,
+        content=b"not json",
+    )
+    logger = MagicMock()
+    with pytest.raises(RateLimitError) as exc_info:
+        _handle_http_status_error(
+            response=response,
+            endpoint="/test",
+            method="GET",
+            logger=logger,
+        )
+    assert exc_info.value.retry_after == 45
+    assert exc_info.value.reset_time == 1700000000
+    logger.warning.assert_not_called()
+
+
+def test_handle_403_with_retry_after_but_no_rate_limit_signal_stays_forbidden() -> None:
+    """remaining != 0 かつ非 secondary の 403 は Retry-After が付いていても Forbidden のまま。
+
+    rate limit 判定に Retry-After の有無を使うと、WAF 等が Retry-After を付けた
+    通常の Forbidden を RateLimitError に誤分類する。判定材料は remaining と
+    message 文言のみであることを固定する。
+    """
+    response = httpx.Response(
+        403,
+        headers={"X-RateLimit-Remaining": "50", "Retry-After": "45"},
+        json={"message": "Forbidden by policy"},
+    )
+    logger = MagicMock()
+    with pytest.raises(GitHubAPIError, match="^Access forbidden$") as exc_info:
+        _handle_403_response(response, logger=logger)
+    assert not isinstance(exc_info.value, RateLimitError)
+
+
+def test_handle_403_exhausted_primary_without_retry_after_defers_to_reset() -> None:
+    """Retry-After 欠落の primary 枯渇 403 は retry_after=None で reset 待ちに委ねる。"""
+    response = httpx.Response(
+        403,
+        headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1700000000"},
+    )
+    logger = MagicMock()
+    with pytest.raises(RateLimitError) as exc_info:
+        _handle_403_response(response, logger=logger)
+    assert exc_info.value.retry_after is None
+    assert exc_info.value.reset_time == 1700000000
+
+
+def test_handle_403_exhausted_primary_without_reset_keeps_retry_after() -> None:
+    """Reset 欠落の primary 枯渇 403 でも Retry-After は破棄せず保持する（429 側と対称）。"""
+    response = httpx.Response(
+        403,
+        headers={"X-RateLimit-Remaining": "0", "Retry-After": "45"},
+    )
+    logger = MagicMock()
+    with pytest.raises(RateLimitError) as exc_info:
+        _handle_403_response(response, logger=logger)
+    assert exc_info.value.retry_after == 45
+    assert exc_info.value.reset_time == 0
+
+
+def test_handle_http_status_error_429_exhausted_primary_without_reset_keeps_retry_after() -> None:
+    """Reset 欠落の primary 枯渇 429 でも Retry-After は破棄せず保持する。
+
+    reset_time は欠落フォールバックの 0（= 不明）になるため、Retry-After まで捨てると
+    消費者が待機時間を一切算出できなくなる。
+    """
+    response = httpx.Response(
+        429,
+        headers={"X-RateLimit-Remaining": "0", "Retry-After": "45"},
+    )
+    logger = MagicMock()
+    with pytest.raises(RateLimitError) as exc_info:
+        _handle_http_status_error(
+            response=response,
+            endpoint="/test",
+            method="GET",
+            logger=logger,
+        )
+    assert exc_info.value.retry_after == 45
+    assert exc_info.value.reset_time == 0
 
 
 @pytest.mark.parametrize(

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -25,6 +25,9 @@ from utils.github_error_handler import (
 from utils.github_error_handler import (
     _parse_json_response as parse_json_response,
 )
+from utils.github_error_handler import (
+    _resolve_rate_limit_retry_after as resolve_rate_limit_retry_after,
+)
 from utils.github_etag_cache import GitHubETagCache
 from utils.github_rate_limit import (
     _RATE_LIMIT_FALLBACK_REMAINING,
@@ -482,17 +485,27 @@ class AsyncGitHubClient:
                             logger=self.logger,
                         )
                     )
+                    # 429 は primary / secondary の両方で返る。Retry-After は両者で保持し、
+                    # 再試行可能時刻は max(now + retry_after, reset_time)
+                    # (utils/github_error_handler.py の RateLimitError 参照)。
+                    # remaining は上でパース済み。渡さないと同じヘッダーが再パースされ、
+                    # 不正値のとき invalid_rate_limit_header warning が重複する。
+                    retry_after = resolve_rate_limit_retry_after(
+                        response,
+                        logger=self.logger,
+                        rate_remaining=remaining,
+                    )
                     # PII漏洩防止: 例外チェーン経由の httpx URL/header 露出を抑制
                     # (defensive path との等価性維持: 403→RateLimitError 変換も from None)
-                    raise RateLimitError(reset_time) from None
+                    raise RateLimitError(reset_time, retry_after=retry_after) from None
 
                 if response.status_code == 403:
                     # 注: warning_reset_time は _check_rate_limit_warning が
                     # remaining < RATE_LIMIT_WARNING_THRESHOLD (=10) のときのみ
                     # 非 None を返す (utils/github_rate_limit.py)。
-                    # 閾値変更時はこの reset_time が常に None になり _handle_403_response
-                    # 側の Retry-After ヘッダー fallback パスに倒れる挙動になる。
-                    # debug-only ログのため動作影響は限定的だが、依存関係を明示する。
+                    # 閾値変更時はこの reset_time が常に None になり、_handle_403_response
+                    # 側が X-RateLimit-Reset を自前パースする経路に倒れる。同じヘッダーを
+                    # 同じ既定値で読むため値は変わらないが、依存関係を明示する。
                     handle_403_response(
                         response,
                         logger=self.logger,

--- a/utils/github_error_handler.py
+++ b/utils/github_error_handler.py
@@ -123,6 +123,17 @@ class GitHubServerError(GitHubAPIError):
     """GitHub returned a server-side failure."""
 
 
+def _decode_error_position(error: json.JSONDecodeError | UnicodeDecodeError) -> dict[str, int]:
+    """Return the log-safe position fields of a body decode failure.
+
+    位置情報の属性名は型ごとに異なる（JSONDecodeError は pos/lineno、UnicodeDecodeError は
+    start のみで行・列の概念を持たない）。どちらも int しか返さないため body は漏れない。
+    """
+    if isinstance(error, json.JSONDecodeError):
+        return {"error_pos": error.pos, "error_lineno": error.lineno}
+    return {"error_pos": error.start}
+
+
 def _extract_error_message(
     response: httpx.Response,
     *,
@@ -141,7 +152,11 @@ def _extract_error_message(
         return ""
     try:
         parsed = response.json()
-    except json.JSONDecodeError as parse_err:
+    except (json.JSONDecodeError, UnicodeDecodeError) as parse_err:
+        # httpx は response.json() で bytes を直接デコードするため、不正 UTF-8 では
+        # JSONDecodeError ではなく UnicodeDecodeError が飛ぶ。utils/response_parsing.py と
+        # 同じ扱い。捕捉しないと 403/429 の整形が例外で抜け、UnicodeDecodeError.object が
+        # 生 body を Sentry へ運ぶ（モジュール docstring の PII 制約に反する）。
         logger.warning(
             "failed_to_parse_error_message",
             # 本関数は 403 と 429 の両経路から呼ばれるため、status_code がないと
@@ -149,8 +164,7 @@ def _extract_error_message(
             status_code=response.status_code,
             error_type=type(parse_err).__qualname__,
             error_module=type(parse_err).__module__,
-            error_pos=parse_err.pos,
-            error_lineno=parse_err.lineno,
+            **_decode_error_position(parse_err),
         )
         return ""
     if not isinstance(parsed, dict):
@@ -326,22 +340,28 @@ def _parse_json_response(
     sanitized_cause: SanitizedJSONDecodeError | None = None
     try:
         return cast("dict[str, Any] | list[dict[str, Any]]", response.json())
-    except json.JSONDecodeError as error:
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        # 不正 UTF-8 では UnicodeDecodeError が飛ぶ（_extract_error_message と同じ理由）。
+        # 生のまま漏らすと .object が body を保持したまま Sentry へ届き、本モジュールが
+        # SanitizedJSONDecodeError を設けた意味がなくなる。
         logger.error(
             "json_decode_error",
             endpoint=endpoint,
             error_type=type(error).__qualname__,
             error_module=type(error).__module__,
-            error_pos=error.pos,
-            error_lineno=error.lineno,
+            **_decode_error_position(error),
         )
-        sanitized_cause = SanitizedJSONDecodeError(
-            f"{type(error).__module__}.{type(error).__qualname__}",
-            error.msg,
-            error.pos,
-            error.lineno,
-            error.colno,
-        )
+        cause_type = f"{type(error).__module__}.{type(error).__qualname__}"
+        if isinstance(error, json.JSONDecodeError):
+            sanitized_cause = SanitizedJSONDecodeError(
+                cause_type, error.msg, error.pos, error.lineno, error.colno
+            )
+        else:
+            # UnicodeDecodeError は行・列の概念を持たないため -1（該当なし）を渡す。
+            # msg/pos に相当するのは reason/start。
+            sanitized_cause = SanitizedJSONDecodeError(
+                cause_type, error.reason, error.start, -1, -1
+            )
     raise GitHubAPIError("Invalid JSON response") from sanitized_cause
 
 

--- a/utils/github_error_handler.py
+++ b/utils/github_error_handler.py
@@ -13,6 +13,7 @@ Sentry や traceback 経由でトークン・private repository 名が漏れう�
 import asyncio
 import hashlib
 import json
+import re
 from datetime import UTC, datetime
 from typing import Any, NoReturn, cast
 
@@ -23,12 +24,19 @@ from utils.exceptions import APIClientError
 from utils.github_rate_limit import (
     _RATE_LIMIT_FORBIDDEN_FALLBACK,
     _RATE_LIMIT_RESET_FALLBACK,
+    SECONDARY_RATE_LIMIT_FALLBACK_RETRY_AFTER,
     _parse_rate_limit_header,
 )
 from utils.retry import exponential_backoff_with_jitter
 
 _MAX_403_ERROR_MESSAGE_CHARS = 200
 _MAX_HTTP_ERROR_BODY_PREVIEW_BYTES = 200
+
+# secondary rate limit は primary と違い remaining が 0 にならず Retry-After も
+# 付かないことがあるため、ヘッダーだけでは通常の 403/429 と区別できない。
+# body の message 文言が唯一の判定材料であり、公式SDK octokit/plugin-throttling.js も
+# 同一の正規表現で判定している。文言変更で検出漏れしうる既知の脆さだが代替手段がない。
+_SECONDARY_RATE_LIMIT_PATTERN = re.compile(r"\bsecondary rate\b", re.IGNORECASE)
 
 
 def redact_body_preview(body_preview: str) -> str:
@@ -75,10 +83,25 @@ class SanitizedJSONDecodeError(Exception):
 
 
 class RateLimitError(GitHubAPIError):
-    """GitHub primary or secondary rate limit was exceeded."""
+    """GitHub primary or secondary rate limit was exceeded.
 
-    def __init__(self, reset_time: int) -> None:
+    Args:
+        reset_time: primary quota がリセットされる unix 時刻。GitHub が X-RateLimit-Reset
+            を返さなかった場合は 0（= 不明）。
+        retry_after: Retry-After ヘッダーの秒数。primary / secondary を問わず保持する。
+            secondary で Retry-After 欠損時は既定60秒。None のときは reset_time まで待つが、
+            reset_time == 0 なら待機時間を算出できないため、呼び出し側が既定値を決める。
+
+    GitHub docs は「Retry-After の秒数が経過するまで再試行しない」と「remaining == 0 なら
+    reset 時刻まで再試行しない」を独立した条件として課すため、再試行可能時刻は
+    max(now + retry_after, reset_time) とする。本リポジトリに自動リトライの消費者は
+    ないが（4xx 即失敗契約）、導入する場合は上記の遅い方まで待機すること。
+    どの条件で retry_after が定まるかは _rate_limit_retry_after を参照。
+    """
+
+    def __init__(self, reset_time: int, *, retry_after: int | None = None) -> None:
         self.reset_time = reset_time
+        self.retry_after = retry_after
         if reset_time > 0:
             try:
                 reset_str = datetime.fromtimestamp(reset_time, tz=UTC).isoformat()
@@ -86,7 +109,10 @@ class RateLimitError(GitHubAPIError):
                 reset_str = f"unix:{reset_time}"
         else:
             reset_str = "unknown"
-        super().__init__(f"Rate limit exceeded. Reset at {reset_str}")
+        message = f"Rate limit exceeded. Reset at {reset_str}"
+        if retry_after is not None:
+            message = f"{message}. Retry after {retry_after}s"
+        super().__init__(message)
 
 
 class NotFoundError(GitHubAPIError):
@@ -97,6 +123,113 @@ class GitHubServerError(GitHubAPIError):
     """GitHub returned a server-side failure."""
 
 
+def _extract_error_message(
+    response: httpx.Response,
+    *,
+    logger: FilteringBoundLogger,
+) -> str:
+    """Return the JSON body's `message` field, or "" when absent or unparsable.
+
+    呼び出し側は本関数を1レスポンスにつき1回だけ呼ぶこと。body は都度パースされ、
+    失敗時に warning を出すため、複数回呼ぶとログが重複する。
+
+    空 body は「パース失敗」ではなく「message なし」として warning なしで "" を返す。
+    429 は body を持たないことが常態であり、警告を出すとノイズになるため。この結果、
+    従来 warning が出ていた空 body の 403 では出なくなるが、送出される例外は変わらない。
+    """
+    if not response.content:
+        return ""
+    try:
+        parsed = response.json()
+    except json.JSONDecodeError as parse_err:
+        logger.warning(
+            "failed_to_parse_error_message",
+            # 本関数は 403 と 429 の両経路から呼ばれるため、status_code がないと
+            # ログだけではどちらのレスポンスで失敗したか切り分けられない。
+            status_code=response.status_code,
+            error_type=type(parse_err).__qualname__,
+            error_module=type(parse_err).__module__,
+            error_pos=parse_err.pos,
+            error_lineno=parse_err.lineno,
+        )
+        return ""
+    if not isinstance(parsed, dict):
+        return ""
+    raw_message = parsed.get("message", "")
+    if not isinstance(raw_message, str):
+        return ""
+    return raw_message[:_MAX_403_ERROR_MESSAGE_CHARS]
+
+
+def _parse_retry_after(headers: httpx.Headers) -> int | None:
+    """Return the Retry-After seconds, or None when absent, unparsable, or non-positive.
+
+    RFC 9110 は Retry-After に HTTP-date も許すが GitHub は秒数で返す。秒数として
+    読めない値や非正の値はヘッダー不在として扱う（誤った待機時間を返すより安全側）。
+    """
+    raw = headers.get("Retry-After")
+    if raw is None:
+        return None
+    try:
+        seconds = int(raw)
+    except ValueError:
+        return None
+    return seconds if seconds > 0 else None
+
+
+def _rate_limit_retry_after(response: httpx.Response, error_message: str) -> int | None:
+    """Return the wait seconds for a rate-limited response, or None to wait for the reset time.
+
+    GitHub docs は「Retry-After の秒数が経過するまで再試行しない」と「remaining == 0 なら
+    reset まで再試行しない」を独立した条件として課すため、Retry-After は primary /
+    secondary を問わず常に保持する（再試行可能時刻の合成規則は RateLimitError を参照）。
+    Retry-After 欠損時は、secondary なら docs の「最低1分」に倒し、それ以外は None を
+    返して reset まで待たせる。
+
+    `error_message` は JSON body の message フィールドに限定する。生 body を対象にすると
+    プロキシが返す HTML エラー等が文言を含むだけで誤検出されうる。呼び出し側は
+    remaining == 0（primary 枯渇）のとき body を読まず "" を渡す規約なので、
+    secondary の 60 秒フォールバックが primary 枯渇時に誤って適用されることはない。
+    """
+    seconds = _parse_retry_after(response.headers)
+    if seconds is not None:
+        return seconds
+    if _SECONDARY_RATE_LIMIT_PATTERN.search(error_message):
+        return SECONDARY_RATE_LIMIT_FALLBACK_RETRY_AFTER
+    return None
+
+
+def _resolve_rate_limit_retry_after(
+    response: httpx.Response,
+    *,
+    logger: FilteringBoundLogger,
+    rate_remaining: int | None = None,
+) -> int | None:
+    """Return the retry_after seconds for a 429 response, or None to wait for the reset time.
+
+    remaining == 0 は primary 枯渇として扱い body を読まない（403 側と同じ判定規則）。
+    403 ハンドラは抽出した message を forbidden ログにも使うため抽出と判定を分けて呼ぶが、
+    429 の2経路は retry_after しか要らないため本関数を使う（message の二重パースを避ける）。
+
+    Args:
+        rate_remaining: 呼び出し側が X-RateLimit-Remaining をパース済みならその値。None なら
+            本関数がパースする。ヘッダー不正時に _parse_rate_limit_header が warning を出すため、
+            既にパース済みの値を渡さないと1レスポンスにつき warning が重複する。
+            fallback 値は呼び出し側と異なりうるが、0 以外である点は共通なので判定は変わらない。
+    """
+    if rate_remaining is None:
+        rate_remaining = _parse_rate_limit_header(
+            response.headers,
+            "X-RateLimit-Remaining",
+            # 定数名は 403 由来だが、値 -1 の意味は「remaining ヘッダーが読めない」であり
+            # 429 でも同じ。0 以外なら primary 枯渇と誤判定しないため既定として正しい。
+            _RATE_LIMIT_FORBIDDEN_FALLBACK,
+            logger=logger,
+        )
+    error_message = "" if rate_remaining == 0 else _extract_error_message(response, logger=logger)
+    return _rate_limit_retry_after(response, error_message)
+
+
 def _handle_403_response(
     response: httpx.Response,
     *,
@@ -104,7 +237,12 @@ def _handle_403_response(
     rate_remaining: int | None = None,
     reset_time: int | None = None,
 ) -> NoReturn:
-    """Distinguish a rate-limit response from other 403 failures and raise."""
+    """Distinguish a rate-limit response from other 403 failures and raise.
+
+    403 は primary 超過 / secondary rate limit / 通常の Forbidden の3通りで返る。
+    primary は remaining == 0 で判別できるが、secondary は remaining != 0 のまま返り
+    Retry-After も付かないことがあるため、body の message 文言でしか判別できない。
+    """
     if rate_remaining is None:
         rate_remaining = _parse_rate_limit_header(
             response.headers,
@@ -112,7 +250,16 @@ def _handle_403_response(
             _RATE_LIMIT_FORBIDDEN_FALLBACK,
             logger=logger,
         )
-    if rate_remaining == 0:
+
+    # primary は remaining だけで判別でき body を読む必要がない。読まないことで、
+    # primary 経路に parse 失敗 warning を増やさない従来挙動も維持される。
+    error_message = "" if rate_remaining == 0 else _extract_error_message(response, logger=logger)
+    # rate limit 判定は remaining と message 文言のみで行う。Retry-After の有無を判定に
+    # 使うと、WAF 等が Retry-After を付けた通常の Forbidden を RateLimitError に誤分類する。
+    is_secondary = _SECONDARY_RATE_LIMIT_PATTERN.search(error_message) is not None
+
+    if rate_remaining == 0 or is_secondary:
+        retry_after = _rate_limit_retry_after(response, error_message)
         if reset_time is None:
             reset_time = _parse_rate_limit_header(
                 response.headers,
@@ -120,23 +267,7 @@ def _handle_403_response(
                 _RATE_LIMIT_RESET_FALLBACK,
                 logger=logger,
             )
-        raise RateLimitError(reset_time) from None
-
-    error_message = ""
-    try:
-        parsed = response.json()
-        if isinstance(parsed, dict):
-            raw_message = parsed.get("message", "")
-            if isinstance(raw_message, str):
-                error_message = raw_message[:_MAX_403_ERROR_MESSAGE_CHARS]
-    except json.JSONDecodeError as parse_err:
-        logger.warning(
-            "failed_to_parse_403_message",
-            error_type=type(parse_err).__qualname__,
-            error_module=type(parse_err).__module__,
-            error_pos=parse_err.pos,
-            error_lineno=parse_err.lineno,
-        )
+        raise RateLimitError(reset_time, retry_after=retry_after) from None
 
     if error_message:
         logger.warning(
@@ -238,7 +369,10 @@ def _handle_http_status_error(
             _RATE_LIMIT_RESET_FALLBACK,
             logger=logger,
         )
-        raise RateLimitError(reset_time) from None
+        # 429 は primary / secondary の両方で返る。Retry-After は両者で保持し、
+        # 再試行可能時刻は max(now + retry_after, reset_time)（RateLimitError 参照）。
+        retry_after = _resolve_rate_limit_retry_after(response, logger=logger)
+        raise RateLimitError(reset_time, retry_after=retry_after) from None
     if status_code == 403:
         remaining = _parse_rate_limit_header(
             response.headers,

--- a/utils/github_rate_limit.py
+++ b/utils/github_rate_limit.py
@@ -13,6 +13,13 @@ RATE_LIMIT_WARNING_THRESHOLD = 10
 _RATE_LIMIT_FORBIDDEN_FALLBACK = -1
 _RATE_LIMIT_RESET_FALLBACK = 0
 
+# secondary rate limit で Retry-After が欠損・不正のときの待機秒数。GitHub docs の
+# 「最低1分待て」に対応する。Retry-After は primary / secondary を問わず常に保持され、
+# remaining == 0（primary 枯渇）で Retry-After もない場合は X-RateLimit-Reset まで待つため
+# 本定数は使われない。公式SDK octokit/plugin-throttling.js も
+# fallbackSecondaryRateRetryAfter=60 を既定にしている。
+SECONDARY_RATE_LIMIT_FALLBACK_RETRY_AFTER = 60
+
 
 def _parse_rate_limit_header(
     headers: httpx.Headers,


### PR DESCRIPTION
## 概要
GitHubのsecondary rate limitはprimaryと異なりremainingが0にならず、Retry-Afterも欠損することがあるため、従来のprimary判定（remaining==0）では検出できなかった。

## 変更内容
- bodyのmessage文言でsecondary rate limitを判定
- Retry-After欠損時は60秒フォールバックを適用
- RateLimitErrorにretry_afterフィールドを追加し、primary/secondary共通で保持
- 429/403両経路でretry_afterを解決・伝播

## テスト
- [x] ローカルテスト完了 (1441 tests passed)
- [x] CI/CD パイプライン確認

## 関連Issue/PR
関連Issueなし

---
このPRは /push-pr スキルで自動生成されました。