### PR TITLE
docs: 陳腐化した実測値の同期と品質ゲート参照の単一真実源化

### DIFF
--- a/.claude/rules/testing/quality-gates.md
+++ b/.claude/rules/testing/quality-gates.md
@@ -18,7 +18,7 @@ paths:
 ### Gate 1: pytest合格
 
 ```bash
-uv run pytest --cov=utils --cov=config --cov=models
+uv run pytest -m "(unit or integration) and not external" --cov=utils --cov=config --cov=models
 ```
 
 - 全テストケース合格（0 failed）

--- a/.claude/rules/testing/quality-gates.md
+++ b/.claude/rules/testing/quality-gates.md
@@ -5,7 +5,7 @@ paths:
 
 # プロジェクト品質ゲート基準
 
-*最終更新: 2026-07-30*
+*最終更新: 2026-07-31*
 
 ## 目的
 
@@ -18,7 +18,7 @@ paths:
 ### Gate 1: pytest合格
 
 ```bash
-uv run pytest --cov=utils --cov=config --cov=models --cov-fail-under=[Phase別目標]
+uv run pytest --cov=utils --cov=config --cov=models
 ```
 
 - 全テストケース合格（0 failed）
@@ -91,6 +91,7 @@ git diff --quiet && git diff --cached --quiet && \
 | 2026-02-05 | Gate 4: /commit必須化 |
 | 2026-02-10 | 簡潔化（221行→90行） |
 | 2026-07-30 | paths frontmatter追加（遅延ロード化）、コマンドを `.claude/CLAUDE.md`「統合コマンド」参照に統一、削除済みの日次進捗ファイルへの参照を除去 |
+| 2026-07-31 | Gate 1 のコマンドから展開不能プレースホルダ `--cov-fail-under=[Phase別目標]` を除去（下限は `pyproject.toml` の `addopts` が単一真実源） |
 
 ---
 

--- a/.serena/memories/implementation_quality_gates.md
+++ b/.serena/memories/implementation_quality_gates.md
@@ -16,7 +16,7 @@
 
 **検証コマンド**:
 ```bash
-uv run pytest --cov=utils --cov=config --cov=models
+uv run pytest -m "(unit or integration) and not external" --cov=utils --cov=config --cov=models
 ```
 
 **合格基準**:
@@ -205,6 +205,7 @@ Gate 4 (git commit) → 未コミット?
 | 2026-02-05 | CLAUDE.md整合性修正 | Gate 4: /commit必須化、Conventional Commits追加（perf/ci/security） |
 | 2026-07-31 | Gate 1 コマンドの修正 | 展開不能プレースホルダ `--cov-fail-under=[Phase別目標]` を除去（下限は `pyproject.toml` の `addopts` が単一真実源） |
 | 2026-07-31 | Gate 1 合格基準の修正 | 「Phase別、下記参照」が参照先の表を持たない dangling reference だったため、`pyproject.toml` の `--cov-fail-under` 参照へ統一 |
+| 2026-07-31 | Gate 1 マーカーフィルタ追加 | マーカー未指定により実GitHub API呼び出し(external 4件)とperformance 7件がコミット前ゲートで実行される問題を修正。`-m "(unit or integration) and not external"` を追加し `.claude/CLAUDE.md` 統合コマンドと整合（PR #546レビュー対応） |
 
 ---
 

--- a/.serena/memories/implementation_quality_gates.md
+++ b/.serena/memories/implementation_quality_gates.md
@@ -21,7 +21,7 @@ uv run pytest --cov=utils --cov=config --cov=models
 
 **合格基準**:
 - 全テストケース合格（0 failed）
-- カバレッジ目標達成（Phase別、下記参照）
+- カバレッジ下限達成（下限値は `pyproject.toml` の `--cov-fail-under`）
 - テストマーカー別実行も合格（unit, integration）
 
 
@@ -204,6 +204,7 @@ Gate 4 (git commit) → 未コミット?
 | 2025-12-27 | 参照更新 | test_strategy統合に伴う参照先更新 |
 | 2026-02-05 | CLAUDE.md整合性修正 | Gate 4: /commit必須化、Conventional Commits追加（perf/ci/security） |
 | 2026-07-31 | Gate 1 コマンドの修正 | 展開不能プレースホルダ `--cov-fail-under=[Phase別目標]` を除去（下限は `pyproject.toml` の `addopts` が単一真実源） |
+| 2026-07-31 | Gate 1 合格基準の修正 | 「Phase別、下記参照」が参照先の表を持たない dangling reference だったため、`pyproject.toml` の `--cov-fail-under` 参照へ統一 |
 
 ---
 

--- a/.serena/memories/implementation_quality_gates.md
+++ b/.serena/memories/implementation_quality_gates.md
@@ -1,6 +1,6 @@
 # プロジェクト品質ゲート基準
 
-*最終更新: 2026年02月05日*
+*最終更新: 2026-07-31*
 
 ## 目的
 
@@ -16,7 +16,7 @@
 
 **検証コマンド**:
 ```bash
-uv run pytest --cov=utils --cov=config --cov=models --cov-fail-under=[Phase別目標]
+uv run pytest --cov=utils --cov=config --cov=models
 ```
 
 **合格基準**:
@@ -203,6 +203,7 @@ Gate 4 (git commit) → 未コミット?
 | 2025-11-14 | 初版作成 | RULES.md「Implementation Integrity」の具体化 |
 | 2025-12-27 | 参照更新 | test_strategy統合に伴う参照先更新 |
 | 2026-02-05 | CLAUDE.md整合性修正 | Gate 4: /commit必須化、Conventional Commits追加（perf/ci/security） |
+| 2026-07-31 | Gate 1 コマンドの修正 | 展開不能プレースホルダ `--cov-fail-under=[Phase別目標]` を除去（下限は `pyproject.toml` の `addopts` が単一真実源） |
 
 ---
 

--- a/.serena/memories/improvement-checklist.md
+++ b/.serena/memories/improvement-checklist.md
@@ -391,7 +391,7 @@
 
   **Gate 1: pytest合格**:
   ```bash
-  uv run pytest --cov=utils --cov=config --cov=models
+  uv run pytest -m "(unit or integration) and not external" --cov=utils --cov=config --cov=models
   ```
   - [ ] 全テストケース合格（0 failed）
   - [ ] カバレッジ下限達成（__% / 下限値は `pyproject.toml` の `--cov-fail-under`）

--- a/.serena/memories/improvement-checklist.md
+++ b/.serena/memories/improvement-checklist.md
@@ -1,6 +1,6 @@
 # 改善効果測定チェックリスト
 
-*最終更新: 2026年02月07日*
+*最終更新: 2026-07-31*
 *用途: reflexion改善効果の実行可能な測定手順*
 *対象: Phase 1実装完了後の効果測定実施、今後の改善検証*
 *アクセス頻度: 高（改善施策実施時、毎タスク終了時）*
@@ -391,10 +391,10 @@
 
   **Gate 1: pytest合格**:
   ```bash
-  uv run pytest --cov=utils --cov=config --cov=models --cov-fail-under=83
+  uv run pytest --cov=utils --cov=config --cov=models
   ```
   - [ ] 全テストケース合格（0 failed）
-  - [ ] カバレッジ目標達成（__% / 目標83%）
+  - [ ] カバレッジ下限達成（__% / 下限値は `pyproject.toml` の `--cov-fail-under`）
 
   **Gate 2: ruff合格**:
   ```bash
@@ -651,7 +651,7 @@
   #### 🛠️ ポートフォリオ実装進捗
 
   **品質ゲート（実装活動判定）**:
-  - [ ] pytest合格（カバレッジ: __% / 目標83%）
+  - [ ] pytest合格（カバレッジ: __% / 下限値は `pyproject.toml` の `--cov-fail-under`）
   - [ ] ruff合格（0 errors）
   - [ ] mypy合格（0 errors）
   - [ ] git commit実行済み（commit: [hash]）
@@ -1075,6 +1075,7 @@ fi
 | 日付 | 変更内容 | Phase | 担当 |
 |------|---------|-------|------|
 | 2026-02-07 | 初版作成（Task #22対応） | improvement-kpi-definition.md（未作成）準拠、実行可能チェックリスト化 | QA Expert Agent |
+| 2026-07-31 | カバレッジ下限のハードコード値 `83` を除去（3箇所） | Gate 1 コマンド・完了判定・日次記録テンプレートを `pyproject.toml` の `--cov-fail-under` 参照へ統一 | Claude Code |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md **Last Updated**: 2026-07-30
+# CLAUDE.md **Last Updated**: 2026-07-31
 
 **軽量インデックス — 詳細は `.claude/CLAUDE.md` を参照**
 
@@ -43,8 +43,7 @@ APIテスト + DevOps統合学習ポートフォリオ（Python 3.14 / httpx / p
 
 ## graphify
 
-- アーキテクチャ質問前に `graphify-out/GRAPH_REPORT.md` を読む
-- コード変更後は `graphify update .` を実行
+アーキテクチャ質問前に `graphify-out/GRAPH_REPORT.md` を読む（ローカル生成物・gitignore対象のため未コミット）。未生成時およびコード変更後は `graphify update .` を実行。
 
 <!-- code-review-graph MCP tools -->
 ## MCP Tools: code-review-graph

--- a/PROJECT_INDEX.md
+++ b/PROJECT_INDEX.md
@@ -1,7 +1,6 @@
 # Project Index: api-test-devops-portfolio
 
-**Generated:** 2026-07-11 JST
-**Last Commit:** 00d5db8 (2026-07-11)
+**Generated:** 2026-07-31
 **Version:** 0.1.0
 **Python:** ==3.14.*
 
@@ -31,8 +30,8 @@ api-test-devops-portfolio/
 │   ├── logger.py          # 構造化ログ（structlog）
 │   ├── sentry_init.py     # エラー監視（Sentry SDK 初期化）
 │   └── sentry_scrub_*.py  # PIIスクラブ（events / values / primitives）
-├── tests/                  # テストスイート（全22 test files）
-│   ├── unit/              # ユニットテスト（16 files）
+├── tests/                  # テストスイート（全39 test files / 2026-07 実測）
+│   ├── unit/              # ユニットテスト（33 files）
 │   ├── integration/       # 統合テスト（4 files）
 │   ├── performance/       # パフォーマンステスト（1 file）
 │   ├── conftest.py        # pytest fixtures
@@ -141,21 +140,21 @@ api-test-devops-portfolio/
 ## 🧪 Test Coverage
 
 ### Test Statistics
-- **Total Test Files**: 23
-- **Unit Tests**: 16 files (tests/unit/)
-- **Integration Tests**: 5 files (tests/integration/)
+- **Total Test Files**: 39（2026-07 実測）
+- **Unit Tests**: 33 files (tests/unit/)
+- **Integration Tests**: 4 files (tests/integration/)
 - **Performance Tests**: 1 file (tests/performance/)
 - **Smoke Tests**: 1 file (tests/test_smoke.py)
 
 ### Coverage Metrics
-- **Current Coverage**: 96.15%（unit+integration条件）
-- **Target Coverage**: 85% (Week 5-6 goal) ✅ 達成済み
+- **Coverage**: 97.60%（2026-07 実測 / unit+integration条件）
+- **Target Coverage**: `pyproject.toml` の `--cov-fail-under` ✅ 達成済み
 - **Coverage Reports**: `reports/coverage.json`, `reports/htmlcov/`
 
 ### Test Execution
 ```bash
-# 全テスト実行（カバレッジ付き）
-uv run pytest --cov=. --cov-report=term-missing
+# 全テスト実行（カバレッジ計測は pyproject.toml の addopts で自動適用）
+uv run pytest
 
 # 並列実行（高速化）
 uv run pytest -n auto
@@ -217,18 +216,12 @@ uv run python
 
 ### 3. Test
 ```bash
-# 全テスト実行
+# 全テスト実行（カバレッジ計測・下限・HTMLレポートは pyproject.toml の addopts で自動適用）
 uv run pytest
-
-# カバレッジ付き実行
-uv run pytest --cov=. --cov-report=html
 open reports/htmlcov/index.html
 
-# 品質ゲート（4段階チェック）
-uv run pytest --cov-fail-under=85 && \
-uv run ruff check . && \
-uv run mypy utils/ config/ models/ && \
-git status
+# 品質ゲート（コミット前必須）
+# コマンド本体は .claude/CLAUDE.md「品質ゲート」→「統合コマンド」を参照（複製しない）
 ```
 
 ### 4. Development Workflow
@@ -240,8 +233,7 @@ git status
 /git:feature <task-name>
 
 # 3. 実装 + 品質ゲート
-# （コード変更後）
-uv run pytest && uv run ruff check . && uv run mypy utils/ config/ models/
+# （コード変更後）.claude/CLAUDE.md「品質ゲート」→「統合コマンド」を実行
 
 # 4. 自己改善
 /reflexion:reflect
@@ -290,8 +282,8 @@ uv run pytest && uv run ruff check . && uv run mypy utils/ config/ models/
 
 | Metric | Value | Target |
 |--------|-------|--------|
-| Test Coverage | 96.15% | 85% |
-| CI Test Files (unit+integration) | 21 | - |
+| Test Coverage | 97.60%（2026-07 実測） | `pyproject.toml` の `--cov-fail-under` |
+| CI Test Files (unit+integration) | 37（2026-07 実測） | - |
 | Python Version | 3.14 | - |
 | Code Quality | ruff + mypy | 0 errors |
 | Documentation | CLAUDE.md + README | - |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ uv run pytest tests/unit/test_jsonplaceholder_client_sync.py --cov=utils --cov=c
 
 - **`1,457件のテストスイート`**（2026-07 実測）: Unit(1,433) / Integration(15, うちExternal 4件含む) / Performance(7, 週次のみ) / Smoke(2)
 - **`カバレッジ: 97.60%`**（2026-07 実測 / unit+integration条件）: 継続的な品質向上
-- **`CI実行テスト: 1,444件`**（unit+integration条件, external・performance・smoke除外）
+- **`CIカバレッジ対象テスト: 1,444件`**（unit+integration条件, external・performance・smoke除外。PR ValidationはこれにSmoke 2件をカバレッジ計測外で追加実行）
   - 内訳: Unit 1,433件 + Integration 11件（15件のうちexternal 4件を除外）
 - **`CI/CD自動化`**: GitHub Actions による多段階パイプライン
 - **`セキュリティ`**: CI/CD品質ゲート（pytest + ruff + mypy + Trivy）

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # API Test + DevOps Portfolio
 
-*最終更新: 2026-06-07*
+*最終更新: 2026-07-31*
 
 外部API連携における堅牢性と品質保証を追求し、APIテストとDevOps技術を統合したポートフォリオです。
 SSRFやPII漏洩、不安定なリトライといった連携特有のアンチパターンを排除し、1,300件超の自動テストを品質ゲートとして構築・運用しています。
@@ -44,22 +44,22 @@ SSRFやPII漏洩、不安定なリトライといった連携特有のアンチ�
 
 ### 2. テスト実行
 
-![Test Demo - pytest実行で基本テスト19件合格（全1,360件中の抽出実行、CI環境での全体カバレッジ: 96.15%）。テスト自動化スキルを実証](assets/demo-test.gif)
+![Test Demo - pytest実行で基本テスト19件合格（全1,457件中の抽出実行、CI環境での全体カバレッジ: 97.60%）。テスト自動化スキルを実証](assets/demo-test.gif)
 
-**📝 デモ内容**: クイック実行例（基本テスト19件、デモ時間短縮のため抽出。全1,360件は約60秒）
-**🔍 全1,360件を今すぐ確認**: [GitHub Actions CI/CD](https://github.com/yaoki-dev/api-test-devops-portfolio/actions) でフルテスト結果＋カバレッジレポートを閲覧
+**📝 デモ内容**: クイック実行例（基本テスト19件、デモ時間短縮のため抽出。全1,457件は約60秒）
+**🔍 全1,457件を今すぐ確認**: [GitHub Actions CI/CD](https://github.com/yaoki-dev/api-test-devops-portfolio/actions) でフルテスト結果＋カバレッジレポートを閲覧
 
 **何がわかるか**:
 
 - pytest + pytest-covによる自動テスト実行
 - カバレッジレポートによる品質可視化
-- テスト実行: 基本19件 ~5秒、全1,360件 ~60秒
+- テスト実行: 基本19件 ~5秒、全1,457件 ~60秒
 
 <details>
-<summary>全テスト実行コマンド（1,360件、約60秒）</summary>
+<summary>全テスト実行コマンド（1,457件、約60秒）</summary>
 
 ```bash
-# 全テスト実行（1,360件）
+# 全テスト実行（1,457件）
 uv run pytest --cov=utils --cov=config --cov=models --cov-report=term -q --color=yes
 
 # クイック実行（unit tests）
@@ -85,10 +85,10 @@ uv run pytest tests/unit/test_jsonplaceholder_client_sync.py --cov=utils --cov=c
 
 ## 概要
 
-- **`1,360件のテストスイート`**: Unit(1,316) / Integration(35, うちExternal 5件含む) / Performance(7, 週次のみ) / Smoke(2)
-- **`カバレッジ: 96.15%`**（unit+integration条件）: 継続的な品質向上
-- **`CI実行テスト: 1,358件`**（unit+integration条件, external・performance・smoke除外）
-  - 内訳: Unit 1,316件 + Integration 30件（35件のうちexternal 5件を除外）
+- **`1,457件のテストスイート`**（2026-07 実測）: Unit(1,433) / Integration(15, うちExternal 4件含む) / Performance(7, 週次のみ) / Smoke(2)
+- **`カバレッジ: 97.60%`**（2026-07 実測 / unit+integration条件）: 継続的な品質向上
+- **`CI実行テスト: 1,444件`**（unit+integration条件, external・performance・smoke除外）
+  - 内訳: Unit 1,433件 + Integration 11件（15件のうちexternal 4件を除外）
 - **`CI/CD自動化`**: GitHub Actions による多段階パイプライン
 - **`セキュリティ`**: CI/CD品質ゲート（pytest + ruff + mypy + Trivy）
 - **`GitHub API統合`**: 実務的なAPI統合スキルを証明（Rate Limit管理、ETag活用、非同期処理）

--- a/docs/reference/ci_cd_pipeline.md
+++ b/docs/reference/ci_cd_pipeline.md
@@ -1,6 +1,6 @@
 # CI/CD Pipeline
 
-*最終更新: 2026-07-30*
+*最終更新: 2026-07-31*
 
 ## 🚀 CI/CDパイプライン概要
 
@@ -175,18 +175,18 @@ Composite action（`.github/actions/trivy-sarif-verify/action.yml`）内部で�
 ### CI実行テスト条件
 
 ```bash
-# CI/CD実行テストセット（575件: unit+integration, external除外）
-# Note: performanceテスト(5件)は performance マーカーのみのため、この条件から自動除外
+# CI/CD実行テストセット（unit + integration, external除外）
+# Note: performanceテスト(7件)は performance マーカーのみのため、この条件から自動除外
 uv run pytest -n auto -m "(unit or integration) and not external" \
     --cov=utils --cov=config --cov=models --cov-report=term-missing
 ```
 
-| 品質基準 | 目標値 | 現在値 | 検証コマンド |
-|---------|-------|-------|------------|
-| カバレッジ | 85% | 93.43% | `pytest --cov-fail-under=85` |
-| ruff | 0 errors | ✅ | `ruff check .` |
-| mypy | 0 errors | ✅ | `mypy utils/ config/ models/ tests/conftest.py` |
-| セキュリティ | 0 Critical/High | ✅ | Trivy SARIF |
+| 品質基準 | 目標値 | 検証コマンド |
+|---------|-------|------------|
+| カバレッジ | `pyproject.toml` の `--cov-fail-under` | 上記のCI実行コマンド（下限は addopts で自動適用） |
+| ruff | 0 errors | `ruff check .` |
+| mypy | 0 errors | `mypy utils/ config/ models/ tests/conftest.py` |
+| セキュリティ | 0 Critical/High | Trivy SARIF |
 
 ### CD（実装済み）
 


### PR DESCRIPTION
## 概要

ドキュメント6ファイルに残っていた「実行不能なコマンド」「陳腐化した実測値」「変更履歴の欠落」を修正する。いずれもコードロジックには影響しないドキュメント専用の変更。

## 変更内容

### 1. 実行不能な品質ゲートコマンドの修正
`.claude/rules/testing/quality-gates.md` と `.serena/memories/implementation_quality_gates.md` の Gate 1 に `--cov-fail-under=[Phase別目標]` という展開不能なプレースホルダが残っており、記載どおり実行すると pytest が引数エラーで停止する状態だった。カバレッジ下限は `pyproject.toml` の `addopts` が既に供給しているため、ドキュメント側の重複指定を廃止し単一真実源へ集約した。

### 2. 陳腐化した実測値の同期（2026-07 実測）
| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| 総テスト数 | 1,360 | 1,457 |
| カバレッジ | 96.15% | 97.60% |
| テストファイル数 | 22 / 23 | 39 |
| performance テスト | 5件 | 7件 |

取得時期を「2026-07 実測」と明示し、日付なしの数値が静かに誤情報化する構造を解消した。構造的に腐りやすい `ci_cd_pipeline.md` の「現在値」列は削除している。

### 3. 変更履歴の追記
最終更新日を更新しながら変更履歴テーブルに対応行がない状態（監査証跡の断絶）を2ファイルで修正。

### 4. graphify 参照手順の整理
`graphify-out/GRAPH_REPORT.md` が gitignore 対象のローカル生成物である旨を明示し、2項目を1行に統合。

## 変更ファイル

```
.claude/rules/testing/quality-gates.md            |  5 +--
.serena/memories/implementation_quality_gates.md  |  5 +--
CLAUDE.md                                         |  5 ++-
PROJECT_INDEX.md                                  | 40 ++++++-----
README.md                                         | 22 +++++-----
docs/reference/ci_cd_pipeline.md                  | 18 +++++----
6 files changed, 44 insertions(+), 51 deletions(-)
```

## 意図的に変更していない箇所

- **README.md のプレースホルダ**（`{{UNIT_TESTS_COUNT}}` / `{{INTEGRATION_TESTS_COUNT}}` / `{{COVERAGE_PERCENT}}`）— ポートフォリオ完成後に main の実測値で更新する運用のため、意図的に据え置き（Issue #428 で追跡中）
- **`.github/workflows/ci.yml:1350` のカバレッジ値** — 同上の理由で今回対象外

## テスト

- [x] pytest: 1,444 passed / coverage 97.60%（`(unit or integration) and not external`）
- [x] ruff check: 0 errors
- [x] mypy: 0 errors（24 source files）
- [x] markdownlint / textlint: exit 0
- [x] CI/CD パイプライン確認