### PR TITLE
refactor(test): conftest系docstringを整理 (U9)

### DIFF
--- a/.serena/memories/fixture_quick_reference.md
+++ b/.serena/memories/fixture_quick_reference.md
@@ -143,6 +143,6 @@ conftest.py `pytest_configure()` で登録:
 
 ## 5. 関連リソース
 
-- **conftest.py**: `tests/conftest.py`（203行）
+- **conftest.py**: `tests/conftest.py`
 - **テスト戦略**: @memory:test_strategy_details
 - **実装品質ゲート**: @memory:implementation_quality_gates

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,6 @@ import pytest
 
 from config.settings import _resolve_hostname_cached, reload_settings
 
-# =============================================================================
-# Pytest設定
-# =============================================================================
-
 
 def pytest_configure(config: pytest.Config) -> None:
     """pytest実行時の共通設定"""
@@ -52,53 +48,20 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     items.sort(key=_sort_key)
 
 
-# =============================================================================
-# Infrastructure Fixtures (autouse - テストコードから直接呼び出さない)
-# =============================================================================
-
-
 @pytest.fixture(autouse=True)
 def disable_sentry_for_tests(monkeypatch: pytest.MonkeyPatch) -> None:
-    """
-    テスト実行時にSentry SDKを無効化。
-
-    Purpose:
-        テスト中のエラーがSentryに送信されるのを防止し、
-        本番ダッシュボードへの誤送信リスクを排除する。
-
-    Note:
-        - autouse=True により全テストに自動適用
-        - テストコードから明示的に呼び出す必要なし
-        - 環境変数はPydantic Settings形式（SENTRY__ENABLED）
-    """
+    """テスト中のエラーがSentry本番ダッシュボードへ誤送信されるリスクを排除する。"""
     monkeypatch.setenv("SENTRY__ENABLED", "false")
 
 
 @pytest.fixture(scope="session", autouse=True)
 def isolate_proxy_env() -> Iterator[None]:
-    """
-    テストセッション全体でプロキシ系環境変数を除去し、テストを環境非依存にする。
+    """httpx クライアント生成をアンビエントなプロキシ設定から隔離する。
 
-    Purpose:
-        開発環境の HTTP(S)_PROXY / NO_PROXY / ALL_PROXY を剥離し、
-        httpx クライアント生成をアンビエントなプロキシ設定から隔離する。
-        ローカルインターセプタ (例: llmtrim) が NO_PROXY に IPv6 CIDR
-        (fd00::/8 等) を注入すると httpx が InvalidURL を送出し
-        (encode/httpx#3221)、全 httpx.Client/AsyncClient 生成が失敗する。
-        本 fixture でテストが実行環境のプロキシ設定に依存しないことを保証する。
-
-    Scope:
-        session スコープにすることで、class / module スコープのクライアント
-        fixture（例: tests/test_smoke.py の class スコープ api_client）が生成
-        される前に env を剥離する。function スコープでは高スコープ fixture の
-        後に実行され間に合わない（pytest は高スコープ fixture を先に生成する）。
-
-    Note:
-        - autouse=True により全テストに自動適用
-        - 本番挙動は不変（本番クライアントは trust_env=True のまま）
-        - httpx は小文字系も参照するため大文字/小文字の両方を除去
-        - monkeypatch fixture は function スコープ専用のため、公式 API の
-          pytest.MonkeyPatch() を直接使用し teardown で undo する
+    NO_PROXY に IPv6 CIDR が入ると httpx が InvalidURL を送出するため
+    (encode/httpx#3221)、大文字/小文字の両方を除去する。
+    session スコープで class/module client fixture より先に剥離し、
+    function scope の monkeypatch ではなく直接 MonkeyPatch を undo する。
     """
     mp = pytest.MonkeyPatch()
     for var in (
@@ -116,31 +79,16 @@ def isolate_proxy_env() -> Iterator[None]:
     mp.undo()
 
 
-# =============================================================================
-# 基本フィクスチャ
-# =============================================================================
-
-
 @pytest.fixture
 def logger() -> logging.Logger:
     """テスト用ロガー"""
     return logging.getLogger("test")
 
 
-# =============================================================================
-# API関連フィクスチャ
-# =============================================================================
-
-
 @pytest.fixture
 def mock_base_url() -> str:
     """unit テスト用ダミーURL（外部通信なし）"""
     return "https://test.local"
-
-
-# =============================================================================
-# クリーンアップフィクスチャ
-# =============================================================================
 
 
 @pytest.fixture(autouse=True)
@@ -156,12 +104,7 @@ def cleanup_test_files() -> Iterator[None]:
 
 @pytest.fixture(scope="function", autouse=True)
 def reset_settings() -> Iterator[None]:
-    """
-    各テスト実行前に設定をリロードしてテスト独立性を保証
-
-    同一プロセス内での逐次テスト間、
-    グローバルシングルトンsettingsのテスト間汚染（環境変数変更の残留等）を防止
-    """
+    """settings singleton と hostname cache のテスト間汚染を防ぐ。"""
     _resolve_hostname_cached.cache_clear()
     reload_settings()
     yield
@@ -171,30 +114,11 @@ def reset_settings() -> Iterator[None]:
 def reset_sentry_warning_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> Iterator[None]:
-    """utils.logger の sentry warning throttle 状態をテスト前後でリセット
+    """Sentry warning throttle/cache の module state をテスト前後で隔離する。
 
-    6 つの permanent throttle マーカー
-    ("settings"/"sdk"/"bug"/"outside_except"/"invalid_exc_info"/"safe_error_summary") を
-    保持する `_sentry_warnings_emitted: set[str]` を空集合に、
-    `_sentry_send_error_last_warned` timestamp を float("-inf") にリセットする。
-    `_is_sentry_debug_enabled` は lru_cache 削除済みのためリアルタイム取得。
-    monkeypatch.setenv/delenv との整合性は自動的に保たれる。
-
-    `_sentry_warning_lock` (threading.Lock) はリセット対象外:
-    Lock インスタンス自体を差し替えるとモジュール内の他参照と整合しなくなり、また
-    ロック状態は test 間で leak しない (各テスト内でロック取得・解放が完結する) ため
-    リセット不要。
-
-    monkeypatch.setattr は test 終了時に自動復元され、環境変数変更も即時反映される。
-    lru_cache 削除済みのため teardown での cache_clear() は不要。
-
-    autouse=True により全テストで自動適用し、TestSentryProcessor 以外のクラスでも
-    モジュールレベル throttle 状態の汚染を防止する (同一プロセス内の逐次テスト間
-    におけるフラグ汚染による偽陽性回避)。
-
-    Note: pytest-xdist は各ワーカーが別プロセスで動作するためモジュールレベルの
-    グローバル変数はプロセス間で共有されない。本 fixture の主目的は同一プロセス内
-    の逐次テスト間の汚染防止であり、xdist による並列実行は副次的な恩恵。
+    `_sentry_warning_lock` は差し替えるとモジュール内の他参照と整合しないため残す。
+    monkeypatch 復元と cache なしの debug flag により teardown の cache_clear は不要。
+    同一プロセス内の逐次テスト汚染を防ぎ、xdist は別プロセスなので副次的な保護に留まる。
     """
 
     monkeypatch.setattr("utils.logger._sentry_warnings_emitted", set())

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,26 +10,12 @@ from utils.sentry_init import _is_sensitive_key
 
 @pytest.fixture(autouse=True)
 def block_network_socket() -> Generator[None]:
-    """unit テスト実行中のみ実 TCP/UDP socket 使用を構造的に遮断する
+    """unit テスト中の実 TCP/UDP socket 使用を socket レベルで遮断する。
 
-    実 DNS 解決すり抜けを、テスト実装者の注意ではなく
-    socket レベルの失敗 (SocketBlockedError) で再発防止する。
-
-    - 適用範囲は tests/unit/ 配下のみ (conftest 限定)。integration / external /
-      performance の実ネットワーク方針には影響しない。
-    - allow_unix_socket=True: pytest-xdist の並列ワーカー間通信や asyncio
-      イベントループが Unix domain socket を使うため許可する。
-    - function スコープで disable→enable を都度トグルし、グローバル socket
-      パッチが unit 層の外へ漏れないようにする。
-    - pytest-socket v0.8.0でgethostbynameが遮断される
-    - pytest fixture 解決順序の制約: session または module スコープのfixture は、 function スコープの本 fixture より先に解決されるため、
-      それらの setup 中に発生した socket 操作は遮断されない。
-      現在の tests/unit/ 配下に該当 fixture は存在しないが、将来追加時の注意点として明記する。
-
-    # NOTE: pytest-socket v0.8.0 は socket.gethostbyname() も SocketBlockedError で遮断する。
-    # SSRF validator のように DNS 解決結果を制御する必要があるテストでは、
-    # deterministic_ssrf_validator_dns fixture が socket.gethostbyname を fake に差し替え、
-    # テスト実行中のみ決定論的な DNS 解決結果（localhost→127.0.0.1, その他→1.2.3.4）を提供する。
+    allow_unix_socket=True は xdist/asyncio の Unix domain socket 通信を残すため。
+    function スコープで unit 層外への漏れを防ぐが、高スコープ fixture setup は先に走る。
+    pytest-socket は DNS も遮断するため、SSRF validator は決定論的 DNS fixture で上書きする
+    (localhost→127.0.0.1、その他→1.2.3.4)。
     """  # noqa: E501
     disable_socket(allow_unix_socket=True)
     yield
@@ -38,11 +24,7 @@ def block_network_socket() -> Generator[None]:
 
 @pytest.fixture(autouse=True)
 def clear_sensitive_key_cache() -> Generator[None]:
-    """_is_sensitive_key lru_cache をテスト間でリセット (#10-TC-2)
-
-    monkeypatch で SENSITIVE_KEYS を変更するテストがある場合、
-    cache_clear() がないと古いキャッシュ値が他テストに残存する。
-    """
+    """SENSITIVE_KEYS monkeypatch の古い lru_cache 値が他テストへ残るのを防ぐ。"""
     _is_sensitive_key.cache_clear()
     yield
     _is_sensitive_key.cache_clear()

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -13,27 +13,11 @@ import respx
 
 
 def mock_get_route(url: str, params: dict[str, Any] | None, json_data: Any) -> respx.Route:
-    """respx GETルートのparams有無対応ヘルパー
+    """respx GET ルートを、クエリ有無で正しいマッチ方式に分けて登録する。
 
-    respxのparams=はcontains match（サブセットマッチ）。
-    paramsがNoneの場合はparams__eq={}を使用する（等価マッチ、クエリパラメータなしのリクエストのみにマッチ）。
-
-    前提条件:
-        必ず @respx.mock デコレータまたは with respx.mock: ブロック内から
-        呼び出すこと。コンテキスト外でもルート登録自体は成功するが、
-        モックは機能しない。モックされていないリクエストが発行された場合、
-        respxは AllMockedAssertionError を発生させる。
-
-    Args:
-        url: モック対象のURL
-        params: クエリパラメータ（Noneの場合はparams__eq={}を使用 - クエリパラメータなしのみマッチ）
-        json_data: レスポンスとして返すJSONデータ
-
-    Returns:
-        respx.Route: call_count等の検証に使用可能なルートオブジェクト
-
-    Raises:
-        なし（この関数自体は例外を発生させない）
+    respx の params= は subset match なので、params=None は params__eq={} にして
+    クエリなしリクエストだけに一致させる。@respx.mock/with respx.mock 外では
+    ルート登録できてもモックが効かず、未モック通信は AllMockedAssertionError になる。
     """
     if params is not None:
         return respx.get(url, params=params).respond(json=json_data)
@@ -41,16 +25,7 @@ def mock_get_route(url: str, params: dict[str, Any] | None, json_data: Any) -> r
 
 
 def assert_warning_log_count(log_output: list, event_name: str, expected_count: int) -> None:
-    """警告ログの発生回数を検証するヘルパー関数
-
-    structlog の capture_logs() が収集したログエントリから、
-    指定したイベント名の警告ログが期待回数発生していることを検証する。
-
-    Args:
-        log_output: capture_logs() が収集したログエントリのリスト
-        event_name: 検証対象のイベント名
-        expected_count: 期待する警告ログの発生回数
-    """
+    """structlog capture_logs() から指定 warning event の発生回数を検証する。"""
     warning_events = [log["event"] for log in log_output if log.get("log_level") == "warning"]
     assert warning_events.count(event_name) == expected_count, (
         f"Expected {expected_count} '{event_name}' warnings, got: {warning_events}"
@@ -58,18 +33,7 @@ def assert_warning_log_count(log_output: list, event_name: str, expected_count: 
 
 
 def make_mock_user(uid: int, **overrides: Any) -> dict[str, Any]:
-    """テスト用ユーザーデータのモック生成ファクトリ
-
-    DRY原則に基づき、テストコード間でのモックデータ重複を排除する。
-    デフォルトで完全なユーザー構造を生成し、**overridesで特定フィールドを上書き可能。
-
-    Args:
-        uid: ユーザーID
-        **overrides: 上書きするフィールド名と値
-
-    Returns:
-        dict[str, Any]: 生成されたユーザーデータ辞書
-    """
+    """完全な User 形状を生成し、overrides でフィールド単位の差分だけ表現する。"""
     user = {
         "id": uid,
         "name": f"User {uid}",
@@ -101,22 +65,7 @@ def make_canonical_user(
     email: str = "Sincere@april.biz",
     website: str = "https://hildegard.org",
 ) -> dict[str, Any]:
-    """正準（JSONPlaceholder準拠）の User ペイロードを生成するヘルパー関数
-
-    `make_mock_user`（uid連動の合成データ）とは別用途で、JSONPlaceholder実APIに
-    近い実在風データを返す。Pydantic User モデルへ検証可能な完全構造を提供し、
-    name/username/email/website は部分的に上書き可能。
-
-    Args:
-        user_id: ユーザーID
-        name: ユーザー名
-        username: ユーザー名（ハンドル）
-        email: メールアドレス
-        website: WebサイトURL
-
-    Returns:
-        完全な User ペイロード辞書
-    """
+    """JSONPlaceholder 実APIに近い正準 User 形状で、Pydantic 検証用の完全構造を返す。"""
     return {
         "id": user_id,
         "name": name,


### PR DESCRIPTION
## 概要
計画書2026-07-13-001のU9区分（Issue #506対応）に基づき、conftest系3ファイルの冗長なdocstringを整理しました。

## 変更内容
- `tests/conftest.py`: WHATの重複記述を削り、WHY（非自明な設計理由）のみ残す方針で圧縮
- `tests/unit/conftest.py`: 同上の方針で圧縮
- `tests/unit/helpers.py`: 同上の方針で圧縮
- `.serena/memories/fixture_quick_reference.md`: 行数記載を実態に追従

## テスト
- [x] ローカルテスト完了（1443 tests passed / 97.58% coverage）
- [x] ruff / mypy 0 errors
- [ ] CI/CD パイプライン確認

## 関連Issue/PR
Closes #506 (Issue)

---
このPRは /push-pr スキルで自動生成されました。