### PR TITLE
security(ci): zizmor High検出をfail-closedゲート化

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -48,9 +48,9 @@ docs/
 !README.md
 
 # CI/CD（1MB削減）
+# 例外を設けない: .github/ を読む静的契約テストは repo_contract マーカーで
+# コンテナ実行から除外済み（Dockerfile test ステージのコメント参照）
 .github/
-# ci.yml は tests/unit/test_ci_workflow_contract.py が読み込むため test ステージへ渡す
-!.github/workflows/ci.yml
 .gitlab-ci.yml
 .circleci/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,12 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev --frozen
 
+      - name: Show zizmor version
+        run: uv run --frozen --no-sync zizmor --version
+
+      - name: Run zizmor High-severity gate
+        run: uv run --frozen --no-sync zizmor --offline --no-config --strict-collection --persona=regular --min-severity=high --format=github .github/workflows .github/actions
+
       # ruff を mypy より先に実行: lint 問題を先に除去し mypy の誤検知を低減（実行順設計）
       - name: Run ruff check
         run: uv run ruff check .

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,12 +118,10 @@ COPY --chown=appuser:appgroup utils/ ./utils/
 COPY --chown=appuser:appgroup models/ ./models/
 COPY --chown=appuser:appgroup scripts/ ./scripts/
 COPY --chown=appuser:appgroup tests/ ./tests/
-# docker-compose.yml は tests/unit/test_docker_compose_contract.py が
-# request.config.rootpath / "docker-compose.yml" で読み込むため、test ステージへ配置する。
-COPY --chown=appuser:appgroup docker-compose.yml ./
-# ci.yml は tests/unit/test_ci_workflow_contract.py が
-# request.config.rootpath / ".github/workflows/ci.yml" で読み込むため、test ステージへ配置する。
-COPY --chown=appuser:appgroup .github/workflows/ci.yml ./.github/workflows/ci.yml
+# リポジトリメタデータ (docker-compose.yml / .github/) は意図的に配置しない。
+# それらを読む静的契約テストは repo_contract マーカーでコンテナ実行から除外され、
+# 全リポジトリツリーを持つホスト (CI: pr-validation) 側でのみ実行される。
+# 部分的に COPY するとフィルタ済みツリーを全体と誤認し、検査 0 件で無音合格しうる。
 
 # デフォルトコマンド: テスト実行
 # カバレッジ scope は CI 品質ゲート (--cov=utils --cov=config --cov=models) と統一

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,10 @@ services:
       COVERAGE_FILE: /tmp/.coverage
     # Dockerfile CMD を上書き。pyproject.toml の addopts (--cov=utils --cov=config --cov=models 等)
     # および --cov-fail-under=85 は継承されるため、command 側では重複指定しない
-    command: ["pytest", "-m", "(unit or integration) and not external"]
+    # repo_contract はリポジトリ全体のツリーを前提とする静的契約テスト。test イメージは
+    # .dockerignore でツリーを絞るため、ここで除外しホスト実行 (CI: pr-validation) に一本化する
+    command:
+      ["pytest", "-m", "(unit or integration) and not external and not repo_contract"]
     # カバレッジ成果物を host に永続化（htmlcov / coverage.xml）
     volumes:
       - ./reports:/app/reports

--- a/docs/reference/ci_cd_pipeline.md
+++ b/docs/reference/ci_cd_pipeline.md
@@ -188,6 +188,18 @@ uv run pytest -n auto -m "(unit or integration) and not external" \
 | mypy | 0 errors | `mypy utils/ config/ models/ tests/conftest.py` |
 | セキュリティ | 0 Critical/High | Trivy SARIF |
 
+### zizmor GitHub Actionsゲート
+
+ローカル再現時は、CIのsource of truthである `.github/workflows/ci.yml` と同じく、先にdev依存をlockfileどおり同期します。
+
+```bash
+uv sync --dev --frozen
+uv run --frozen --no-sync zizmor --version
+uv run --frozen --no-sync zizmor --offline --no-config --strict-collection --persona=regular --min-severity=high --format=github .github/workflows .github/actions
+```
+
+`--offline` は監査中のネットワークアクセスを禁止し、`--no-config` はリポジトリ設定によるseverity remapを無効化します。`--strict-collection` は指定対象を厳格に収集し、`--min-severity=high` は High 以上の検出をゲートにします。zizmorにはGitHubトークンを渡しません。
+
 ### CD（実装済み）
 
 main push時に以下3ジョブが実行され、Continuous Delivery（成果物の配信・検証）を完結します：

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "socksio>=1.0.0",           # SOCKS5 proxy support for httpx
     # 品質管理
     "ruff>=0.16.1,<0.17",       # pre-commit frozen: v0.15.11（.pre-commit-config.yaml参照）
+    "zizmor==1.29.0",
     "mypy>=2.3.0,<3.0.0",
     "bandit>=1.8.6",
     "safety>=3.8.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ markers = [
     "slow: Slow tests (>3s, excluded from local dev)",
     "external: External API tests (weekly CI only)",
     "smoke: Smoke tests (basic functionality)",
+    "repo_contract: Repository-static contract tests (require the full repo tree; host-only)",
 ]
 asyncio_mode = "auto"            # 非同期テスト自動検出
 

--- a/tests/unit/test_ci_workflow_contract.py
+++ b/tests/unit/test_ci_workflow_contract.py
@@ -5,7 +5,9 @@ from typing import Any
 import pytest
 import yaml  # type: ignore[import-untyped]
 
-pytestmark = pytest.mark.unit
+# repo_contract: request.config.rootpath 経由でリポジトリ全体を静的検査するため、
+# ビルドコンテキストが絞られた test コンテナでは走らせない（pyproject.toml の marker 定義参照）
+pytestmark = [pytest.mark.unit, pytest.mark.repo_contract]
 
 
 @pytest.fixture

--- a/tests/unit/test_ci_zizmor_gate_contract.py
+++ b/tests/unit/test_ci_zizmor_gate_contract.py
@@ -22,15 +22,18 @@ EXIT_CODE_SUPPRESSING_ARGS = ("--no-exit-codes", "--fix", "--format sarif")
 # 設定ファイル実在 / --no-config 脱落 の 4 経路すべてを塞ぐ必要がある。
 CONFIG_LOADING_ARGS = ("--config", "-c")
 
-# 監査 step の run に現れてはならないシェルのコマンド区切り。GitHub Actions の既定 shell は
-# `bash -e` で pipefail を含まないため、区切りが 1 つでも入ると最終コマンドの終了コードが
-# step の結果になり、zizmor の exit 11-14 が握り潰される。実測 (bash -e):
-#   `false | cat` / `false &` / `false ; true` / 改行 + `true` はいずれも exit 0 (= fail-open)
-#   一方 `false` 単体は -e の有無に関わらず exit 1 で、単一コマンドなら終了コードは必ず伝播する
-# `|| true` のような構文を列挙する denylist では `|| echo skipped` や `| tee log` といった
-# 未知の組み合わせを取りこぼすため、「区切り文字を 1 つも含まない」という閉じた文法条件で
-# 固定する。`||` は `|` に、`&&` は `&` に含まれる。単一コマンドのゲートでは && / || を
-# 併せて禁じても実害が無く、判定を単純に保てる。
+# 監査 step の run に現れてはならないシェルのコマンド区切り。GitHub Actions 公式ドキュメント
+# の通り、既定 shell (`bash --noprofile --norc -eo pipefail {0}`) は `-e` に加え `-o pipefail`
+# も適用する。実測 (bash -e -o pipefail、GitHub Actions の既定を再現):
+#   `false | cat` / `false | tee x` / `false ; true` / 改行 + `true` はいずれも exit 1 で安全。
+#   -e がパイプライン全体・逐次実行の失敗を検知するため、後続コマンドの成功で握り潰されない。
+#   唯一の真の fail-open は `false &`（バックグラウンド実行）で exit 0 になる。`-e` はバック
+#   グラウンドジョブの失敗を検知できないため、シェルオプションに関係なく握り潰される。
+# それでも `|` / `;` / 改行を禁止に含めるのは、上記の安全性が defaults.run.shell によるシェル
+# 上書き（test_audit_step_uses_default_shell で別途禁止）に依存する前提付きの安全性だから。
+# 「区切り文字を 1 つも含まない単一コマンド」という閉じた文法条件にしておけば、シェル上書き
+# ガードが将来欠けても、あるいは `|| echo skipped` のような未知の組み合わせが来ても、この
+# 契約テスト単体で防御が成立する。`||` は `|` に、`&&` は `&` に含まれるため個別列挙は不要。
 RUN_COMMAND_SEPARATORS = ("|", "&", ";", "\n")
 
 # ゲートの挙動を外部から変える環境変数。token 系は online audit を有効化してゲート結果を

--- a/tests/unit/test_ci_zizmor_gate_contract.py
+++ b/tests/unit/test_ci_zizmor_gate_contract.py
@@ -1,0 +1,296 @@
+"""ci.yml の zizmor fail-closed ゲートの運用契約テスト."""
+
+import re
+from typing import Any
+
+import pytest
+import yaml
+
+# Module-level marker: 外部プロセスを起動せず ci.yml の YAML 構造のみを検証するため unit。
+# このマーカーを欠くと CI の `-m "(unit or integration) and not external"` から漏れ、
+# ゲートを守るはずの本ファイル自身が無音で実行されなくなる。
+pytestmark = pytest.mark.unit
+
+# zizmor の非ゼロ終了 (exit 11-14) を無効化する引数。--no-exit-codes は zizmor --help の
+# "Disable all error codes besides success and tool failure"、--format sarif は findings を
+# SARIF へ流して終了コードを立てず、--fix は違反そのものを自動書き換えで消す。
+EXIT_CODE_SUPPRESSING_ARGS = ("--no-exit-codes", "--fix", "--format sarif")
+
+# 監査設定を差し込み severity を remap しうる引数。zizmor 1.29.0 は git リポジトリ内では
+# リポジトリルートと .github/ から zizmor.yml を自動探索する (非 git ディレクトリでは発火せず、
+# ここを取り違えると「設定は読まれない」という誤った結論になる)。よって --config / ZIZMOR_CONFIG /
+# 設定ファイル実在 / --no-config 脱落 の 4 経路すべてを塞ぐ必要がある。
+CONFIG_LOADING_ARGS = ("--config", "-c")
+
+# 監査 step の run に現れてはならないシェルのコマンド区切り。GitHub Actions の既定 shell は
+# `bash -e` で pipefail を含まないため、区切りが 1 つでも入ると最終コマンドの終了コードが
+# step の結果になり、zizmor の exit 11-14 が握り潰される。実測 (bash -e):
+#   `false | cat` / `false &` / `false ; true` / 改行 + `true` はいずれも exit 0 (= fail-open)
+#   一方 `false` 単体は -e の有無に関わらず exit 1 で、単一コマンドなら終了コードは必ず伝播する
+# `|| true` のような構文を列挙する denylist では `|| echo skipped` や `| tee log` といった
+# 未知の組み合わせを取りこぼすため、「区切り文字を 1 つも含まない」という閉じた文法条件で
+# 固定する。`||` は `|` に、`&&` は `&` に含まれる。単一コマンドのゲートでは && / || を
+# 併せて禁じても実害が無く、判定を単純に保てる。
+RUN_COMMAND_SEPARATORS = ("|", "&", ";", "\n")
+
+# ゲートの挙動を外部から変える環境変数。token 系は online audit を有効化してゲート結果を
+# ネットワーク状態に依存させ、ZIZMOR_CONFIG は severity remap を注入する。
+FORBIDDEN_ENV_NAMES = ("GH_TOKEN", "GITHUB_TOKEN", "ZIZMOR_GITHUB_TOKEN", "ZIZMOR_CONFIG")
+
+# ci.yml は --no-config で自動探索を止めているが、そのフラグが外れた瞬間に remap が効く。
+# 設定ファイルの不在を独立に固定し、フラグ脱落と設定ファイル追加の二重防御にする。
+# 網羅範囲は zizmor 1.29.0 で実測済み。High 検出 1 件 (exit 14) の workflow に対し
+# severity remap を仕込むと、root と .github/ は exit 0 に反転する (= 攻撃経路)。
+# 一方 .github/workflows/ は --strict-collection が workflow として収集を試みて exit 1
+# (fail-closed)、.github/actions/ は探索対象外で exit 14 のまま。下の 4 パスで過不足ない。
+ZIZMOR_CONFIG_PATHS = ("zizmor.yml", "zizmor.yaml", ".github/zizmor.yml", ".github/zizmor.yaml")
+
+# 監査 step に固定するフラグ。--no-config と --strict-collection は脱落が実測で fail-open に
+# なる (前者は zizmor.yml 自動探索が復活して severity remap を許し、後者は解析不能ファイルが
+# 混在すると exit 0 に落ちる)。残り 3 つは脱落しても fail-open にはならないが、ゲートの契約
+# そのものなので無断改変を落とす。
+REQUIRED_AUDIT_ARGS = (
+    "--offline",
+    "--no-config",
+    "--strict-collection",
+    "--persona regular",
+    "--min-severity high",
+)
+
+# 監査対象パス。片方が外れると .github/actions 配下の composite action が無検査で通る。
+REQUIRED_AUDIT_PATHS = (".github/workflows", ".github/actions")
+
+# ゲートが所属すべき job。PR をブロックする required status check はこの job だけ。
+AUDIT_JOB = "pr-validation"
+
+# job-level if はゲートの実行条件そのもの。GitHub は skip された job を required check の
+# 成功として扱うため、条件を改変すれば「PR は緑のまま監査ゼロ」が成立する。値ごと固定する。
+AUDIT_JOB_IF = "github.event_name == 'pull_request'"
+
+# zizmor 公式の抑止コメント (docs/usage.md)。監査される側の workflow 行に置くだけで、
+# ci.yml も設定ファイルも変更せずに個別の High 検出を消せる (実測 exit 14 → 0)。
+# Issue #557 が定義する 4 層 (Actions / Shell / Tool / Config) のいずれにも該当しない第 5 の
+# 経路であり、ゲート step の文字列一致では原理的に見えない。
+# `zizmor:ignore` (空白なし) は zizmor に認識されない (実測 exit 14) が、検出漏れより
+# 過検出のほうが安全なため両形式にマッチさせる。
+INLINE_IGNORE_PATTERN = re.compile(r"zizmor:\s*ignore")
+
+
+def _normalize(run: str) -> str:
+    """`--flag=value` と `--flag value` を同一視する。
+
+    両形式とも zizmor が受け付けるため、= 形式だけを見る素朴な部分文字列判定は
+    `--format sarif` を取りこぼしてゲート無効化を素通しする。
+    末尾に空白を足し、最終トークンの引数名も境界付きで判定できるようにする。
+    """
+    return " ".join(run.replace("=", " ").split()) + " "
+
+
+class TestZizmorGateContract:
+    @pytest.fixture
+    def ci_workflow(self, request: pytest.FixtureRequest) -> dict[str, Any]:
+        """pytest rootpath 基準で解決し、テストファイル移動によるパス破損を防ぐ。"""
+        ci_path = request.config.rootpath / ".github" / "workflows" / "ci.yml"
+        data = yaml.safe_load(ci_path.read_text(encoding="utf-8"))
+        assert isinstance(data, dict), f"ci.yml の構造が不正: type={type(data)}, path={ci_path}"
+        assert isinstance(data.get("jobs"), dict), f"ci.yml に jobs が無い: path={ci_path}"
+        return data
+
+    @pytest.fixture
+    def audit_steps(self, ci_workflow: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+        """zizmor で実監査を行う step を (job名, step) で返す。--version 表示 step は除く。"""
+        return [
+            (job_name, step)
+            for job_name, job in ci_workflow["jobs"].items()
+            for step in job.get("steps", [])
+            if "zizmor" in step.get("run", "") and "--version" not in step.get("run", "")
+        ]
+
+    def test_audit_step_exists(self, audit_steps: list[tuple[str, dict[str, Any]]]) -> None:
+        """他の不在 assert が空集合に対して vacuous pass するのを防ぐアンカー。
+
+        ゲート step の削除・改名・composite action への移動・zizmor 呼び出しの変数化を
+        ここで落とす。step の本数ではなく「監査が1件以上ある」を固定するため、
+        step 追加では壊れない。
+        """
+        assert audit_steps, (
+            "ci.yml に zizmor の監査 step が存在しない。"
+            "ゲートが削除されたか、run から zizmor 呼び出しが消えている。"
+        )
+
+    def test_audit_step_has_no_fail_open(
+        self, audit_steps: list[tuple[str, dict[str, Any]]]
+    ) -> None:
+        """step 層の fail-open (continue-on-error / if / shell 握り潰し / 終了コード抑止) を禁じる。
+
+        step-level if はゲートを無音でスキップさせる純粋なキルスイッチで、正当な用途が無い。
+        job-level if は PR 限定実行という本来の役割を持つため、ここではなく
+        test_audit_job_if_condition_is_pinned で値ごと固定する。
+
+        shell 層は「区切り文字ゼロの単一コマンド」を要求することで塞ぐ。zizmor 以外の
+        コマンドが step に存在しなければ、終了コードを決めるのは zizmor しか残らない。
+        """
+        for job_name, step in audit_steps:
+            where = f"{job_name} / {step.get('name')!r}"
+            assert "continue-on-error" not in step, f"{where}: continue-on-error でゲートが無効化"
+            assert "if" not in step, f"{where}: step-level if でゲートが無音スキップされる"
+
+            run = step["run"].strip()
+            for separator in RUN_COMMAND_SEPARATORS:
+                assert separator not in run, (
+                    f"{where}: run に区切り {separator!r} があり、単一コマンドではない。"
+                    "zizmor の終了コードが step の結果になることを保証できない "
+                    "(`&&` のように実際は伝播する区切りも含めて一律禁止している。"
+                    "例外を設けると判定が『安全な組み合わせの列挙』に戻り、"
+                    "`| tee` や `|| echo` のような未知の組み合わせを取りこぼすため)"
+                )
+
+            normalized = _normalize(run)
+            for arg in EXIT_CODE_SUPPRESSING_ARGS:
+                assert arg not in normalized, f"{where}: {arg} が zizmor の終了コードを抑止する"
+
+    def test_audit_step_uses_default_shell(
+        self,
+        ci_workflow: dict[str, Any],
+        audit_steps: list[tuple[str, dict[str, Any]]],
+    ) -> None:
+        """既定 shell を固定する。単一コマンドの終了コード伝播が既定挙動に依るため。
+
+        カスタム shell は `command [options] {0} [more_options]` というテンプレートで、
+        runner が {0} を一時スクリプトのパスに置換して実行する (GitHub 公式 workflow syntax)。
+        つまり run を 1 文字も変えずに、shell 側だけで終了コードを握り潰す余地がある。
+        さらに shell は workflow / job の defaults.run 経由でも上書きでき、その場合 step を
+        見ても気付けない。env と同じく 3 階層すべてで未設定を固定する。
+        """
+        for job_name, step in audit_steps:
+            where = f"{job_name} / {step.get('name')!r}"
+            defaults_sources = (
+                ("workflow の defaults.run", ci_workflow.get("defaults")),
+                ("job の defaults.run", ci_workflow["jobs"][job_name].get("defaults")),
+            )
+            for label, defaults in defaults_sources:
+                shell = ((defaults or {}).get("run") or {}).get("shell")
+                assert shell is None, f"{where}: {label} で shell が {shell!r} に上書きされている"
+            assert "shell" not in step, (
+                f"{where}: step で shell が {step.get('shell')!r} に上書きされている。"
+                f"カスタム shell は run を変えずに終了コードを握り潰せる"
+            )
+
+    def test_audit_step_loads_no_external_config(
+        self, audit_steps: list[tuple[str, dict[str, Any]]]
+    ) -> None:
+        """設定ファイルの読み込みを禁じる。severity remap で high 検出を exit 0 に落とせるため。"""
+        for job_name, step in audit_steps:
+            normalized = _normalize(step["run"])
+            for arg in CONFIG_LOADING_ARGS:
+                assert f"{arg} " not in normalized, (
+                    f"{job_name} / {step.get('name')!r}: {arg} で severity remap を注入可能"
+                )
+
+    def test_audit_job_has_no_fail_open(
+        self,
+        ci_workflow: dict[str, Any],
+        audit_steps: list[tuple[str, dict[str, Any]]],
+    ) -> None:
+        """job 層の continue-on-error を禁じる。
+
+        step 側が健全でも、job に1行足すだけでゲート全体が非ブロッキング化するため分けて固定する。
+        """
+        for job_name in {job_name for job_name, _ in audit_steps}:
+            assert "continue-on-error" not in ci_workflow["jobs"][job_name], (
+                f"{job_name}: job レベル continue-on-error でゲート全体が非ブロッキング化"
+            )
+
+    def test_audit_step_env_is_clean(
+        self,
+        ci_workflow: dict[str, Any],
+        audit_steps: list[tuple[str, dict[str, Any]]],
+    ) -> None:
+        """workflow / job / step の 3 階層すべてで禁止環境変数と --gh-token を塞ぐ。
+
+        workflow レベル env は全 step へ伝播するため、step だけ見ると注入を見逃す。
+        """
+        workflow_env = set(ci_workflow.get("env") or {})
+        for job_name, step in audit_steps:
+            where = f"{job_name} / {step.get('name')!r}"
+            env_keys = (
+                workflow_env
+                | set(ci_workflow["jobs"][job_name].get("env") or {})
+                | set(step.get("env") or {})
+            )
+            for name in FORBIDDEN_ENV_NAMES:
+                assert name not in env_keys, f"{where}: env に {name} が注入されている"
+            assert "--gh-token" not in step["run"], f"{where}: --gh-token が渡されている"
+
+    def test_audit_step_runs_in_pr_validation(
+        self, audit_steps: list[tuple[str, dict[str, Any]]]
+    ) -> None:
+        """PR をブロックしない job への移設を禁じる。
+
+        required status check は pr-validation だけなので、同じ if を持つ新設 job へ
+        移すだけで「監査は走るが PR は止まらない」状態を作れる。
+        """
+        for job_name, step in audit_steps:
+            assert job_name == AUDIT_JOB, (
+                f"{job_name} / {step.get('name')!r}: 監査が {AUDIT_JOB} の外にある。"
+                f"required check 対象外の job では PR をブロックできない"
+            )
+
+    def test_audit_step_keeps_required_args(
+        self, audit_steps: list[tuple[str, dict[str, Any]]]
+    ) -> None:
+        """必須フラグと監査対象パスの脱落を禁じる."""
+        for job_name, step in audit_steps:
+            where = f"{job_name} / {step.get('name')!r}"
+            normalized = _normalize(step["run"])
+            for arg in REQUIRED_AUDIT_ARGS:
+                assert f"{arg} " in normalized, f"{where}: {arg} が欠落している"
+            for path in REQUIRED_AUDIT_PATHS:
+                assert f"{path} " in normalized, f"{where}: 監査対象 {path} が外れている"
+
+    def test_audit_job_if_condition_is_pinned(
+        self,
+        ci_workflow: dict[str, Any],
+        audit_steps: list[tuple[str, dict[str, Any]]],
+    ) -> None:
+        """job-level if の改変を禁じる。
+
+        `&& false` の連結や schedule への差し替えで job ごと skip させると、GitHub は
+        skip を required check の成功として扱うため、PR は緑のまま監査が一度も走らない。
+        step 側の健全性では防げないので値ごと固定する。
+        """
+        for job_name in {job_name for job_name, _ in audit_steps}:
+            actual = ci_workflow["jobs"][job_name].get("if")
+            assert actual == AUDIT_JOB_IF, (
+                f"{job_name}: job-level if が {actual!r} に改変されている "
+                f"(期待: {AUDIT_JOB_IF!r})。job が skip されるとゲートが無音化する"
+            )
+
+    def test_audited_paths_have_no_inline_ignore(self, request: pytest.FixtureRequest) -> None:
+        """監査対象内のインライン抑止コメントを禁じる。
+
+        ゲート step 自体が健全でも、監査される側の workflow に 1 行足すだけで High 検出を
+        個別に消せる。step の文字列一致では原理的に見えないため独立して固定する。
+        検査範囲を REQUIRED_AUDIT_PATHS から導出し、監査対象の増減に追従させる。
+        """
+        found: list[str] = []
+        for audit_path in REQUIRED_AUDIT_PATHS:
+            root = request.config.rootpath / audit_path
+            targets = sorted(root.rglob("*.yml")) + sorted(root.rglob("*.yaml"))
+            # rglob は存在しないディレクトリでも例外を出さず空を返す。監査パスが改名・削除
+            # されると「0 件を検査して合格」という無音の骨抜きが成立するため件数を固定する。
+            assert targets, f"監査対象 {audit_path} に yaml が 1 件も無い。パスが失われている"
+            for path in targets:
+                for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                    if INLINE_IGNORE_PATTERN.search(line):
+                        found.append(f"{path.relative_to(request.config.rootpath)}:{lineno}")
+        assert not found, (
+            f"インライン抑止が High 検出を個別に無効化しうる: {found}。"
+            "正当な false positive の場合は本テストに allowlist を追加し、"
+            "抑止する理由と再評価時期をコメントで明記すること"
+        )
+
+    def test_no_zizmor_config_file(self, request: pytest.FixtureRequest) -> None:
+        """将来版が自動探索に対応した場合に備え、設定ファイルの実在を禁じる。"""
+        found = [path for path in ZIZMOR_CONFIG_PATHS if (request.config.rootpath / path).exists()]
+        assert not found, f"zizmor 設定ファイルが severity remap を持ちうる: {found}"

--- a/tests/unit/test_ci_zizmor_gate_contract.py
+++ b/tests/unit/test_ci_zizmor_gate_contract.py
@@ -9,7 +9,9 @@ import yaml
 # Module-level marker: 外部プロセスを起動せず ci.yml の YAML 構造のみを検証するため unit。
 # このマーカーを欠くと CI の `-m "(unit or integration) and not external"` から漏れ、
 # ゲートを守るはずの本ファイル自身が無音で実行されなくなる。
-pytestmark = pytest.mark.unit
+# repo_contract: request.config.rootpath 経由でリポジトリ全体を静的検査するため、
+# ビルドコンテキストが絞られた test コンテナでは走らせない（pyproject.toml の marker 定義参照）
+pytestmark = [pytest.mark.unit, pytest.mark.repo_contract]
 
 # zizmor の非ゼロ終了 (exit 11-14) を無効化する引数。--no-exit-codes は zizmor --help の
 # "Disable all error codes besides success and tool failure"、--format sarif は findings を

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -8,7 +8,9 @@ import yaml
 # Module-level marker: All tests in this file are unit tests
 # 外部プロセス(Docker)を起動せずYAML構造のみを検証するため
 # pyproject.toml marker定義 「unit」 に整合
-pytestmark = pytest.mark.unit
+# repo_contract: request.config.rootpath 経由でリポジトリ全体を静的検査するため、
+# ビルドコンテキストが絞られた test コンテナでは走らせない（pyproject.toml の marker 定義参照）
+pytestmark = [pytest.mark.unit, pytest.mark.repo_contract]
 
 
 class TestDockerComposeContract:
@@ -45,7 +47,13 @@ class TestDockerComposeContract:
         assert test_service["environment"]["ENVIRONMENT"] == "testing"
         assert test_service["environment"]["COVERAGE_FILE"] == "/tmp/.coverage"  # noqa: S108
         assert test_service["user"] == "${DOCKER_UID:-1000}:${DOCKER_GID:-1000}"
-        assert test_service["command"] == ["pytest", "-m", "(unit or integration) and not external"]
+        # ci.yml の test_filter と同一 + repo_contract 除外。完全一致で固定し、除外条件が
+        # 無音で増える（＝コンテナのテスト範囲が黙って狭まる）退行を検出する。
+        assert test_service["command"] == [
+            "pytest",
+            "-m",
+            "(unit or integration) and not external and not repo_contract",
+        ]
 
     def test_test_service_security_contract(self, compose_data: dict[str, Any]) -> None:
         """test service の権限昇格防止設定 (security_opt/init) を YAML レベルで保護する."""

--- a/uv.lock
+++ b/uv.lock
@@ -61,6 +61,7 @@ dev = [
     { name = "ruff" },
     { name = "safety" },
     { name = "socksio" },
+    { name = "zizmor" },
 ]
 
 [package.metadata]
@@ -89,6 +90,7 @@ dev = [
     { name = "ruff", specifier = ">=0.16.1,<0.17" },
     { name = "safety", specifier = ">=3.8.1" },
     { name = "socksio", specifier = ">=1.0.0" },
+    { name = "zizmor", specifier = "==1.29.0" },
 ]
 
 [[package]]
@@ -1339,4 +1341,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2f/c9/18d4b36606d6091844daa3bd93cf7dc78e6f5da21d9f21d06c221104b684/virtualenv-21.1.0.tar.gz", hash = "sha256:1990a0188c8f16b6b9cf65c9183049007375b26aad415514d377ccacf1e4fb44", size = 5840471, upload-time = "2026-02-27T08:49:29.702Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/55/896b06bf93a49bec0f4ae2a6f1ed12bd05c8860744ac3a70eda041064e4d/virtualenv-21.1.0-py3-none-any.whl", hash = "sha256:164f5e14c5587d170cf98e60378eb91ea35bf037be313811905d3a24ea33cc07", size = 5825072, upload-time = "2026-02-27T08:49:27.516Z" },
+]
+
+[[package]]
+name = "zizmor"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/f8/f4e3fc0b316d5241b6d6968e8fb702e28446bc7d3c1e2b229f4caa6eacf2/zizmor-1.29.0.tar.gz", hash = "sha256:60e34e83c67064e0036989c7c525d13413e897aa4c4f683f1efb2048cdb28a47", size = 571865, upload-time = "2026-08-01T21:09:19.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/97/667ef4db0ca9225ee402c1b947b5b6f17fd234d72c15a71db150b7695c62/zizmor-1.29.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ea72f84d610643d57f96430c655a3780d0b874e477d32e14eae8e910f6cce1fd", size = 9037504, upload-time = "2026-08-01T21:08:56.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d4/9fc7deaf75778e7516fa1d6c836377c3cb5d203dedc28899946b6f11ecdb/zizmor-1.29.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5aafe617d7b1e0c0c15d58fdf20495f360f74a791dfa136f76630b4cc06c2a34", size = 8654426, upload-time = "2026-08-01T21:08:59.212Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f6/6db714fb0aa08aeec62eb9d6ad6a443a1f4ed50d4c0b789944ae55fb83e4/zizmor-1.29.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:67644ae8d6d0394204b9a488f7d86f0dd66fe562f4ba85fc53e6105a6bfc7b6a", size = 8918927, upload-time = "2026-08-01T21:09:01.46Z" },
+    { url = "https://files.pythonhosted.org/packages/15/40/a12edc0c0c0a0101c54dbb9099ff08f8de2fcb35c36cb706db3deb2c2728/zizmor-1.29.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:81e4093fed5c8a41d6ae7bb773085a9d2e6c0b0a0b560d46a9c76d69be0a07ed", size = 8500655, upload-time = "2026-08-01T21:09:03.677Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f0/dfa67018b76bc4f2f50e265e8cbd1293833d1b1de5f3f02fbbb7487ae9c6/zizmor-1.29.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:587b99c2e1b34575c6c8565c2bfde415ca8bc0310f5589f19bc948c8dea10a20", size = 9351035, upload-time = "2026-08-01T21:09:06.16Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1b/93cdd5a06984b394d90001f9778008a21689052904109080a09952626c99/zizmor-1.29.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:061600f23c46f2e400bcdef666c236de7e5c0b07dd6ca046daa001eb1514b909", size = 8941717, upload-time = "2026-08-01T21:09:08.861Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f4/8d9e54405b477bc8e4b56c1a60123fca26c109ea6a762eea104fab32555e/zizmor-1.29.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:332546480be38aca95c149f835e0dcb7679ab5d74618a90c6ccb3fa6b8c7b99d", size = 8468289, upload-time = "2026-08-01T21:09:11.096Z" },
+    { url = "https://files.pythonhosted.org/packages/72/86/06d57ca830cc4653369c5aca22cccbf04c8c36ee84a67f351214e556bad8/zizmor-1.29.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a7462b9ab45d72a20ad5ab8193b430df8184c59e2bf46954ddd09496f2f00b45", size = 9446505, upload-time = "2026-08-01T21:09:13.38Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/253d9a3538e0ea6f96a3bcd69839c0c5a816a00299620b58a10b5bd1df59/zizmor-1.29.0-py3-none-win32.whl", hash = "sha256:8c759e68cd866375030ca39e19e2de47a056b7be7288c1620e2d5b4c274f631f", size = 7655723, upload-time = "2026-08-01T21:09:15.758Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2d/7919bc23475273ed8038a031fc24bc3f2005c78e608ce8df96746ef0fb98/zizmor-1.29.0-py3-none-win_amd64.whl", hash = "sha256:0fb85948ba5ffc7a8116eee36fe9cfc10167225c97bd2810e3378e66a9fd27c4", size = 8785519, upload-time = "2026-08-01T21:09:17.513Z" },
 ]


### PR DESCRIPTION
## 概要
ci.yml に zizmor High-severity fail-closed ゲートを追加し、静的契約テストで fail-open 退行を防止する。

## 変更内容
- `.github/workflows/ci.yml`: pr-validation ジョブに zizmor 監査 step を追加（High 以上検出で非ゼロ終了）
- `pyproject.toml` / `uv.lock`: zizmor==1.29.0 を dev 依存に固定ピン（推移的依存ゼロ）
- `docs/reference/ci_cd_pipeline.md`: ローカル再現手順を追記
- `tests/unit/test_ci_zizmor_gate_contract.py`（新規・11テスト）: ゲート設定の退行を防ぐ静的契約テスト
  - シェル層は禁止構文の列挙ではなく「区切り文字を含まない単一コマンド」という構造不変条件で固定
  - workflow/job/step の3階層で shell 上書きを禁止
  - Actions/Shell/Tool/Config の4層バイパスと設定ファイル自動探索経路を個別に固定

## 実施した検証
- 品質ゲート: 1455 tests passed / 97.60% coverage / ruff 0 errors / mypy 0 errors
- zizmor 実行: exit 0（本ブランチ、origin/develop 追従後）
- 変異テスト: 13/13 捕捉（旧denylist方式が見逃していた `| tee`, `|| echo`, `&`, `shell:` 上書き経路を含む変異を全て検知）
- 差分検証: 新ガードが旧denylistの厳密な上位互換であることを実測確認（退行0件、強化23件）
- GitHub Actions の実デフォルト shell (`bash -e -o pipefail`) で再実測し、区切り文字のうち真に fail-open なのは `&`（バックグラウンド実行）のみと判明。`|`/`;`/改行の禁止はshell上書き（`defaults.run.shell`）に依存しない多層防御目的であり、実装（構造不変条件）自体は変更なし。コメントの実測記述のみを訂正（58e1853）

## テスト
- [x] ローカルテスト完了（1455 passed / 97.60%）
- [ ] CI/CD パイプライン確認

## 関連Issue
Closes #557 (Issue)

---
このPRは /push-pr スキルで自動生成されました。