### PR TITLE
feat(github): AsyncGitHubClientの接続プール上限を明示化

### DIFF
--- a/docs/adr/0001-async-only-github-client.md
+++ b/docs/adr/0001-async-only-github-client.md
@@ -2,7 +2,8 @@
 
 **Status**: Accepted
 **Date**: 2026-05-08
-**Last verified**: 2026-08-05 — 決定は有効。実装位置の変更 (「実装位置の変遷」参照) に加え、公開メソッドの戻り値が parsed JSON から検証済み Pydantic モデルへ変わった (「AsyncAPIClient との契約差異」参照)。継承しない判断はこの変更で論拠がむしろ強まっている
+**Last verified**: 2026-08-06 — 決定は有効。実装位置の変更 (「実装位置の変遷」参照) に加え、公開メソッドの戻り値が parsed JSON から検証済み Pydantic モデルへ変わった (「AsyncAPIClient との契約差異」参照)。継承しない判断はこの変更で論拠がむしろ強まっている。
+補足 (2026-08-06 実測): 採用理由 1 が挙げる並行 fetch は**現時点で未行使**。`AsyncGitHubClient` を `asyncio.gather` / `TaskGroup` / `Semaphore` へ渡す fan-out 経路は本番・テストとも 0 件。Async-only の判断自体は「同期 caller 不在」と SRP/LSP の論拠から独立に成立するため決定は変わらないが、並行 fetch は実現済みの便益ではなく設計上の余地にとどまる。あわせて、将来の fan-out に備えて接続プール上限を `AsyncGitHubClient(max_connections=10)` として明示化した (「GitHub API の特性」参照)。受け付ける範囲は 1..100 で、上限は GitHub の同時リクエスト制限そのものに一致させている
 **Context tags**: API client design, Async/Sync paradigm, GitHub API integration, inheritance vs composition
 
 ## Context
@@ -13,6 +14,9 @@ GitHub API クライアント (`utils/github_client.py`) の実装パラダイ�
 
 - **認証あり**: Personal Access Token / OAuth
 - **Rate Limit**: 認証なし 60 req/h、認証あり 5000 req/h
+- **同時接続の上限**: 同時 100 リクエスト (REST/GraphQL 共有) を超えないことが secondary
+  rate limit として文書化されている。httpx の既定 `max_connections` も偶然 100 のため、
+  未設定だとプール飽和と API 拒否が同時に起き、マージンが残らない
 - **ETag による Conditional Requests**: 304 Not Modified でレスポンスボディ省略・帯域節約
 - **想定ユースケース**: CI/CD での複数リポジトリ状態取得、Dashboard 集計クエリ、Rate Limit 内で多数リクエストを効率消化
 

--- a/tests/unit/test_github_client_lifecycle.py
+++ b/tests/unit/test_github_client_lifecycle.py
@@ -32,6 +32,42 @@ async def test_context_manager_initialization() -> None:
     assert managed_client.is_closed
 
 
+async def test_aenter_caps_connection_pool() -> None:
+    """__aenter__ が接続プール上限を明示的に httpx へ渡すことを固定する。
+
+    未指定だと httpx 既定の max_connections=100 が効くが、これは GitHub が強制する
+    同時100リクエスト上限と偶然一致し、プール飽和と API 拒否が同時に起きてマージンが
+    ゼロになる。この暗黙の一致へ戻る回帰を防ぐ。
+    """
+    target = "utils.github_client.httpx.AsyncClient"
+    with patch(target, return_value=AsyncMock()) as async_client_cls:
+        async with AsyncGitHubClient():
+            pass
+        assert async_client_cls.call_args.kwargs["limits"].max_connections == 10
+
+        async with AsyncGitHubClient(max_connections=3):
+            pass
+        assert async_client_cls.call_args.kwargs["limits"].max_connections == 3
+
+
+@pytest.mark.parametrize("invalid", [0, -1, 101])
+async def test_init_rejects_out_of_range_max_connections(invalid: int) -> None:
+    """max_connections を 1..100 に制限する（settings.api.max_connections と同一契約）。
+
+    下限: 0 以下ではプールが接続を確保できず全リクエストが PoolTimeout になる。
+    上限: 100 は GitHub の同時リクエスト制限そのもので、超えても API 側で拒否される。
+    どちらも即座の ValueError で呼び出し側の設定ミスを表面化させる。
+    """
+    with pytest.raises(ValueError, match="max_connections must be between 1 and 100"):
+        AsyncGitHubClient(max_connections=invalid)
+
+
+@pytest.mark.parametrize("valid", [1, 100])
+async def test_init_accepts_max_connections_boundaries(valid: int) -> None:
+    """境界値 1 / 100 は許容する（off-by-one で有効値を弾かないことの固定）。"""
+    assert AsyncGitHubClient(max_connections=valid).max_connections == valid
+
+
 @pytest.mark.parametrize(
     ("close_exception", "expected_type", "expected_module"),
     [

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -115,6 +115,8 @@ class AsyncGitHubClient:
     """
 
     BASE_URL = "https://api.github.com"
+    # GitHub が secondary rate limit として文書化する同時リクエスト上限（REST/GraphQL 共有）。
+    MAX_CONNECTIONS_LIMIT = 100
 
     def __init__(
         self,
@@ -122,6 +124,7 @@ class AsyncGitHubClient:
         max_retries: int = 3,
         user_agent: str = "AsyncGitHubClient/1.0",
         max_cache_entries: int = 256,
+        max_connections: int = 10,
     ):
         """AsyncGitHubClientの初期化
 
@@ -132,11 +135,25 @@ class AsyncGitHubClient:
                 デフォルト設定(timeout=30, max_retries=3)での最悪ケース: 約96秒。
             user_agent: User-Agentヘッダー（GitHub要求事項）
             max_cache_entries: ETag/dataキャッシュの最大エントリ数（デフォルト256）
+            max_connections: 接続プールの同時接続上限（デフォルト10 — JSONPlaceholder
+                クライアント群の `settings.api.max_connections` と同値）。未設定だと
+                httpx 既定の100が効くが、これは GitHub が文書化する同時100リクエスト上限と
+                一致するため、プール飽和と API 拒否が同時に起きマージンが残らない。
+                上限到達時は接続を待機し、`timeout` 経過で `httpx.PoolTimeout`
+                （`_request` のリトライ対象）。有効範囲は 1..100 で、上限は上記の
+                GitHub 制限そのもの、下限は 0 以下だと接続を確保できないため
+                （`settings.api.max_connections` の `ge=1, le=100` と同一契約）。
+
+        Raises:
+            ValueError: max_connections が 1..100 の範囲外（理由は Args を参照）
 
         """
+        if not 1 <= max_connections <= self.MAX_CONNECTIONS_LIMIT:
+            raise ValueError(f"max_connections must be between 1 and {self.MAX_CONNECTIONS_LIMIT}")
         self.timeout = timeout
         self.max_retries = max_retries
         self.user_agent = user_agent
+        self.max_connections = max_connections
         self._client: httpx.AsyncClient | None = None
         self.logger = get_logger(__name__)
         # ETag/data キャッシュは GitHubETagCache が排他所有する（facade は保持と委譲のみ）。
@@ -157,6 +174,7 @@ class AsyncGitHubClient:
                 "Accept": "application/vnd.github+json",
                 "User-Agent": self.user_agent,
             },
+            limits=httpx.Limits(max_connections=self.max_connections),
         )
         return self
 

--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -125,7 +125,7 @@ class AsyncGitHubClient:
         user_agent: str = "AsyncGitHubClient/1.0",
         max_cache_entries: int = 256,
         max_connections: int = 10,
-    ):
+    ) -> None:
         """AsyncGitHubClientの初期化
 
         Args:


### PR DESCRIPTION
## 概要
`AsyncGitHubClient` に `max_connections` 引数（デフォルト10、1..100検証付き）を追加し、`__aenter__` で `httpx.Limits(max_connections=self.max_connections)` を渡すよう変更。

## 変更内容
- 未設定時はhttpxの既定値である同時100接続が実効値となり、GitHubが文書化する同時100リクエスト制限と一致してマージンがなかった問題を解消
- 値を既存の JSONPlaceholder クライアント群（`settings.api.max_connections`）と同一の規約に揃え、デフォルト10とした
- ADR-0001 に同時接続上限に関する記載を補足
- 範囲外の値には `ValueError` を送出する検証を新設（既存呼び出し元はすべてデフォルト値のため影響なし）

## テスト
- [x] ローカルテスト完了（1484 tests passed / 97.62% coverage / ruff 0 errors / mypy 0 errors）
- [ ] CI/CD パイプライン確認

## 関連Issue/PR
連携なし

---
このPRは /push-pr スキルで自動生成されました。