### PR TITLE
chore(github): _requestのnoqaコメント根拠を修正

### DIFF
--- a/utils/github_client.py
+++ b/utils/github_client.py
@@ -410,7 +410,7 @@ class AsyncGitHubClient:
         result = await self._request("GET", f"/repos/{owner}/{repo}")
         return validate_parsed_model(result, GitHubRepo, error_factory=GitHubAPIError)
 
-    async def _request(  # noqa: C901 - HTTPプロトコル処理の最小必要分岐（4xxステータス, 5xxリトライ, タイムアウト, キャンセル等）のため許容 CC≈12
+    async def _request(  # noqa: C901 - 個別ハンドラは委譲済み。PII-safeなretry/例外境界を本関数に集約
         self,
         method: str,
         endpoint: str,


### PR DESCRIPTION
## 概要
`utils/github_client.py` の `_request` メソッドに付与されている `# noqa: C901` コメントの複雑度実測値が誤っていたため修正した。

## 変更内容
- 誤った実測値 `CC≈12`（Ruff実測はC901=23）を削除
- 個別ハンドラへの委譲後もPII-safeなretry/例外境界をこの関数に集約している設計理由を1行で明記
- 実行コード・公開API・例外挙動の変更なし（コメントのみ、1ファイル1行）

## テスト
- [x] 対象テスト: 124 passed（`utils/github_client.py` 関連）
- [x] 統合品質ゲート: 1492 passed / カバレッジ97.62%
- [x] ruff check: 0 errors
- [x] mypy: 0 errors

## 関連Issue/PR
Closes #583 (Issue)

---
このPRは /push-pr スキルで自動生成されました。