### PR TITLE
security(docker): runtime stage から pip を除去

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,10 @@ RUN uv sync --frozen --no-dev --no-install-project
 # ============================================================
 FROM base AS runtime
 
+# セキュリティ: runtime に pip は不要（実行は仮想環境の python のみ）。
+# pip 同梱の vendored ライブラリを含めて攻撃面から除去する。
+RUN python -m pip uninstall -y pip
+
 # 仮想環境をコピー
 COPY --from=dependencies /app/.venv /app/.venv
 


### PR DESCRIPTION
## 概要
runtime stage で `RUN python -m pip uninstall -y pip` を実行し、実行環境から pip を除去する。

## 背景
base image の digest 更新により pip 26.2.1 同梱の vendored SBOM（`pip/_vendor/bom.cdx.json`）が Trivy から可視化され、msgpack / setuptools を HIGH 脆弱性として誤検出。runtime は仮想環境の python のみを実行し pip 自体は不要なため、uninstall により攻撃面ごと除去する。

## 変更内容
- Dockerfile: runtime stage 先頭（venv コピー前）に `RUN python -m pip uninstall -y pip` を追加

## テスト
- [x] ローカル品質ゲート通過（pytest 1484 passed / coverage 97.62%、ruff 0 errors、mypy 0 errors）
- [x] CI/CD パイプライン確認（Trivy image scan gate 含む）

## 関連Issue/PR
Closes #576 (Issue)

---
このPRは /push-pr スキルで自動生成されました。