### PR TITLE
ci(precommit): verify/writeジョブを分離しTOCTOUを是正

### DIFF
--- a/.github/workflows/autoupdate-precommit.yml
+++ b/.github/workflows/autoupdate-precommit.yml
@@ -6,19 +6,25 @@ on:
     - cron: '0 0 1 * *'  # 毎月1日 00:00 UTC
   workflow_dispatch:      # 手動実行可能
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
-  update-precommit:
-    name: Update pre-commit hooks
+  verify:
+    name: Verify updated hooks
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      verified_base_sha: ${{ steps.checkout.outputs.commit }}
+      changed: ${{ steps.git-check.outputs.changed }}
 
     steps:
       - name: Checkout code
+        id: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: develop
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -53,15 +59,100 @@ jobs:
 
       - name: Check for changes
         id: git-check
+        shell: bash
         run: |
-          if git diff --quiet .pre-commit-config.yaml; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          changed_paths=$(git diff --name-only)
+          name_status=$(git diff --name-status)
+
+          case "$changed_paths" in
+            '')
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+              ;;
+            .pre-commit-config.yaml)
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Unexpected changed path(s): $changed_paths" >&2
+              exit 1
+              ;;
+          esac
+
+          if [[ -n "$name_status" ]]; then
+            while IFS=$'\t' read -r status path extra; do
+              if [[ "$status" != M || "$path" != .pre-commit-config.yaml || -n "$extra" || -d "$path" ]]; then
+                echo "::error::Unexpected diff entry: $status $path $extra" >&2
+                exit 1
+              fi
+            done <<< "$name_status"
           fi
 
-      # NOTE: 企業環境ではSHA pinning推奨（例: @67ccf781d68cd99b580ae25a5c18a1cc84ffff1f）
-      # ポートフォリオではメジャーバージョンタグで保守性とセキュリティをバランス
+      - name: Upload verified pre-commit config
+        if: steps.git-check.outputs.changed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: verified-precommit-config
+          path: .pre-commit-config.yaml
+          include-hidden-files: true
+          if-no-files-found: error
+
+  write:
+    name: Create pull request
+    needs: verify
+    if: needs.verify.result == 'success' && needs.verify.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.verify.outputs.verified_base_sha }}
+
+      - name: Download verified pre-commit config
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: verified-precommit-config
+          path: .artifact/verified-precommit-config
+
+      - name: Restore verified pre-commit config
+        run: |
+          test -f .artifact/verified-precommit-config/.pre-commit-config.yaml
+          cp -- .artifact/verified-precommit-config/.pre-commit-config.yaml .pre-commit-config.yaml
+
+      - name: Check for restored changes
+        id: git-check
+        shell: bash
+        run: |
+          set -euo pipefail
+          changed_paths=$(git diff --name-only)
+          name_status=$(git diff --name-status)
+
+          case "$changed_paths" in
+            '')
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+              ;;
+            .pre-commit-config.yaml)
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Unexpected changed path(s): $changed_paths" >&2
+              exit 1
+              ;;
+          esac
+
+          if [[ -n "$name_status" ]]; then
+            while IFS=$'\t' read -r status path extra; do
+              if [[ "$status" != M || "$path" != .pre-commit-config.yaml || -n "$extra" || -d "$path" ]]; then
+                echo "::error::Unexpected diff entry: $status $path $extra" >&2
+                exit 1
+              fi
+            done <<< "$name_status"
+          fi
+
       - name: Create Pull Request
         id: create-pr
         if: steps.git-check.outputs.changed == 'true'
@@ -80,10 +171,12 @@ jobs:
             pre-commit run --all-files
             ```
           branch: chore/update-precommit-hooks
+          base: develop
           labels: |
             dependencies
             pre-commit
           delete-branch: true
+          add-paths: .pre-commit-config.yaml
 
       - name: Verify pull request output
         if: steps.git-check.outputs.changed == 'true'

--- a/.github/workflows/autoupdate-precommit.yml
+++ b/.github/workflows/autoupdate-precommit.yml
@@ -103,7 +103,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      # 更新ブランチへコミットを push するために必要
       contents: write
+      # PR を作成・更新するために必要
       pull-requests: write
 
     steps:


### PR DESCRIPTION
## 概要
autoupdate-precommit.yml を verify（読み取り専用）と write（PR作成）のジョブへ分離し、TOCTOU（Time-of-check to time-of-use）リスクを是正しました。

## 変更内容
- 既存の単一jobに常時付与されていた `contents: write` / `pull-requests: write` を撤廃し、権限を最小化
- verify jobは読み取り専用権限のみで `.pre-commit-config.yaml` 差分を検証し、artifact経由でwrite jobへ受け渡し
- `verified_base_sha` をpinしてPR作成時の基点をverify時点に固定
- diffの変更パス・変更エントリ（status/path）を厳格に検証するガードを追加し、想定外の変更を検出した場合はエラーで停止

## テスト
- [x] actionlint によるワークフロー構文検証
- [x] YAML構文検証（python3 -c "import yaml; ..."）
- [ ] CI/CD パイプライン確認（本PRでの実行結果待ち）

## 関連Issue/PR
Closes #551 (Issue)

---
このPRは /push-pr スキルで自動生成されました。