### PR TITLE
feat(ci): JUnitテスト結果のジョブサマリー可視化を追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,6 +49,8 @@ docs/
 
 # CI/CD（1MB削減）
 .github/
+# ci.yml は tests/unit/test_ci_workflow_contract.py が読み込むため test ステージへ渡す
+!.github/workflows/ci.yml
 .gitlab-ci.yml
 .circleci/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI/CD Pipeline
 
 # Test Pyramid Strategy (Google Testing Blog):
 #   Unit 70% / Integration 30%
-# Coverage Target: 96.15% (achieved 2026-06, CI条件: unit+integration, not external)
 # Reference: .serena/memories/test_strategy_part1_overview.md
 
 # Default permissions (least privilege principle)
@@ -76,11 +75,21 @@ jobs:
           # Step 1: unit + integration with coverage
           uv run pytest -n auto -m "${{ steps.markers.outputs.test_filter }}" \
             --cov=utils --cov=config --cov=models \
+            --junitxml=reports/junit.xml \
             --cov-report=json:coverage.json \
             --cov-report=term-missing \
             -v --tb=short
           # Step 2: smoke without coverage (using output variable)
           uv run pytest -m "${{ steps.markers.outputs.smoke_marker }}" -v --tb=short --no-cov
+
+      # Rendered here rather than in status-report: this job already has the uv
+      # environment and holds reports/junit.xml locally, so no artifact round-trip
+      # and no extra setup steps are needed.
+      - name: Render JUnit test summary
+        if: always()
+        run: |
+          uv run python scripts/render_test_summary.py reports/junit.xml \
+            >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload test results
         if: always()
@@ -1347,7 +1356,6 @@ jobs:
             echo ""
             echo "## Test Pyramid Strategy"
             echo "- Unit 70% / Integration 30%"
-            echo "- Coverage Target: 96.15% (achieved)"
             echo ""
             echo "## Stage Results"
             echo "- PR Validation: ${{ needs.pr-validation.result }}"
@@ -1366,6 +1374,29 @@ jobs:
             echo "## Triggered By: ${{ github.event_name }}"
           } > status_report.md
           cat status_report.md
+
+      - name: Append status report to Job Summary
+        if: always()
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ -f status_report.md ]; then
+            cat status_report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "CI/CD Pipeline Status Report unavailable." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          coverage_file="artifacts/pr-validation-results-py3.14/coverage.json"
+          if [ "$EVENT_NAME" = "pull_request" ] && [ -f "$coverage_file" ]; then
+            if coverage=$(jq -er '.totals.percent_covered_display // empty' "$coverage_file" 2>/dev/null); then
+              coverage="${coverage%\%}"
+              echo "Coverage: ${coverage}%" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "Coverage: n/a (not generated for this trigger)" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo "Coverage: n/a (not generated for this trigger)" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload status report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,10 +116,14 @@ RUN uv sync --frozen --no-install-project
 COPY --chown=appuser:appgroup config/ ./config/
 COPY --chown=appuser:appgroup utils/ ./utils/
 COPY --chown=appuser:appgroup models/ ./models/
+COPY --chown=appuser:appgroup scripts/ ./scripts/
 COPY --chown=appuser:appgroup tests/ ./tests/
-# docker-compose.yml は tests/integration/test_docker_compose_contract.py が
-# request.config.rootdir / "docker-compose.yml" で読み込むため、test ステージへ配置する。
+# docker-compose.yml は tests/unit/test_docker_compose_contract.py が
+# request.config.rootpath / "docker-compose.yml" で読み込むため、test ステージへ配置する。
 COPY --chown=appuser:appgroup docker-compose.yml ./
+# ci.yml は tests/unit/test_ci_workflow_contract.py が
+# request.config.rootpath / ".github/workflows/ci.yml" で読み込むため、test ステージへ配置する。
+COPY --chown=appuser:appgroup .github/workflows/ci.yml ./.github/workflows/ci.yml
 
 # デフォルトコマンド: テスト実行
 # カバレッジ scope は CI 品質ゲート (--cov=utils --cov=config --cov=models) と統一

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "pytest-xdist>=3.5.0",
     "pytest-socket>=0.8.0,<0.9",     # unit層のネットワーク構造的分離
+    "defusedxml>=0.7.1",              # CI JUnit XML parsing
     "genbadge[coverage]==1.1.3",  # Coverage badge生成（Q19 C3: uv.lock管理）
     "respx>=0.23.1",            # httpx用モックライブラリ
     "socksio>=1.0.0",           # SOCKS5 proxy support for httpx

--- a/scripts/render_test_summary.py
+++ b/scripts/render_test_summary.py
@@ -9,6 +9,8 @@ from typing import Any
 
 from defusedxml import ElementTree  # type: ignore[import-untyped]
 
+__all__ = ["main", "render_junit_summary"]
+
 MAX_IDENTIFIER_LENGTH = 300
 MAX_IDENTIFIERS_PER_CATEGORY = 20
 MAX_SUMMARY_BYTES = 64 * 1024
@@ -173,7 +175,17 @@ def _empty_summary(message: str) -> str:
 
 
 def render_junit_summary(xml_text: str) -> str:
-    """Return bounded Markdown for valid, empty, or invalid JUnit XML."""
+    """Return bounded Markdown for valid, empty, or invalid JUnit XML.
+
+    Args:
+        xml_text: JUnit XML content, or an empty string when no report was generated.
+
+    Returns:
+        Markdown bounded to MAX_SUMMARY_BYTES, suitable for a GitHub Job Summary.
+
+    Raises:
+        None. Malformed XML falls back to an "Unable to parse" summary instead of raising.
+    """
     if not xml_text.strip():
         return _empty_summary("No JUnit XML was generated.")
 
@@ -201,7 +213,19 @@ def render_junit_summary(xml_text: str) -> str:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Render the first XML path in ``argv`` without failing the CI job."""
+    """Render the first XML path in ``argv`` without failing the CI job.
+
+    Args:
+        argv: Command-line arguments; defaults to ``sys.argv[1:]`` when None.
+            The first element is the JUnit XML file path.
+
+    Returns:
+        Always 0. Missing, unreadable, or malformed input renders a fallback
+        summary instead of raising, so the CI job never fails on this step.
+
+    Raises:
+        None.
+    """
     arguments = list(sys.argv[1:] if argv is None else argv)
     if not arguments:
         print(_empty_summary("No JUnit XML was generated."))

--- a/scripts/render_test_summary.py
+++ b/scripts/render_test_summary.py
@@ -1,0 +1,221 @@
+"""Render safe, bounded Markdown from pytest's JUnit XML output."""
+
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from html import escape
+from pathlib import Path
+from typing import Any
+
+from defusedxml import ElementTree  # type: ignore[import-untyped]
+
+MAX_IDENTIFIER_LENGTH = 300
+MAX_IDENTIFIERS_PER_CATEGORY = 20
+MAX_SUMMARY_BYTES = 64 * 1024
+TRUNCATION_MARKER = "… [truncated]"
+# Held back so the trailing omission line always fits within MAX_SUMMARY_BYTES.
+# Its longest form, "- NN identifier(s) omitted due to summary size.", is 46 bytes.
+OMISSION_LINE_RESERVE_BYTES = 96
+
+
+@dataclass
+class _SummaryStats:
+    total: int = 0
+    failures: int = 0
+    errors: int = 0
+    skipped: int = 0
+    duration: float = 0.0
+    failure_identifiers: list[str] = field(default_factory=list)
+    error_identifiers: list[str] = field(default_factory=list)
+
+
+def _local_name(element: Any) -> str:
+    return str(element.tag).rsplit("}", 1)[-1]
+
+
+def _count_attribute(element: Any, name: str) -> int | None:
+    value = element.attrib.get(name)
+    if value is None:
+        return None
+    try:
+        return max(int(float(value)), 0)
+    except TypeError:
+        return 0
+    except ValueError:
+        return 0
+
+
+def _duration_attribute(element: Any) -> float:
+    value = element.attrib.get("time", "0")
+    try:
+        return max(float(value), 0.0)
+    except TypeError:
+        return 0.0
+    except ValueError:
+        return 0.0
+
+
+def _test_cases(suite: Any) -> list[Any]:
+    return [element for element in suite.iter() if _local_name(element) == "testcase"]
+
+
+def _case_state(case: Any) -> str:
+    child_names = {_local_name(child) for child in case}
+    if "failure" in child_names:
+        return "failure"
+    if "error" in child_names:
+        return "error"
+    if "skipped" in child_names:
+        return "skipped"
+    return "passed"
+
+
+def _escape_for_summary(text: str) -> str:
+    """Escape for HTML and neutralize Markdown link syntax.
+
+    GitHub Flavored Markdown keeps parsing Markdown inside raw inline HTML,
+    so wrapping a value in ``<code>`` does not stop ``[label](url)`` from
+    becoming a live link. ``html.escape`` leaves brackets untouched, so the
+    brackets are replaced with numeric character references; they render back
+    as literal ``[`` and ``]`` without reopening link syntax.
+    """
+    return escape(text, quote=True).replace("[", "&#91;").replace("]", "&#93;")
+
+
+def _identifier(case: Any) -> str:
+    classname = str(case.attrib.get("classname", ""))
+    name = str(case.attrib.get("name", ""))
+    if classname and name:
+        value = f"{classname}::{name}"
+    else:
+        value = classname or name or "<unnamed test>"
+    escaped = _escape_for_summary(value[:MAX_IDENTIFIER_LENGTH])
+    if len(value) <= MAX_IDENTIFIER_LENGTH and len(escaped) <= MAX_IDENTIFIER_LENGTH:
+        return escaped
+
+    budget = MAX_IDENTIFIER_LENGTH - len(TRUNCATION_MARKER)
+    prefix = value[:MAX_IDENTIFIER_LENGTH]
+    while len(_escape_for_summary(prefix)) > budget:
+        prefix = prefix[:-1]
+    return f"{_escape_for_summary(prefix)}{TRUNCATION_MARKER}"
+
+
+def _collect_stats(root: Any) -> _SummaryStats:
+    if _local_name(root) == "testsuite":
+        suites = [root]
+    else:
+        suites = [element for element in root if _local_name(element) == "testsuite"]
+        if not suites:
+            suites = [root]
+
+    stats = _SummaryStats()
+    for suite in suites:
+        cases = _test_cases(suite)
+        fallback_counts = {state: 0 for state in ("passed", "failure", "error", "skipped")}
+        for case in cases:
+            state = _case_state(case)
+            fallback_counts[state] += 1
+            if state == "failure":
+                stats.failure_identifiers.append(_identifier(case))
+            elif state == "error":
+                stats.error_identifiers.append(_identifier(case))
+
+        tests = _count_attribute(suite, "tests")
+        failures = _count_attribute(suite, "failures")
+        errors = _count_attribute(suite, "errors")
+        skipped = _count_attribute(suite, "skipped")
+        stats.total += tests if tests is not None else len(cases)
+        if failures is None:
+            failures = fallback_counts["failure"]
+        if errors is None:
+            errors = fallback_counts["error"]
+        if skipped is None:
+            skipped = fallback_counts["skipped"]
+        stats.failures += failures
+        stats.errors += errors
+        stats.skipped += skipped
+        stats.duration += _duration_attribute(suite)
+
+    return stats
+
+
+def _byte_length(lines: list[str]) -> int:
+    return len(("\n".join(lines) + "\n").encode("utf-8"))
+
+
+def _identifier_sections(stats: _SummaryStats, lines: list[str]) -> list[str]:
+    categories = (
+        ("Failed", stats.failure_identifiers),
+        ("Errors", stats.error_identifiers),
+    )
+    for title, identifiers in categories:
+        if not identifiers:
+            continue
+        lines.append(f"### {title} identifiers")
+        count_omitted = max(len(identifiers) - MAX_IDENTIFIERS_PER_CATEGORY, 0)
+        byte_omitted = 0
+        for identifier in identifiers[:MAX_IDENTIFIERS_PER_CATEGORY]:
+            item = f"- <code>{identifier}</code>"
+            reserve = OMISSION_LINE_RESERVE_BYTES if count_omitted or byte_omitted else 0
+            if _byte_length(lines + [item]) + reserve <= MAX_SUMMARY_BYTES:
+                lines.append(item)
+            else:
+                byte_omitted += 1
+        total_omitted = count_omitted + byte_omitted
+        if total_omitted:
+            suffix = " due to summary size" if byte_omitted else ""
+            lines.append(f"- {total_omitted} identifier(s) omitted{suffix}.")
+    return lines
+
+
+def _empty_summary(message: str) -> str:
+    return f"## Test Results\n\n{message}"
+
+
+def render_junit_summary(xml_text: str) -> str:
+    """Return bounded Markdown for valid, empty, or invalid JUnit XML."""
+    if not xml_text.strip():
+        return _empty_summary("No JUnit XML was generated.")
+
+    try:
+        root = ElementTree.fromstring(xml_text)
+        stats = _collect_stats(root)
+    except Exception:  # noqa: BLE001 - summary rendering must never fail CI
+        return _empty_summary("Unable to parse JUnit XML.")
+
+    passed = max(stats.total - stats.failures - stats.errors - stats.skipped, 0)
+    lines = [
+        "## Test Results",
+        "",
+        f"- Total: {stats.total}",
+        f"- Passed: {passed}",
+        f"- Failed: {stats.failures}",
+        f"- Errors: {stats.errors}",
+        f"- Skipped: {stats.skipped}",
+        f"- Duration: {stats.duration:.2f}s",
+    ]
+    if stats.total == 0:
+        lines.extend(["", "No tests were recorded."])
+    _identifier_sections(stats, lines)
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Render the first XML path in ``argv`` without failing the CI job."""
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if not arguments:
+        print(_empty_summary("No JUnit XML was generated."))
+        return 0
+
+    try:
+        xml_text = Path(arguments[0]).read_text(encoding="utf-8")
+    except OSError:
+        xml_text = ""
+    except UnicodeError:
+        xml_text = ""
+    print(render_junit_summary(xml_text))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_ci_workflow_contract.py
+++ b/tests/unit/test_ci_workflow_contract.py
@@ -1,0 +1,74 @@
+"""Static contracts for the Issue #552 CI workflow changes."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml  # type: ignore[import-untyped]
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def workflow_data() -> dict[str, Any]:
+    workflow_path = Path(__file__).parents[2] / ".github/workflows/ci.yml"
+    data = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def test_pr_validation_main_pytest_emits_junit_xml(workflow_data: dict[str, Any]) -> None:
+    steps = workflow_data["jobs"]["pr-validation"]["steps"]
+    test_step = next(
+        step for step in steps if step.get("name") == "Run tests (unit + integration + smoke)"
+    )
+    run = test_step["run"]
+
+    main_pytest = run.split("# Step 2:", 1)[0]
+    assert "uv run pytest" in main_pytest
+    assert "--junitxml=reports/junit.xml" in main_pytest
+    assert run.count("--junitxml=reports/junit.xml") == 1
+
+    upload_step = next(step for step in steps if step.get("name") == "Upload test results")
+    assert upload_step["if"] == "always()"
+    assert "reports/" in upload_step["with"]["path"]
+    assert upload_step["with"]["name"] == "pr-validation-results-py3.14"
+
+
+def test_renderer_step_runs_always_after_pytest(workflow_data: dict[str, Any]) -> None:
+    steps = workflow_data["jobs"]["pr-validation"]["steps"]
+    renderer_index = next(
+        index for index, step in enumerate(steps) if "render_test_summary.py" in step.get("run", "")
+    )
+    pytest_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Run tests (unit + integration + smoke)"
+    )
+
+    assert steps[renderer_index]["if"] == "always()"
+    assert "reports/junit.xml" in steps[renderer_index]["run"]
+    # Rendering before pytest would silently produce an empty summary.
+    assert pytest_index < renderer_index
+
+
+def test_status_report_summary_and_pr_coverage_contract(
+    workflow_data: dict[str, Any],
+) -> None:
+    assert "pr-validation" in workflow_data["jobs"]["status-report"]["needs"]
+
+    steps = workflow_data["jobs"]["status-report"]["steps"]
+    summary_step = next(
+        step for step in steps if step.get("name") == "Append status report to Job Summary"
+    )
+    run = summary_step["run"]
+
+    assert summary_step["if"] == "always()"
+    assert summary_step["env"]["EVENT_NAME"] == "${{ github.event_name }}"
+    assert 'cat status_report.md >> "$GITHUB_STEP_SUMMARY"' in run
+    assert 'coverage_file="artifacts/pr-validation-results-py3.14/coverage.json"' in run
+    assert 'if [ "$EVENT_NAME" = "pull_request" ] && [ -f "$coverage_file" ]; then' in run
+    assert (
+        run.count('echo "Coverage: n/a (not generated for this trigger)" >> "$GITHUB_STEP_SUMMARY"')
+        == 2
+    )

--- a/tests/unit/test_ci_workflow_contract.py
+++ b/tests/unit/test_ci_workflow_contract.py
@@ -1,6 +1,5 @@
 """Static contracts for the Issue #552 CI workflow changes."""
 
-from pathlib import Path
 from typing import Any
 
 import pytest
@@ -10,8 +9,9 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.fixture
-def workflow_data() -> dict[str, Any]:
-    workflow_path = Path(__file__).parents[2] / ".github/workflows/ci.yml"
+def workflow_data(request: pytest.FixtureRequest) -> dict[str, Any]:
+    """pytest rootpath 基準で解決し、テストファイル移動によるパス破損を防ぐ。"""
+    workflow_path = request.config.rootpath / ".github/workflows/ci.yml"
     data = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
     assert isinstance(data, dict)
     return data

--- a/tests/unit/test_render_test_summary.py
+++ b/tests/unit/test_render_test_summary.py
@@ -1,0 +1,194 @@
+"""Tests for the JUnit XML to Job Summary renderer."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.render_test_summary import main, render_junit_summary
+
+pytestmark = pytest.mark.unit
+
+
+def test_render_junit_summary_reports_passed_failed_errors_and_skipped() -> None:
+    xml = """
+    <testsuites>
+      <testsuite tests="4" failures="1" errors="1" skipped="1" time="1.25">
+        <testcase classname="tests.unit.test_ok" name="test_ok" />
+        <testcase classname="tests.unit.test_failure" name="test_failure">
+          <failure message="secret failure message">secret traceback</failure>
+        </testcase>
+        <testcase classname="tests.unit.test_error" name="test_error">
+          <error message="secret error message">secret traceback</error>
+        </testcase>
+        <testcase classname="tests.unit.test_skip" name="test_skip">
+          <skipped message="secret skip message" />
+        </testcase>
+      </testsuite>
+    </testsuites>
+    """
+
+    summary = render_junit_summary(xml)
+
+    assert "- Total: 4" in summary
+    assert "- Passed: 1" in summary
+    assert "- Failed: 1" in summary
+    assert "- Errors: 1" in summary
+    assert "- Skipped: 1" in summary
+    assert "- Duration: 1.25s" in summary
+    assert "<code>tests.unit.test_failure::test_failure</code>" in summary
+    assert "<code>tests.unit.test_error::test_error</code>" in summary
+    assert "secret" not in summary
+    assert "traceback" not in summary
+
+
+def test_render_junit_summary_aggregates_multiple_suites_and_keeps_errors_separate() -> None:
+    xml = """
+    <testsuites>
+      <testsuite tests="2" failures="0" errors="1" skipped="0" time="0.50">
+        <testcase classname="tests.unit.test_setup" name="setup">
+          <error>setup traceback</error>
+        </testcase>
+        <testcase classname="tests.unit.test_pass" name="test_pass" />
+      </testsuite>
+      <testsuite tests="2" failures="1" errors="1" skipped="0" time="0.75">
+        <testcase classname="tests.unit.test_teardown" name="teardown">
+          <error>teardown traceback</error>
+        </testcase>
+        <testcase classname="tests.unit.test_failure" name="test_failure">
+          <failure>failure traceback</failure>
+        </testcase>
+      </testsuite>
+    </testsuites>
+    """
+
+    summary = render_junit_summary(xml)
+
+    assert "- Total: 4" in summary
+    assert "- Passed: 1" in summary
+    assert "- Failed: 1" in summary
+    assert "- Errors: 2" in summary
+    assert "- Skipped: 0" in summary
+    assert "- Duration: 1.25s" in summary
+    assert "<code>tests.unit.test_setup::setup</code>" in summary
+    assert "<code>tests.unit.test_teardown::teardown</code>" in summary
+    assert "<code>tests.unit.test_failure::test_failure</code>" in summary
+    assert "traceback" not in summary
+
+
+def test_render_junit_summary_escapes_only_failure_and_error_identifiers() -> None:
+    xml = """
+    <testsuites>
+      <testsuite tests="2" failures="1" errors="1" skipped="0">
+        <testcase classname="pkg&lt;script&gt;" name="test&amp;bad&quot;id">
+          <failure message="do not render">do not render</failure>
+          <system-out>captured output</system-out>
+          <system-err>captured error</system-err>
+        </testcase>
+        <testcase classname="pkg" name="test'error">
+          <error message="do not render">do not render</error>
+        </testcase>
+      </testsuite>
+    </testsuites>
+    """
+
+    summary = render_junit_summary(xml)
+
+    assert "<code>pkg&lt;script&gt;::test&amp;bad&quot;id</code>" in summary
+    assert "<code>pkg::test&#x27;error</code>" in summary
+    assert "captured" not in summary
+    assert "do not render" not in summary
+
+
+def test_render_junit_summary_neutralizes_markdown_link_syntax() -> None:
+    # GFM parses Markdown inside raw inline HTML, so <code> alone lets a
+    # fork-authored identifier such as [label](url) render as a live link.
+    xml = """
+    <testsuites>
+      <testsuite tests="1" failures="1" errors="0" skipped="0">
+        <testcase classname="pkg" name="test_[click_here](https://evil.example)">
+          <failure message="x">x</failure>
+        </testcase>
+      </testsuite>
+    </testsuites>
+    """
+
+    summary = render_junit_summary(xml)
+
+    assert "&#91;click_here&#93;" in summary
+    assert "[click_here]" not in summary
+
+
+def test_render_junit_summary_handles_empty_and_invalid_xml() -> None:
+    empty_summary = render_junit_summary("")
+    invalid_summary = render_junit_summary("<testsuites>")
+
+    assert "No JUnit XML was generated." in empty_summary
+    assert "Unable to parse JUnit XML." in invalid_summary
+
+
+def test_render_junit_summary_limits_identifier_count_and_length() -> None:
+    cases = "".join(
+        f'<testcase classname="pkg" name="{("'x" * 175) + str(index)}"><failure /></testcase>'
+        for index in range(25)
+    )
+    xml = f'<testsuites><testsuite tests="25" failures="25">{cases}</testsuite></testsuites>'
+
+    summary = render_junit_summary(xml)
+
+    assert summary.count("<code>") == 20
+    assert "5 identifier(s) omitted." in summary
+    assert "… [truncated]" in summary
+    code_values = [
+        line.split("<code>", 1)[1].split("</code>", 1)[0]
+        for line in summary.splitlines()
+        if "<code>" in line
+    ]
+    assert all(len(value) <= 300 for value in code_values)
+
+
+def test_render_junit_summary_applies_utf8_summary_limit() -> None:
+    apostrophe = "'"
+    failed_cases = "".join(
+        f'<testcase classname="pkg" name="{apostrophe * 300}{index}"><failure /></testcase>'
+        for index in range(20)
+    )
+    error_cases = "".join(
+        f'<testcase classname="pkg" name="{apostrophe * 300}{index}"><error /></testcase>'
+        for index in range(20)
+    )
+    xml = (
+        '<testsuites><testsuite tests="40" failures="20" errors="20">'
+        f"{failed_cases}{error_cases}"
+        "</testsuite></testsuites>"
+    )
+
+    summary = render_junit_summary(xml)
+
+    assert len(summary.encode("utf-8")) <= 64 * 1024
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        '<testsuites><testsuite tests="0" /></testsuites>',
+        "",
+        "<testsuites>",
+        "<not-junit />",
+    ],
+    ids=["valid", "empty", "malformed", "empty-result"],
+)
+def test_main_returns_zero_for_non_renderable_xml(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], content: str
+) -> None:
+    xml_path = tmp_path / "junit.xml"
+    xml_path.write_text(content, encoding="utf-8")
+
+    assert main([str(xml_path)]) == 0
+    assert capsys.readouterr().out
+
+
+def test_main_returns_zero_for_missing_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main([str(tmp_path / "missing.xml")]) == 0
+    assert "No JUnit XML was generated." in capsys.readouterr().out

--- a/uv.lock
+++ b/uv.lock
@@ -49,6 +49,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "bandit" },
+    { name = "defusedxml" },
     { name = "genbadge", extra = ["coverage"] },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -77,6 +78,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "bandit", specifier = ">=1.8.6" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "genbadge", extras = ["coverage"], specifier = "==1.1.3" },
     { name = "mypy", specifier = ">=2.3.0,<3.0.0" },
     { name = "pre-commit", specifier = ">=4.6.1" },


### PR DESCRIPTION
## 概要
CI実行結果（pytest数・カバレッジ・失敗箇所）をGitHub Job Summaryへ可視化する。ログ全文を読まなくてもPR上で結果を確認できるようにする。

## 変更内容
- `.github/workflows/ci.yml`: pytestにjunitxml出力を追加し、レンダリングステップを追加
- `scripts/render_test_summary.py`: JUnit XMLをパースしGitHub Job Summary向けMarkdownを生成（フォークPR由来の値に対するMarkdown/リンクインジェクション対策のエスケープ処理含む）
- `tests/unit/test_render_test_summary.py`, `tests/unit/test_ci_workflow_contract.py`: 上記の単体テスト・ワークフロー契約テストを追加
- `pyproject.toml` / `uv.lock`: JUnit XML解析用に `defusedxml` を追加

## テスト
- [x] `pytest -n auto -m "(unit or integration) and not external"`: 1459 passed / 97.60% coverage
- [x] `ruff check .`: 0 errors
- [x] `mypy utils/ config/ models/ tests/conftest.py`: 0 errors
- [ ] CI/CD パイプライン確認

## 関連Issue/PR
Closes #552 (Issue)

---
このPRは /push-pr スキルで自動生成されました。