### PR TITLE
ci(security): TrivyスキャンをSARIF可視化とCIゲートに分離

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
   # Strategy:
   #   - develop: trivy fs only (fast, no Docker build)
   #   - main: trivy fs + trivy image (comprehensive)
-  # Format: SARIF (error differentiation + GitHub Security tab integration)
+  # Format: SARIF (all severities -> Security tab) + table (CI gate: CRITICAL/HIGH)
   # Error Handling: Differentiates security findings vs infrastructure errors
   # ============================================================
   pr-trivy-scan:
@@ -162,7 +162,11 @@ jobs:
           persist-credentials: false
 
       # Step 1: Filesystem scan (both develop and main)
-      - name: Trivy filesystem scan (dependencies)
+      # Stage 1a: Security tab 可視化用（全severity・ジョブを落とさない）
+      # trivy-action は format=sarif のとき TRIVY_SEVERITY を unset する（entrypoint.sh:76-83）。
+      # つまり SARIF スキャンに severity を指定しても無視されるため、ここでは指定せず
+      # 全severityを Security tab に記録し、CIゲートは Stage 1b に分離する。
+      - name: Trivy filesystem scan (SARIF for Security tab)
         id: fs-scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         env:
@@ -172,9 +176,8 @@ jobs:
           scan-ref: "."
           format: "sarif"
           output: "trivy-fs-scan.sarif"
-          exit-code: "1"
+          exit-code: "0"
           ignore-unfixed: true
-          severity: "CRITICAL,HIGH"
           trivyignores: ".trivyignore"
           # Trivyキャッシュ戦略: 週次スケジュール実行時のみDB再ダウンロード、通常PRではキャッシュ利用
           cache: ${{ github.event_name != 'schedule' }}
@@ -182,7 +185,7 @@ jobs:
 
       - name: Verify filesystem scan execution
         id: verify-fs-scan
-        if: always()
+        if: "!cancelled()"
         uses: ./.github/actions/trivy-sarif-verify
         with:
           sarif-file: "trivy-fs-scan.sarif"
@@ -195,33 +198,68 @@ jobs:
           sarif_file: "trivy-fs-scan.sarif"
           category: "trivy-pr-fs-scan"
 
-      - name: Fail job if vulnerabilities found or verification failed
+      # Stage 1b: CIゲート（CRITICAL,HIGH のみ）
+      # format=table では TRIVY_SEVERITY が unset されないため severity 指定が実際に効く。
+      # 併せてジョブログに脆弱性テーブルが出力され、開発者が失敗理由を直接確認できる。
+      - name: Trivy filesystem gate (CRITICAL,HIGH)
+        id: fs-gate
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          format: "table"
+          exit-code: "1"
+          ignore-unfixed: true
+          severity: "CRITICAL,HIGH"
+          trivyignores: ".trivyignore"
+          # 同一job内での再呼び出し: 直前のSARIFスキャンが2種類のキャッシュを処理済みのため両方止める。
+          #   skip-setup-trivy → Trivyバイナリの再取得(trivy-binary-* キャッシュ)を省略
+          #   cache: false     → 脆弱性DBの actions/cache 再実行(cache-trivy-* キャッシュ)を省略
+          # DBは cache-dir (${{ github.workspace }}/.cache/trivy) に残り、TRIVY_CACHE_DIR は常に設定される。
+          skip-setup-trivy: true
+          cache: false
+        continue-on-error: true
+
+      - name: Fail job if fs vulnerabilities found or verification failed
         if: |
           !cancelled() && (
             steps.fs-scan.outcome == 'failure' ||
-            steps.fs-scan.outcome == 'cancelled' ||
             steps.fs-scan.outcome == 'skipped' ||
-            steps.verify-fs-scan.outcome == 'failure' ||
-            steps.verify-fs-scan.outcome == 'cancelled'
+            steps.fs-gate.outcome == 'failure' ||
+            steps.fs-gate.outcome == 'skipped' ||
+            steps.verify-fs-scan.outcome == 'failure'
           )
         run: |
-          # 優先度1: スキャン未実施
+          # 優先度1: スキャン自体が未実施
           if [ "${{ steps.fs-scan.outcome }}" == "skipped" ]; then
-            echo "::error::Trivy filesystem scan was skipped — security gate requires scan to complete"
-            exit 1
-          fi
-          # 優先度2: SARIF検証失敗（インフラ問題の可能性）
-          if [ "${{ steps.verify-fs-scan.outcome }}" == "failure" ]; then
-            echo "::error::SARIF検証が失敗しました - Trivyがクラッシュした可能性があります"
-            echo "::warning::考えられる原因: DB取得失敗、タイムアウト、ディスク容量不足"
-            echo "::notice::対処法: Trivyログを確認し、インフラ問題を調査してください"
+            echo "::error::Trivy filesystem scan was skipped — security gate requires the scan to run"
           fi
 
-          # 優先度3: 脆弱性検出（正常な失敗）
-          if [ "${{ steps.fs-scan.outcome }}" == "failure" ]; then
-            echo "::error::脆弱性（CRITICAL/HIGH）が dependencies で検出されました"
-            echo "::notice::対処法: 脆弱性レポートを確認し、依存関係を更新してください"
+          # 優先度2: SARIF検証失敗
+          if [ "${{ steps.verify-fs-scan.outcome }}" == "failure" ]; then
+            echo "::error::SARIF検証が失敗しました — Trivyの異常終了または不正なSARIFの可能性があります"
+            echo "::warning::考えられる原因: DB取得失敗、タイムアウト、ディスク容量不足、SARIF出力不備"
+            echo "::notice::対処法: TrivyおよびSARIF検証ステップのログを確認してください"
           fi
+
+          # 優先度3: SARIFスキャンの実行エラー
+          if [ "${{ steps.fs-scan.outcome }}" == "failure" ]; then
+            echo "::error::SARIFスキャンが異常終了しました — Trivy実行エラーの可能性があります"
+          fi
+
+          # 優先度4: ゲート未実施
+          if [ "${{ steps.fs-gate.outcome }}" == "skipped" ]; then
+            echo "::error::Filesystem vulnerability gate was skipped because a prerequisite step did not complete successfully"
+          fi
+
+          # 優先度5: 脆弱性検出
+          if [ "${{ steps.fs-gate.outcome }}" == "failure" ]; then
+            echo "::error::脆弱性（CRITICAL/HIGH）がdependenciesで検出されました"
+            echo "::notice::対処法: 上記のTrivyテーブル出力を確認し、依存関係を更新してください"
+          fi
+
           exit 1
 
       # Step 2: Build Docker image (main PRs + Dependabot docker PRs)
@@ -250,7 +288,8 @@ jobs:
           exit 1
 
       # Step 3: Docker image scan (main PRs + Dependabot docker PRs)
-      - name: Trivy image scan (main PRs + docker label)
+      # Stage 3a: Security tab 可視化用（全severity・ここではジョブを落とさない）
+      - name: Trivy image scan (SARIF for Security tab)
         id: image-scan
         if: steps.docker-build.outcome == 'success'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
@@ -260,9 +299,8 @@ jobs:
           image-ref: "security-scan:${{ github.sha }}"
           format: "sarif"
           output: "trivy-image-scan.sarif"
-          exit-code: "1"
+          exit-code: "0"
           ignore-unfixed: true
-          severity: "CRITICAL,HIGH"
           trivyignores: ".trivyignore"
           # Trivyキャッシュ戦略: 週次スケジュール実行時のみDB再ダウンロード、通常PRではキャッシュ利用
           cache: ${{ github.event_name != 'schedule' }}
@@ -283,27 +321,76 @@ jobs:
           sarif_file: "trivy-image-scan.sarif"
           category: "trivy-pr-image-scan"
 
-      - name: Fail job if vulnerabilities found or verification failed
+      # Stage 3b: CIゲート（CRITICAL,HIGH のみ）
+      - name: Trivy image gate (CRITICAL,HIGH)
+        id: image-gate
+        if: steps.docker-build.outcome == 'success'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+        with:
+          image-ref: "security-scan:${{ github.sha }}"
+          format: "table"
+          exit-code: "1"
+          ignore-unfixed: true
+          severity: "CRITICAL,HIGH"
+          trivyignores: ".trivyignore"
+          # 同一job内での再呼び出し: 直前のSARIFスキャンが2種類のキャッシュを処理済みのため両方止める。
+          #   skip-setup-trivy → Trivyバイナリの再取得(trivy-binary-* キャッシュ)を省略
+          #   cache: false     → 脆弱性DBの actions/cache 再実行(cache-trivy-* キャッシュ)を省略
+          # DBは cache-dir (${{ github.workspace }}/.cache/trivy) に残り、TRIVY_CACHE_DIR は常に設定される。
+          skip-setup-trivy: true
+          cache: false
+        continue-on-error: true
+
+      # 'skipped'チェックは docker-build 成功時のみ評価する。
+      # 本ジョブの docker-build は条件付き (main PR / docker ラベル) のため、無ガードだと
+      # image scan 対象外の通常 develop PR を落としてしまう (post-trivy-scan の
+      # docker-build は無条件なので、あちらは無ガードで成立する)。
+      # docker-build 成功後に image-scan/image-gate が skip されるのは、先行ステップが
+      # conclusion=failure で終わった場合のみ (if: の暗黙 success() が false になる)。
+      # その時点でジョブは既に赤なので、本チェックは pass/fail を変えない。
+      # ゲートが未実行だった事実を明示するための診断用セーフネットである。
+      - name: Fail job if image vulnerabilities found or verification failed
         if: |
-          always() && !cancelled() && (
-          steps.image-scan.outcome == 'failure' ||
-          steps.image-scan.outcome == 'cancelled' ||
-          steps.verify-image-scan.outcome == 'failure' ||
-          steps.verify-image-scan.outcome == 'cancelled'
+          !cancelled() && (
+            steps.image-scan.outcome == 'failure' ||
+            steps.image-gate.outcome == 'failure' ||
+            steps.verify-image-scan.outcome == 'failure' ||
+            (steps.docker-build.outcome == 'success' && (
+              steps.image-scan.outcome == 'skipped' ||
+              steps.image-gate.outcome == 'skipped'
+            ))
           )
         run: |
-          # 優先度1: SARIF検証失敗（インフラ問題の可能性）
-          if [ "${{ steps.verify-image-scan.outcome }}" == "failure" ]; then
-            echo "::error::SARIF検証が失敗しました - Trivyがクラッシュした可能性があります"
-            echo "::warning::考えられる原因: DB取得失敗、タイムアウト、ディスク容量不足"
-            echo "::notice::対処法: Trivyログを確認し、インフラ問題を調査してください"
+          # 優先度1: スキャン自体が未実施
+          if [ "${{ steps.image-scan.outcome }}" == "skipped" ]; then
+            echo "::error::Trivy image scan was skipped — security gate requires the scan to run"
           fi
 
-          # 優先度2: 脆弱性検出（正常な失敗）
-          if [ "${{ steps.image-scan.outcome }}" == "failure" ]; then
-            echo "::error::脆弱性（CRITICAL/HIGH）が Docker image で検出されました"
-            echo "::notice::対処法: 脆弱性レポートを確認し、ベースイメージを更新してください"
+          # 優先度2: SARIF検証失敗
+          if [ "${{ steps.verify-image-scan.outcome }}" == "failure" ]; then
+            echo "::error::SARIF検証が失敗しました — Trivyの異常終了または不正なSARIFの可能性があります"
+            echo "::warning::考えられる原因: DB取得失敗、タイムアウト、ディスク容量不足、SARIF出力不備"
+            echo "::notice::対処法: TrivyおよびSARIF検証ステップのログを確認してください"
           fi
+
+          # 優先度3: SARIFスキャンの実行エラー
+          if [ "${{ steps.image-scan.outcome }}" == "failure" ]; then
+            echo "::error::SARIFスキャンが異常終了しました — Trivy実行エラーの可能性があります"
+          fi
+
+          # 優先度4: ゲート未実施
+          if [ "${{ steps.image-gate.outcome }}" == "skipped" ]; then
+            echo "::error::Image vulnerability gate was skipped because a prerequisite step did not complete successfully"
+          fi
+
+          # 優先度5: 脆弱性検出
+          if [ "${{ steps.image-gate.outcome }}" == "failure" ]; then
+            echo "::error::脆弱性（CRITICAL/HIGH）が Docker image で検出されました"
+            echo "::notice::対処法: 上記のTrivyテーブル出力を確認し、ベースイメージを更新してください"
+          fi
+
           exit 1
 
       # Step 4: Cleanup Docker image (resource hygiene)
@@ -802,7 +889,7 @@ jobs:
   # Triggers: push to main or develop
   # Strategy: fs scan (dependencies) + image scan (Docker image)
   #   following pr-trivy-scan pattern for consistency
-  # Format: SARIF (error differentiation + GitHub Security tab integration)
+  # Format: SARIF (all severities -> Security tab) + table (CI gate: CRITICAL/HIGH)
   # ============================================================
   post-trivy-scan:
     name: Post Trivy Scan
@@ -820,7 +907,10 @@ jobs:
           persist-credentials: false
 
       # ===== Stage 1: Filesystem Scan (dependencies) =====
-      - name: Trivy filesystem scan (dependencies)
+      # Stage 1a: Security tab 可視化用（全severity・ここではジョブを落とさない）
+      # trivy-action は format=sarif のとき TRIVY_SEVERITY を unset する（entrypoint.sh:76-83）。
+      # CIゲートは Stage 1b (format=table) に分離する。
+      - name: Trivy filesystem scan (SARIF for Security tab)
         id: fs-scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         env:
@@ -830,16 +920,15 @@ jobs:
           scan-ref: "."
           format: "sarif"
           output: "trivy-post-fs-scan.sarif"
-          exit-code: "1"
+          exit-code: "0"
           ignore-unfixed: true
-          severity: "CRITICAL,HIGH"
           trivyignores: ".trivyignore"
           cache: ${{ github.event_name != 'schedule' }}
         continue-on-error: true
 
       - name: Verify filesystem scan execution
         id: verify-fs-scan
-        if: always()
+        if: "!cancelled()"
         uses: ./.github/actions/trivy-sarif-verify
         with:
           sarif-file: "trivy-post-fs-scan.sarif"
@@ -852,28 +941,67 @@ jobs:
           sarif_file: "trivy-post-fs-scan.sarif"
           category: "trivy-post-fs-scan"
 
+      # Stage 1b: CIゲート（CRITICAL,HIGH のみ）
+      # format=table では TRIVY_SEVERITY が unset されないため severity 指定が実際に効く。
+      - name: Trivy filesystem gate (CRITICAL,HIGH)
+        id: fs-gate
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          format: "table"
+          exit-code: "1"
+          ignore-unfixed: true
+          severity: "CRITICAL,HIGH"
+          trivyignores: ".trivyignore"
+          # 同一job内での再呼び出し: 直前のSARIFスキャンが2種類のキャッシュを処理済みのため両方止める。
+          #   skip-setup-trivy → Trivyバイナリの再取得(trivy-binary-* キャッシュ)を省略
+          #   cache: false     → 脆弱性DBの actions/cache 再実行(cache-trivy-* キャッシュ)を省略
+          # DBは cache-dir (${{ github.workspace }}/.cache/trivy) に残り、TRIVY_CACHE_DIR は常に設定される。
+          skip-setup-trivy: true
+          cache: false
+        continue-on-error: true
+
       - name: Fail job if fs vulnerabilities found or verification failed
         if: |
           !cancelled() && (
             steps.fs-scan.outcome == 'failure' ||
-            steps.fs-scan.outcome == 'cancelled' ||
             steps.fs-scan.outcome == 'skipped' ||
-            steps.verify-fs-scan.outcome == 'failure' ||
-            steps.verify-fs-scan.outcome == 'cancelled'
+            steps.fs-gate.outcome == 'failure' ||
+            steps.fs-gate.outcome == 'skipped' ||
+            steps.verify-fs-scan.outcome == 'failure'
           )
         run: |
+          # 優先度1: スキャン自体が未実施
           if [ "${{ steps.fs-scan.outcome }}" == "skipped" ]; then
-            echo "::error::Trivy filesystem scan was skipped — security gate requires scan to complete"
-            exit 1
+            echo "::error::Trivy filesystem scan was skipped — security gate requires the scan to run"
           fi
+
+          # 優先度2: SARIF検証失敗
           if [ "${{ steps.verify-fs-scan.outcome }}" == "failure" ]; then
-            echo "::error::SARIF検証が失敗しました - Trivyがクラッシュした可能性があります"
-            echo "::warning::考えられる原因: DB取得失敗、タイムアウト、ディスク容量不足"
+            echo "::error::SARIF検証が失敗しました — Trivyの異常終了または不正なSARIFの可能性があります"
+            echo "::warning::考えられる原因: DB取得失敗、タイムアウト、ディスク容量不足、SARIF出力不備"
+            echo "::notice::対処法: TrivyおよびSARIF検証ステップのログを確認してください"
           fi
+
+          # 優先度3: SARIFスキャンの実行エラー（exit-code:0 のため脆弱性では失敗しない）
           if [ "${{ steps.fs-scan.outcome }}" == "failure" ]; then
-            echo "::error::脆弱性（CRITICAL/HIGH）が dependencies で検出されました"
-            echo "::notice::対処法: 脆弱性レポートを確認し、依存関係を更新してください"
+            echo "::error::SARIFスキャンが異常終了しました — Trivy実行エラーの可能性があります"
           fi
+
+          # 優先度4: ゲート未実施
+          if [ "${{ steps.fs-gate.outcome }}" == "skipped" ]; then
+            echo "::error::Filesystem vulnerability gate was skipped because a prerequisite step did not complete successfully"
+          fi
+
+          # 優先度5: 脆弱性検出
+          if [ "${{ steps.fs-gate.outcome }}" == "failure" ]; then
+            echo "::error::脆弱性（CRITICAL/HIGH）がdependenciesで検出されました"
+            echo "::notice::対処法: 上記のTrivyテーブル出力を確認し、依存関係を更新してください"
+          fi
+
           exit 1
 
       # ===== Stage 2: Docker Image Build =====
@@ -909,7 +1037,8 @@ jobs:
           exit 1
 
       # ===== Stage 3: Docker Image Scan =====
-      - name: Trivy image scan (CRITICAL + HIGH)
+      # Stage 3a: Security tab 可視化用（全severity・ここではジョブを落とさない）
+      - name: Trivy image scan (SARIF for Security tab)
         id: image-scan
         if: steps.docker-build.outcome == 'success'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
@@ -919,9 +1048,8 @@ jobs:
           image-ref: ${{ steps.image-tag.outputs.tag }}
           format: "sarif"
           output: "trivy-post-image-scan.sarif"
-          exit-code: "1"
+          exit-code: "0"
           ignore-unfixed: true
-          severity: "CRITICAL,HIGH"
           trivyignores: ".trivyignore"
           cache: ${{ github.event_name != 'schedule' }}
         continue-on-error: true
@@ -941,26 +1069,70 @@ jobs:
           sarif_file: "trivy-post-image-scan.sarif"
           category: "trivy-post-image-scan"
 
+      # Stage 3b: CIゲート（CRITICAL,HIGH のみ）
+      - name: Trivy image gate (CRITICAL,HIGH)
+        id: image-gate
+        if: steps.docker-build.outcome == 'success'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+        with:
+          image-ref: ${{ steps.image-tag.outputs.tag }}
+          format: "table"
+          exit-code: "1"
+          ignore-unfixed: true
+          severity: "CRITICAL,HIGH"
+          trivyignores: ".trivyignore"
+          # 同一job内での再呼び出し: 直前のSARIFスキャンが2種類のキャッシュを処理済みのため両方止める。
+          #   skip-setup-trivy → Trivyバイナリの再取得(trivy-binary-* キャッシュ)を省略
+          #   cache: false     → 脆弱性DBの actions/cache 再実行(cache-trivy-* キャッシュ)を省略
+          # DBは cache-dir (${{ github.workspace }}/.cache/trivy) に残り、TRIVY_CACHE_DIR は常に設定される。
+          skip-setup-trivy: true
+          cache: false
+        continue-on-error: true
+
       # 'skipped'チェックは Docker build security gate (上記) が先に exit する shielding により
-      # 通常重複だが、将来の条件分岐変更時の防御的セーフネット（pr-trivy-scan fs-scan L464と対称）
+      # 通常重複だが、将来の条件分岐変更時の防御的セーフネット。
+      # 本ジョブの docker-build は無条件 (pr-trivy-scan と異なり if: を持たない) ため、
+      # pr-trivy-scan 側のような docker-build 成功ガードは不要。
       - name: Fail job if image vulnerabilities found or verification failed
         if: |
           !cancelled() && (
             steps.image-scan.outcome == 'failure' ||
-            steps.image-scan.outcome == 'cancelled' ||
             steps.image-scan.outcome == 'skipped' ||
-            steps.verify-image-scan.outcome == 'failure' ||
-            steps.verify-image-scan.outcome == 'cancelled'
+            steps.image-gate.outcome == 'failure' ||
+            steps.image-gate.outcome == 'skipped' ||
+            steps.verify-image-scan.outcome == 'failure'
           )
         run: |
+          # 優先度1: スキャン自体が未実施
+          if [ "${{ steps.image-scan.outcome }}" == "skipped" ]; then
+            echo "::error::Trivy image scan was skipped — security gate requires the scan to run"
+          fi
+
+          # 優先度2: SARIF検証失敗
           if [ "${{ steps.verify-image-scan.outcome }}" == "failure" ]; then
-            echo "::error::SARIF検証が失敗しました - Trivyがクラッシュした可能性があります"
-            echo "::warning::考えられる原因: DB取得失敗、タイムアウト、ディスク容量不足"
+            echo "::error::SARIF検証が失敗しました — Trivyの異常終了または不正なSARIFの可能性があります"
+            echo "::warning::考えられる原因: DB取得失敗、タイムアウト、ディスク容量不足、SARIF出力不備"
+            echo "::notice::対処法: TrivyおよびSARIF検証ステップのログを確認してください"
           fi
+
+          # 優先度3: SARIFスキャンの実行エラー
           if [ "${{ steps.image-scan.outcome }}" == "failure" ]; then
-            echo "::error::脆弱性（CRITICAL/HIGH）が Docker image で検出されました"
-            echo "::notice::対処法: 脆弱性レポートを確認し、ベースイメージを更新してください"
+            echo "::error::SARIFスキャンが異常終了しました — Trivy実行エラーの可能性があります"
           fi
+
+          # 優先度4: ゲート未実施
+          if [ "${{ steps.image-gate.outcome }}" == "skipped" ]; then
+            echo "::error::Image vulnerability gate was skipped because a prerequisite step did not complete successfully"
+          fi
+
+          # 優先度5: 脆弱性検出
+          if [ "${{ steps.image-gate.outcome }}" == "failure" ]; then
+            echo "::error::脆弱性（CRITICAL/HIGH）が Docker image で検出されました"
+            echo "::notice::対処法: 上記のTrivyテーブル出力を確認し、ベースイメージを更新してください"
+          fi
+
           exit 1
 
       # ===== Cleanup =====

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,18 +1,6 @@
 # .trivyignore
-# 最終更新: 2026-03-12
+# 最終更新: 2026-07-18
 #
-# CVE-2026-0861: glibc memalign 整数オーバーフロー (HIGH)
-# 対象: libc-bin, libc6 2.41-12+deb13u1 (Debian 13 trixie)
-# 抑制理由:
-#   - Debian公式が no-dsa (Minor issue) に分類 → DSA発行予定なし
-#   - 修正版: glibc 2.43 (sid/forky のみ, Debian 13向けパッチ未提供)
-#   - 攻撃条件: memalign の size と alignment 両方を攻撃者制御 +
-#              size が PTRDIFF_MAX 付近 → 本プロジェクト（APIテストクライアント）
-#              では該当する攻撃経路なし
-#   - 参考: https://security-tracker.debian.org/tracker/CVE-2026-0861
-#   - 確認日: 2026-03-12（Five Whys 根本原因分析 + ローカル Trivy スキャン検証）
-#   - 再評価: Debian 13向けパッチリリース時に本エントリを削除する。
-#     ただし本エントリで抑制中はCIのTrivyスキャンに現れないため、自動検出はされない。
-#     上記 security-tracker で手動確認するか、Dependabotのdocker digest更新PR
-#     （.github/dependabot.yml, weekly）時に併せて再評価すること。
-CVE-2026-0861
+# アクティブな抑制エントリなし。
+# CVE-2026-0861 (glibc memalign HIGH) は base image が修正版 glibc 2.41-12+deb13u3 を
+# 取り込んだため削除 (2026-07-18)。参考: https://security-tracker.debian.org/tracker/CVE-2026-0861

--- a/.trivyignore
+++ b/.trivyignore
@@ -11,5 +11,8 @@
 #              では該当する攻撃経路なし
 #   - 参考: https://security-tracker.debian.org/tracker/CVE-2026-0861
 #   - 確認日: 2026-03-12（Five Whys 根本原因分析 + ローカル Trivy スキャン検証）
-#   - 再評価: Debian 13向けパッチリリース時に削除（週次Trivyスキャンで自動検出可能）
+#   - 再評価: Debian 13向けパッチリリース時に本エントリを削除する。
+#     ただし本エントリで抑制中はCIのTrivyスキャンに現れないため、自動検出はされない。
+#     上記 security-tracker で手動確認するか、Dependabotのdocker digest更新PR
+#     （.github/dependabot.yml, weekly）時に併せて再評価すること。
 CVE-2026-0861


### PR DESCRIPTION
## 概要
Trivyスキャンを **SARIF可視化（全severity）** と **CIゲート（CRITICAL/HIGHのみ）** の二段構成に分離

## 変更内容
- `.github/workflows/ci.yml`: `pr-trivy-scan` と `post-trivy-scan` の両ジョブで二段階スキャンを導入
  - Stage 1a/3a: SARIF形式で全severityをSecurity tabに記録（exit-code:0, severity指定なし）
  - Stage 1b/3b: table形式でCRITICAL/HIGHのみをCIゲートとして判定（exit-code:1, severity:CRITICAL,HIGH）
  - trivy-actionの仕様（format=sarif時はTRIVY_SEVERITYをunsetする）への対応をアーキテクチャコメントでドキュメント化
- `.trivyignore`: 再評価方針を明文化（Dependabot docker digest更新PR時の併用確認）

## テスト
- [x] ローカルテスト完了（1420 passed / 97.51% coverage）
- [x] CI/CD パイプライン確認
- [x] ruff 0 errors / mypy 0 errors

## 関連Issue/PR
なし（独立したセキュリティ改善）

---
このPRは push-pr スキルで自動生成されました。

<!-- resolve-review:954860e -->
## Review Response (2026-07-18)

| 分類 | 件数 | 対応 |
|------|------|------|
| NEEDS-DECISION (対応不要) | 1件 | pushback返信済み (ci.yml gate fail-closed設計を説明) |
| NEEDS-DECISION (削除) | 1件 | 修正済み (.trivyignore CVE-2026-0861抑制を削除) |

コミット: `954860e`
<!-- /resolve-review:954860e -->
