### PR TITLE
refactor(test): sync基盤テストのdocstring整理 (U6)

### DIFF
--- a/scripts/fixture_docstring_todo.txt
+++ b/scripts/fixture_docstring_todo.txt
@@ -1,1 +1,0 @@
-tests/unit/test_jsonplaceholder_base_sync.py::mock_settings

--- a/tests/unit/test_jsonplaceholder_base_async.py
+++ b/tests/unit/test_jsonplaceholder_base_async.py
@@ -1,4 +1,8 @@
-"""Async base client tests for utils.jsonplaceholder_base_async."""
+"""JSONPlaceholder_base_async モジュールの非同期通信基盤テスト
+
+Note:
+ - Create/Update/Delete は永続化されない。POST は常に ``id=101`` を返す。
+"""
 
 import asyncio
 from unittest.mock import AsyncMock, Mock, patch
@@ -24,20 +28,7 @@ pytestmark = pytest.mark.unit
 @respx.mock
 @patch("utils.jsonplaceholder_base_async.exponential_backoff_with_jitter", return_value=0.0)
 async def test_async_timeout_retry_then_success(mock_backoff: Mock) -> None:
-    """
-    タイムアウトエラー後のリトライで最終的に成功するテスト
-
-    検証項目：
-    - タイムアウトエラー発生時にリトライが行われること（2回連続タイムアウト）
-    - リトライ回数が設定値（retry_count=3）に基づくこと
-      （初回+最大3回リトライ=最大4回実行、本テストは3回目で成功）
-    - リトライ後に成功した場合のレスポンスが正しく返却されること
-
-    Note: test_async_client_error_handling.py の test_async_timeout_then_success（1回タイムアウト）
-          と対をなすテスト。こちらは「2回連続タイムアウト → 3回目で成功」を検証する。
-          @patch(exponential_backoff_with_jitter)でリトライ待機を0秒化しCI時間短縮。
-          respxトランスポートモックにより実際のhttpxコードパスを通じて検証する。
-    """
+    """2回連続タイムアウト後に3回目で成功するリトライ境界を固定する。"""
     # respxルート: 最初の2回はタイムアウト、3回目で成功
     # retry_count=3 の場合: 初回(1) + 最大リトライ(3) = 最大4リクエスト。
     # 本テストは3回目で成功するためリスト要素は3個（TimeoutException 2個 + Response 1個）。
@@ -67,19 +58,7 @@ async def test_async_timeout_retry_then_success(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_async.exponential_backoff_with_jitter", return_value=0.0)
 async def test_async_performance_and_timeout(mock_backoff: Mock) -> None:
-    """
-    非同期処理のパフォーマンス・タイムアウト・リソース管理テスト
-
-    検証項目：
-    - リクエストタイムアウト時のリトライ動作
-    - 全リトライ失敗後のAPIRetryError発生
-    - リトライ回数がretry_countに基づくこと（route.call_countで決定論的に検証）
-
-    Note: タイムアウト時、実装はリトライ後にAPIRetryErrorを発生させる。
-          TimeoutExceptionは内部でキャッチされる。
-          @patch(exponential_backoff_with_jitter)でリトライ待機を0秒化しCI時間短縮。
-          respxトランスポートモックにより実際のhttpxコードパスを通じて検証する。
-    """
+    """全リトライ失敗時にAPIRetryErrorへ集約される境界を固定する。"""
     retry_count = 1  # retry_count=1: 初回 + 1回リトライ = 2回のリクエスト
 
     # respxルート: 全リクエストでタイムアウト（retry_count+1 回）
@@ -100,14 +79,7 @@ async def test_async_performance_and_timeout(mock_backoff: Mock) -> None:
 
 
 async def test_async_context_manager_cleanup_on_success():
-    """
-    正常終了時のコンテキストマネージャーリソースクリーンアップテスト
-
-    検証項目：
-    - async with ブロック正常終了時に aclose() が呼び出されること
-
-    Note: aclose()呼び出し検証はhttpxクライアントの内部動作に依存するためpatchを使用。
-    """
+    """httpx.AsyncClient の aclose() 呼出しは内部動作に依存するため patch で検証する。"""
     with patch("httpx.AsyncClient") as mock_client_class:
         mock_client_instance = AsyncMock()
         mock_client_class.return_value = mock_client_instance
@@ -120,17 +92,7 @@ async def test_async_context_manager_cleanup_on_success():
 
 
 async def test_async_context_manager_cleanup_on_exception():
-    """
-    例外発生時でもコンテキストマネージャーがクリーンアップするテスト
-
-    検証項目：
-    - 例外発生時でも aclose() が呼び出されること（リソースリークなし）
-
-    Note: aclose()呼び出し検証はhttpxクライアントの内部動作に依存するためpatchを使用。
-          RuntimeError は httpx.RequestError のサブクラスではないため、リトライを通らず
-          そのまま伝播する。基底クラス Exception より具体的な型を使用することで
-          テストバグの誤検知を防ぐ。
-    """
+    """RuntimeError は httpx.RequestError ではなく、リトライ対象外の例外でも close を保証する。"""
     with patch("httpx.AsyncClient") as mock_client_class:
         mock_client_instance = AsyncMock()
         mock_client_class.return_value = mock_client_instance
@@ -159,7 +121,7 @@ async def test_async_api_client_aexit_aclose_exception_is_suppressed_with_warnin
     expected_type: str,
     expected_module: str,
 ) -> None:
-    """__aexit__ で aclose() が例外を投げても警告ログのみ出力する"""
+    """通常の close 例外は warning のみで抑止し、例外種別をログに残す。"""
     client = AsyncAPIClient()
 
     with (
@@ -313,7 +275,7 @@ async def test_aclose_exception_is_suppressed_with_warning(
     expected_type: str,
     expected_module: str,
 ) -> None:
-    """aclose() 単独呼び出しでも close 例外は warning のみで抑止する。"""
+    """単独 close の既知例外は warning のみで抑止し、予期しない例外と分類を分ける。"""
     client = AsyncAPIClient()
 
     with (
@@ -333,7 +295,6 @@ async def test_aclose_exception_is_suppressed_with_warning(
 
 
 async def test_aclose_normal_close_logs_info() -> None:
-    """aclose() 単独呼び出し時に async_api_client_closed の info ログが1回出力される。"""
     client = AsyncAPIClient()
 
     with (
@@ -473,15 +434,6 @@ async def test_async_performance_benchmark():
 
 @respx.mock
 async def test_http_put_method():
-    """
-    AsyncAPIClient.put()メソッドの基本動作検証
-
-    検証項目：
-    - PUTリクエストが正しく送信される
-    - JSONデータが正確に送信される
-    - レスポンスが正常に返却される
-    - HTTPメソッドが"PUT"である
-    """
     endpoint = "/posts/1"
     update_data = {"id": 1, "title": "Updated Title", "body": "Updated Content", "userId": 1}
 
@@ -501,14 +453,6 @@ async def test_http_put_method():
 
 @respx.mock
 async def test_http_delete_method():
-    """
-    AsyncAPIClient.delete()メソッドの基本動作検証
-
-    検証項目：
-    - DELETEリクエストが正しく送信される
-    - 204 No Content または 200 OK が返却される
-    - エンドポイントが正確に構築される
-    """
     endpoint = "/posts/1"
 
     # DELETEレスポンスをモック化（204 No Content）
@@ -524,15 +468,6 @@ async def test_http_delete_method():
 
 @respx.mock
 async def test_http_patch_method():
-    """
-    AsyncAPIClient.patch()メソッドの基本動作検証
-
-    検証項目：
-    - PATCHリクエストが正しく送信される
-    - 部分更新データが正確に送信される
-    - レスポンスが正常に返却される
-    - HTTPメソッドが"PATCH"である
-    """
     endpoint = "/posts/1"
     partial_data = {"title": "Partially Updated Title"}
     full_response = {
@@ -558,14 +493,6 @@ async def test_http_patch_method():
 
 @respx.mock
 async def test_http_put_with_error():
-    """
-    AsyncAPIClient.put()の404エラーケーステスト
-
-    検証項目：
-    - 存在しないリソースへのPUTで404エラー
-    - APIHTTPErrorが正しく発生する
-    - エラーステータスコードが404である
-    """
     endpoint = "/posts/999999"
     update_data = {"title": "Non-existent Post"}
 
@@ -649,7 +576,7 @@ async def test_async_client_falsy_values_not_overridden() -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_async.exponential_backoff_with_jitter", return_value=0.0)
 async def test_async_retry_on_server_error_then_success(mock_backoff: Mock) -> None:
-    """サーバーエラー後に成功するケース（5xxはリトライ対象）"""
+    """5xx はリトライ対象とし、成功したレスポンスで終了する境界を固定する。"""
     route = respx.get(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.Response(500),  # 初回: 失敗
@@ -671,7 +598,7 @@ async def test_async_retry_on_server_error_then_success(mock_backoff: Mock) -> N
 @respx.mock
 @patch("utils.jsonplaceholder_base_async.exponential_backoff_with_jitter", return_value=0.0)
 async def test_async_retry_exhausted(mock_backoff: Mock) -> None:
-    """リトライ上限でAPIRetryErrorが発生することを確認（5xxのみリトライ）"""
+    """5xx のリトライ上限到達時に APIRetryError へ集約する境界を固定する。"""
     retry_count = 2
     route = respx.get(f"{BASE_URL}/posts/1")
     route.side_effect = [httpx.Response(500)] * (retry_count + 1)  # 初回 + リトライ数
@@ -690,7 +617,7 @@ async def test_async_retry_exhausted(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_async.exponential_backoff_with_jitter", return_value=0.0)
 async def test_async_4xx_error_no_retry(mock_backoff: Mock) -> None:
-    """4xxクライアントエラーはリトライせず即座にAPIHTTPErrorを発生"""
+    """4xx はリトライせず即時に APIHTTPError とする境界を固定する。"""
     route = respx.get(f"{BASE_URL}/posts/999")
     route.side_effect = [
         httpx.Response(404),
@@ -710,7 +637,6 @@ async def test_async_4xx_error_no_retry(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_async.exponential_backoff_with_jitter", return_value=0.0)
 async def test_async_timeout_error_retry(mock_backoff: Mock) -> None:
-    """タイムアウト時にAPIRetryErrorが発生することを確認"""
     route = respx.get(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.TimeoutException("Request timed out"),
@@ -731,7 +657,6 @@ async def test_async_timeout_error_retry(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_async.exponential_backoff_with_jitter", return_value=0.0)
 async def test_async_timeout_then_success(mock_backoff: Mock) -> None:
-    """タイムアウト後に成功するケース"""
     route = respx.get(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.TimeoutException("Timeout 1"),
@@ -750,7 +675,6 @@ async def test_async_timeout_then_success(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_async.exponential_backoff_with_jitter", return_value=0.0)
 async def test_async_connection_error_retry(mock_backoff: Mock) -> None:
-    """接続エラー時にAPIRetryErrorが発生することを確認"""
     route = respx.get(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.ConnectError("Connection refused"),
@@ -770,7 +694,6 @@ async def test_async_connection_error_retry(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_async.exponential_backoff_with_jitter", return_value=0.0)
 async def test_async_connection_then_success(mock_backoff: Mock) -> None:
-    """接続エラー後に成功するケース"""
     route = respx.get(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.ConnectError("Connection 1"),
@@ -790,7 +713,6 @@ async def test_async_connection_then_success(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_async.exponential_backoff_with_jitter", return_value=0.0)
 async def test_async_mixed_errors_then_success(mock_backoff: Mock) -> None:
-    """タイムアウト→サーバーエラー→成功のシナリオ"""
     route = respx.get(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.TimeoutException("Timeout"),
@@ -810,7 +732,6 @@ async def test_async_mixed_errors_then_success(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_async.exponential_backoff_with_jitter", return_value=0.0)
 async def test_async_mixed_errors_exhaust_retries(mock_backoff: Mock) -> None:
-    """複数のエラータイプでリトライ上限に達するケース"""
     route = respx.get(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.TimeoutException("Timeout"),
@@ -832,7 +753,7 @@ async def test_async_mixed_errors_exhaust_retries(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_async.exponential_backoff_with_jitter", return_value=0.0)
 async def test_async_post_with_retry(mock_backoff: Mock) -> None:
-    """POSTリクエストのリトライ動作確認（5xxはリトライ対象）"""
+    """POSTの5xxはリトライ対象とする外部APIクライアントの境界を固定する。"""
     route = respx.post(f"{BASE_URL}/posts")
     route.side_effect = [
         httpx.Response(502),
@@ -854,7 +775,7 @@ async def test_async_post_with_retry(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_async.exponential_backoff_with_jitter", return_value=0.0)
 async def test_async_put_4xx_no_retry(mock_backoff: Mock) -> None:
-    """PUTリクエストで4xxエラーはリトライせず即座にAPIHTTPErrorを発生"""
+    """PUT の 4xx はリトライせず即時に APIHTTPError とする境界を固定する。"""
     route = respx.put(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.Response(400),
@@ -874,7 +795,6 @@ async def test_async_put_4xx_no_retry(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_async.exponential_backoff_with_jitter", return_value=0.0)
 async def test_async_delete_with_retry(mock_backoff: Mock) -> None:
-    """DELETEリクエストのリトライ動作確認"""
     route = respx.delete(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.TimeoutException("Timeout"),

--- a/tests/unit/test_jsonplaceholder_base_sync.py
+++ b/tests/unit/test_jsonplaceholder_base_sync.py
@@ -1,4 +1,8 @@
-"""Sync base client tests for utils.jsonplaceholder_base_sync."""
+"""JSONPlaceholder_base_sync モジュールの同期通信基盤テスト
+
+Note:
+ - Create/Update/Delete は永続化されない。POST は常に ``id=101`` を返す。
+"""
 
 import logging
 import sys
@@ -44,6 +48,7 @@ mock_settings_instance = MockSettings()
 
 @pytest.fixture(autouse=True)
 def mock_settings():
+    """import済みsettingsを参照先でpatchし、実settingsへの漏れと設定リークを防ぐ。"""
     # NOTE: 各クライアントモジュールは `from config.settings import settings` により
     # 自前の `settings` バインディングを import 時に確定する。そのため
     # `config.settings.settings` を patch しても、それらのバインディングには届かず
@@ -57,7 +62,6 @@ def mock_settings():
 
 
 def test_base_client_initialization():
-    """クライアント初期化テスト"""
     client = SyncAPIClient(base_url="https://test.com", timeout=10.0, retry_count=1)
     assert client.base_url == "https://test.com"
     assert client.timeout == 10.0
@@ -66,14 +70,12 @@ def test_base_client_initialization():
 
 
 def test_context_manager_basic():
-    """Context Manager基本動作テスト"""
     with SyncAPIClient(base_url="https://test.com") as client:
         assert client._client is not None
         assert isinstance(client._client, httpx.Client)
 
 
 def test_base_client_uses_default_settings_if_not_provided():
-    """引数がない場合にデフォルト設定が使用されることを確認"""
     client = SyncAPIClient()  # Uses mock_settings_instance
     assert client.base_url == BASE_URL
     assert client.timeout == 30.0
@@ -81,7 +83,7 @@ def test_base_client_uses_default_settings_if_not_provided():
 
 
 def test_mock_settings_fixture_is_effective():
-    """mock_settings fixture が実際に有効であることを保証する回帰テスト。
+    """mock_settings fixture が実際に有効であることを保証する回帰テスト
 
     retry_delay は mock 値 0.1 と実 .env 既定値 1.0 が異なるため、パッチ標的が
     誤っている（import 済みバインディングに届かない）場合は実値 1.0 が返り、この
@@ -92,7 +94,6 @@ def test_mock_settings_fixture_is_effective():
 
 
 def test_base_client_headers_are_set_correctly():
-    """ヘッダーが正しく設定されることを確認"""
     custom_headers = {"X-Custom-Header": "Value"}
     client = SyncAPIClient(base_url="https://test.com", headers=custom_headers)
     assert client.default_headers["X-Custom-Header"] == "Value"
@@ -100,7 +101,6 @@ def test_base_client_headers_are_set_correctly():
 
 
 def test_base_client_close_method():
-    """closeメソッドがクライアントを閉じることを確認"""
     client = SyncAPIClient(base_url="https://test.com")
     client.__enter__()  # Manually enter context to ensure _client is initialized
     assert client._client is not None
@@ -129,7 +129,6 @@ def test_sync_close_sets_client_none_even_when_close_raises() -> None:
 
 @respx.mock
 def test_sync_get_user() -> None:
-    """GETリクエスト検証"""
     route = respx.get(f"{BASE_URL}/users/1").respond(json={"id": 1, "name": "Test User"})
 
     with SyncAPIClient() as client:
@@ -142,7 +141,6 @@ def test_sync_get_user() -> None:
 
 @respx.mock
 def test_sync_post_create_user() -> None:
-    """POSTリクエスト検証"""
     route = respx.post(f"{BASE_URL}/users").respond(
         status_code=201,
         json={"id": 101, "name": "New User", "email": "new@example.com"},
@@ -158,7 +156,6 @@ def test_sync_post_create_user() -> None:
 
 @respx.mock
 def test_sync_put_update_user() -> None:
-    """PUTリクエスト検証"""
     route = respx.put(f"{BASE_URL}/users/1").respond(json={"id": 1, "name": "Updated"})
 
     with SyncAPIClient() as client:
@@ -171,7 +168,6 @@ def test_sync_put_update_user() -> None:
 
 @respx.mock
 def test_sync_delete_user() -> None:
-    """DELETEリクエスト検証（httpx.Response返却を検証）"""
     route = respx.delete(f"{BASE_URL}/users/1").respond(status_code=204, content=b"")
 
     with SyncAPIClient() as client:
@@ -182,13 +178,7 @@ def test_sync_delete_user() -> None:
 
 
 def test_sync_context_manager_cleanup() -> None:
-    """with文コンテキストマネージャーのクリーンアップ検証
-
-    Note:
-        SyncAPIClient.__exit__でself._client.close()が呼ばれることを検証。
-        patch.objectでhttpx.Clientのcloseメソッドをスパイし、
-        コンテキストマネージャー終了時に呼ばれることを確認する。
-    """
+    """httpx.Client.close() の呼出しを with 終了時に固定するため patch で検証する。"""
     client_instance = SyncAPIClient()
     with patch.object(client_instance._client, "close") as mock_close:
         with client_instance:
@@ -201,7 +191,6 @@ def test_sync_context_manager_cleanup() -> None:
 
 @respx.mock
 def test_sync_empty_response_handling() -> None:
-    """空レスポンス（{}）の安全処理検証"""
     route = respx.get(f"{BASE_URL}/empty").respond(json={})
 
     with SyncAPIClient() as client:
@@ -213,7 +202,6 @@ def test_sync_empty_response_handling() -> None:
 
 @respx.mock
 def test_sync_malformed_json_handling() -> None:
-    """不正JSON時の例外処理検証"""
     route = respx.get(f"{BASE_URL}/malformed").respond(
         content=b"invalid json",
         headers={"content-type": "application/json"},
@@ -230,7 +218,6 @@ def test_sync_malformed_json_handling() -> None:
 @pytest.mark.parametrize("user_id", [0, -1, sys.maxsize], ids=["zero", "negative", "max_int"])
 @respx.mock
 def test_sync_boundary_user_id(user_id: int) -> None:
-    """境界値テスト: user_id=0, -1, MAX_INT（parametrize化）"""
     route = respx.get(f"{BASE_URL}/users/{user_id}").respond(json={"id": user_id})
 
     with SyncAPIClient() as client:
@@ -340,7 +327,6 @@ def test_sync_4xx_error_no_retry() -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_sync.exponential_backoff_with_jitter", return_value=0.0)
 def test_sync_timeout_error_retry(mock_backoff: Mock) -> None:
-    """タイムアウト時にAPIRetryErrorが発生することを確認"""
     route = respx.get(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.TimeoutException("Request timed out"),
@@ -360,7 +346,6 @@ def test_sync_timeout_error_retry(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_sync.exponential_backoff_with_jitter", return_value=0.0)
 def test_sync_connection_error_retry(mock_backoff: Mock) -> None:
-    """接続エラー時にAPIRetryErrorが発生することを確認"""
     route = respx.get(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.ConnectError("Connection refused"),
@@ -401,7 +386,6 @@ def test_sync_retry_exhausted(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_sync.exponential_backoff_with_jitter", return_value=0.0)
 def test_sync_timeout_then_success(mock_backoff: Mock) -> None:
-    """タイムアウト後に成功するケース"""
     route = respx.get(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.TimeoutException("Timeout 1"),
@@ -420,7 +404,6 @@ def test_sync_timeout_then_success(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_sync.exponential_backoff_with_jitter", return_value=0.0)
 def test_sync_connection_then_success(mock_backoff: Mock) -> None:
-    """接続エラー後に成功するケース"""
     route = respx.get(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.ConnectError("Connection 1"),
@@ -440,7 +423,6 @@ def test_sync_connection_then_success(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_sync.exponential_backoff_with_jitter", return_value=0.0)
 def test_sync_mixed_errors_then_success(mock_backoff: Mock) -> None:
-    """タイムアウト→サーバーエラー→成功のシナリオ"""
     route = respx.get(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.TimeoutException("Timeout"),
@@ -460,7 +442,6 @@ def test_sync_mixed_errors_then_success(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_sync.exponential_backoff_with_jitter", return_value=0.0)
 def test_sync_mixed_errors_exhaust_retries(mock_backoff: Mock) -> None:
-    """複数のエラータイプでリトライ上限に達するケース"""
     route = respx.get(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.TimeoutException("Timeout"),
@@ -502,7 +483,6 @@ def test_sync_put_4xx_no_retry(mock_backoff: Mock) -> None:
 @respx.mock
 @patch("utils.jsonplaceholder_base_sync.exponential_backoff_with_jitter", return_value=0.0)
 def test_sync_delete_with_retry(mock_backoff: Mock) -> None:
-    """DELETEリクエストのリトライ動作確認"""
     route = respx.delete(f"{BASE_URL}/posts/1")
     route.side_effect = [
         httpx.TimeoutException("Timeout"),

--- a/tests/unit/test_jsonplaceholder_client_sync.py
+++ b/tests/unit/test_jsonplaceholder_client_sync.py
@@ -1,4 +1,9 @@
-"""Sync JSONPlaceholder client tests for utils.jsonplaceholder_client_sync."""
+"""utils.jsonplaceholder_client_sync モジュールの同期APIクライアントテスト
+
+
+Note:
+ - Create/Update/Delete は永続化されない。POST は常に ``id=101`` を返す。
+"""
 
 import json
 from unittest.mock import patch
@@ -16,14 +21,6 @@ pytestmark = pytest.mark.unit
 
 @respx.mock
 def test_sync_health_check_success() -> None:
-    """
-    API ヘルスチェック正常系テスト（同期版）
-
-    検証項目：
-    - health_check()メソッドの正常動作
-    - 正常時: True返却
-
-    """
     route = respx.get(f"{BASE_URL}/users", params={"_limit": 1}).respond(
         json=[{"id": 1, "name": "User 1"}]
     )
@@ -37,13 +34,6 @@ def test_sync_health_check_success() -> None:
 
 @respx.mock
 def test_sync_health_check_connection_error() -> None:
-    """
-    API ヘルスチェック接続エラー時のテスト（同期版）
-
-    検証項目：
-    - 接続エラー時: False返却（graceful degradation）
-    - httpx.ConnectError → APIConnectionErrorに変換 → health_checkでキャッチ
-    """
     route = respx.get(f"{BASE_URL}/users", params={"_limit": 1}).mock(
         side_effect=httpx.ConnectError("Connection refused")
     )
@@ -57,7 +47,6 @@ def test_sync_health_check_connection_error() -> None:
 
 @respx.mock
 def test_sync_health_check_log_structure() -> None:
-    """health_check失敗時のログ構造検証（error_type/endpointフィールド）"""
     respx.get(f"{BASE_URL}/users", params={"_limit": 1}).mock(
         side_effect=httpx.ConnectError("Connection refused to secret-host.internal")
     )
@@ -96,14 +85,6 @@ def test_sync_health_check_log_structure() -> None:
 )
 @respx.mock
 def test_sync_get_posts(limit: int | None, expected_count: int) -> None:
-    """
-    SyncJSONPlaceholderClient.get_posts()のlimitパラメータ検証
-
-    検証項目：
-    - limit指定時に正しくパラメータが送信される
-    - limit=Noneで全件取得
-    - limit=0で0件取得（API仕様では空配列返却、境界値検証）
-    """
     all_posts = [
         {"id": i, "userId": 1, "title": f"Post {i}", "body": f"Content {i}"} for i in range(1, 6)
     ]
@@ -141,14 +122,6 @@ def test_sync_get_posts(limit: int | None, expected_count: int) -> None:
 )
 @respx.mock
 def test_sync_get_posts_user_filter(user_id: int | None, expected_count: int) -> None:
-    """
-    SyncJSONPlaceholderClient.get_posts()のuser_idパラメータ検証
-
-    検証項目：
-    - user_id=None: フィルタなしで全投稿取得
-    - user_id=1/2: 指定ユーザーの投稿のみ取得（API側フィルタ）
-    - user_id=999: 存在しないユーザーで空配列返却
-    """
     all_posts = [
         {"id": 1, "userId": 1, "title": "Post 1", "body": "Content 1"},
         {"id": 2, "userId": 2, "title": "Post 2", "body": "Content 2"},
@@ -199,13 +172,6 @@ def test_sync_get_posts_user_filter(user_id: int | None, expected_count: int) ->
 def test_sync_get_posts_validation_error(
     limit: int | None, user_id: int | None, expected_error: str
 ) -> None:
-    """
-    SyncJSONPlaceholderClient.get_posts()の入力値バリデーション検証
-
-    検証項目：
-    - limit < 0: ValueError発生
-    - user_id < 1: ValueError発生（JSONPlaceholder APIはID=1から）
-    """
     with SyncJSONPlaceholderClient() as client:
         with pytest.raises(ValueError, match=expected_error):
             client.get_posts(limit=limit, user_id=user_id)
@@ -213,13 +179,6 @@ def test_sync_get_posts_validation_error(
 
 @respx.mock
 def test_sync_get_post_success() -> None:
-    """
-    SyncJSONPlaceholderClient.get_post()の正常系テスト
-
-    検証項目：
-    - post_id指定で特定投稿を取得
-    - レスポンスデータが正確に返却される
-    """
     post_id = 1
     expected_post = {"id": 1, "userId": 1, "title": "Test Post", "body": "Test Content"}
 
@@ -235,14 +194,6 @@ def test_sync_get_post_success() -> None:
 
 @respx.mock
 def test_sync_create_post() -> None:
-    """
-    SyncJSONPlaceholderClient.create_post()の正常系テスト
-
-    検証項目：
-    - title/body/user_id指定で投稿作成
-    - リクエストボディの正確性（title, body, userId）
-    - レスポンスにidが付与される（サーバー生成）
-    """
     title = "New Post"
     body = "This is a new post content"
     user_id = 1
@@ -290,14 +241,6 @@ def test_sync_get_todos(
     limit: int | None,
     expected_count: int,
 ) -> None:
-    """
-    SyncJSONPlaceholderClient.get_todos()の複数パラメータ組み合わせ検証
-
-    検証項目：
-    - user_id/completed/limitの全組み合わせ動作確認
-    - クエリパラメータが正確に構築される
-    - Noneパラメータは送信されない
-    """
     all_todos = [
         {"id": 1, "userId": 1, "title": "Todo 1", "completed": True},
         {"id": 2, "userId": 1, "title": "Todo 2", "completed": False},
@@ -359,13 +302,6 @@ def test_sync_get_todos(
 def test_sync_get_todos_validation_error(
     limit: int | None, user_id: int | None, expected_error: str
 ) -> None:
-    """
-    SyncJSONPlaceholderClient.get_todos()の入力値バリデーション検証
-
-    検証項目：
-    - limit < 0: ValueError発生
-    - user_id < 1: ValueError発生（JSONPlaceholder APIはID=1から）
-    """
     with SyncJSONPlaceholderClient() as client:
         with pytest.raises(ValueError, match=expected_error):
             client.get_todos(limit=limit, user_id=user_id)
@@ -378,14 +314,6 @@ def test_sync_get_todos_validation_error(
 )
 @respx.mock
 def test_sync_get_albums(user_id: int | None, expected_count: int) -> None:
-    """
-    SyncJSONPlaceholderClient.get_albums()のuser_idパラメータ検証
-
-    検証項目：
-    - user_id指定時に正しくパラメータが送信される
-    - user_id=Noneで全件取得
-    - フィルタ結果が期待通りの件数である
-    """
     # モックデータ（5件のアルバム、複数ユーザー）
     all_albums = [
         {"id": 1, "userId": 1, "title": "Album 1"},
@@ -422,12 +350,6 @@ def test_sync_get_albums(user_id: int | None, expected_count: int) -> None:
     ids=["zero_user_id", "negative_user_id"],
 )
 def test_sync_get_albums_validation_error(user_id: int, expected_error: str) -> None:
-    """
-    SyncJSONPlaceholderClient.get_albums()の入力値バリデーション検証
-
-    検証項目：
-    - user_id < 1: ValueError発生（JSONPlaceholder APIはID=1から）
-    """
     with SyncJSONPlaceholderClient() as client:
         with pytest.raises(ValueError, match=expected_error):
             client.get_albums(user_id=user_id)
@@ -440,14 +362,6 @@ def test_sync_get_albums_validation_error(user_id: int, expected_error: str) -> 
 )
 @respx.mock
 def test_sync_get_photos(album_id: int | None, expected_count: int) -> None:
-    """
-    SyncJSONPlaceholderClient.get_photos()のalbum_idパラメータ検証
-
-    検証項目：
-    - album_id指定時に正しくエンドポイントが構築される（/albums/{album_id}/photos）
-    - album_id=Noneで全件取得（/photos）
-    - フィルタ結果が期待通りの件数である
-    """
     # モックデータ（6件の写真、複数アルバム）
     all_photos = [
         {
@@ -512,14 +426,6 @@ def test_sync_get_photos(album_id: int | None, expected_count: int) -> None:
 
 @respx.mock
 def test_sync_get_comments_with_post_id() -> None:
-    """
-    SyncJSONPlaceholderClient.get_comments()のpost_id指定時の正常系
-
-    検証項目：
-    - post_id=1 指定時に /posts/1/comments にGETリクエストが送られる
-    - レスポンスのコメントリストがそのまま返される
-    - リクエストが1回だけ発行される
-    """
     mock_comments = [
         {"id": 1, "postId": 1, "name": "Test Comment", "email": "test@example.com", "body": "Body"},
     ]
@@ -534,14 +440,6 @@ def test_sync_get_comments_with_post_id() -> None:
 
 @respx.mock
 def test_sync_get_comments_without_post_id() -> None:
-    """
-    SyncJSONPlaceholderClient.get_comments()のpost_id未指定時の正常系
-
-    検証項目：
-    - post_id未指定時に /comments にGETリクエストが送られる
-    - 全コメントのリストがそのまま返される
-    - リクエストが1回だけ発行される
-    """
     mock_comments = [
         {"id": 1, "postId": 1, "name": "Comment 1", "email": "a@b.com", "body": "Body 1"},
         {"id": 2, "postId": 2, "name": "Comment 2", "email": "c@d.com", "body": "Body 2"},
@@ -561,14 +459,6 @@ def test_sync_get_comments_without_post_id() -> None:
     ids=["post_id_zero", "post_id_negative", "post_id_large_negative"],
 )
 def test_sync_get_comments_invalid_post_id(post_id: int) -> None:
-    """
-    SyncJSONPlaceholderClient.get_comments()の無効post_idバリデーション
-
-    検証項目：
-    - post_id=0 は ValueError を発生させる（JSONPlaceholder API は1-based ID）
-    - 負数のpost_idも同様に ValueError を発生させる
-    - HTTP リクエストは発行されない
-    """
     with SyncJSONPlaceholderClient() as client:
         with pytest.raises(ValueError, match="post_id must be >= 1"):
             client.get_comments(post_id=post_id)
@@ -580,14 +470,6 @@ def test_sync_get_comments_invalid_post_id(post_id: int) -> None:
     ids=["album_id_zero", "album_id_negative", "album_id_large_negative"],
 )
 def test_sync_get_photos_invalid_album_id(album_id: int) -> None:
-    """
-    SyncJSONPlaceholderClient.get_photos()の無効album_idバリデーション
-
-    検証項目：
-    - album_id=0 は ValueError を発生させる（JSONPlaceholder API は1-based ID）
-    - 負数のalbum_idも同様に ValueError を発生させる
-    - HTTP リクエストは発行されない
-    """
     with SyncJSONPlaceholderClient() as client:
         with pytest.raises(ValueError, match="album_id must be >= 1"):
             client.get_photos(album_id=album_id)
@@ -595,13 +477,6 @@ def test_sync_get_photos_invalid_album_id(album_id: int) -> None:
 
 @respx.mock
 def test_sync_patch_method() -> None:
-    """SyncAPIClient.patch() HTTP PATCHメソッドの動作確認
-
-    検証項目:
-    - PATCHリクエストが正しく送信される
-    - HTTPメソッドが "PATCH" である
-    - リクエストボディが正確に送信される
-    """
     endpoint = "/todos/1"
     patch_data = {"completed": True}
     full_response = {"id": 1, "title": "Test Todo", "completed": True, "userId": 1}
@@ -627,13 +502,6 @@ def test_sync_patch_method() -> None:
 
 @respx.mock
 def test_sync_get_users() -> None:
-    """SyncJSONPlaceholderClient.get_users() ユーザー一覧取得の動作確認
-
-    検証項目:
-    - GET /users リクエストが送信される
-    - ユーザーリストが正しく返される
-    - call_count で1回のリクエストを確認
-    """
     mock_users = [
         make_mock_user(
             1,
@@ -670,12 +538,6 @@ def test_sync_get_users() -> None:
 
 @respx.mock
 def test_sync_get_todo() -> None:
-    """SyncJSONPlaceholderClient.get_todo() 特定TODO取得の動作確認
-
-    検証項目:
-    - GET /todos/{id} リクエストが送信される
-    - 正しいTODOデータが返される
-    """
     mock_todo = {"id": 1, "userId": 1, "title": "delectus aut autem", "completed": False}
 
     route = respx.get(f"{BASE_URL}/todos/1").respond(json=mock_todo)
@@ -691,13 +553,6 @@ def test_sync_get_todo() -> None:
 
 @respx.mock
 def test_sync_create_todo() -> None:
-    """SyncJSONPlaceholderClient.create_todo() 新規TODO作成の動作確認
-
-    検証項目:
-    - POST /todos リクエストが送信される
-    - リクエストボディに title/userId/completed が含まれる
-    - 201 Created レスポンスが正しく処理される
-    """
     new_todo_response = {
         "id": 201,
         "title": "Buy groceries",


### PR DESCRIPTION
## 概要
計画書U6フェーズに基づき、jsonplaceholder sync/async基盤テストのdocstring/commentを整理。

## 変更内容
- 検証項目列挙型docstringを削除し自明なコメントを削減
- 境界を固定する意図のあるコメントのみ簡潔に残存
- scripts/fixture_docstring_todo.txt から対応済みエントリを1件削除
- `tests/unit/test_jsonplaceholder_base_async.py` (+16/-96)
- `tests/unit/test_jsonplaceholder_base_sync.py` (+8/-28)
- `tests/unit/test_jsonplaceholder_client_sync.py` (+6/-92)

## テスト
- [x] ローカルテスト完了（1443 tests passed / 97.58% coverage）
- [x] ruff 0 errors
- [x] mypy 0 errors
- [x] CI/CD パイプライン確認

## 関連Issue/PR
Closes #503 (Issue)

---
このPRは /push-pr スキルで自動生成されました。