### PR TITLE
test(api): sync/async クライアントのメソッドパリティ契約テストを追加

### DIFF
--- a/tests/unit/test_api_parity.py
+++ b/tests/unit/test_api_parity.py
@@ -1,0 +1,101 @@
+"""Sync/Async JSONPlaceholder domain API parity contract"""
+
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from utils.jsonplaceholder_client_async import AsyncJSONPlaceholderClient
+from utils.jsonplaceholder_client_sync import SyncJSONPlaceholderClient
+
+pytestmark = pytest.mark.unit
+
+
+INTENTIONALLY_ASYNC_ONLY: dict[str, str] = {
+    # Intentional async-only: this method demonstrates concurrent fan-out.
+    "bulk_create_users": "Uses asyncio.gather for concurrent user creation.",
+    # Intentional async-only: bounded concurrency is the behavior under demonstration.
+    "get_multiple_users": "Uses a semaphore to bound concurrent user requests.",
+    # Intentional async-only: TaskGroup cancellation behavior is being demonstrated.
+    "get_user_data": "Uses asyncio.TaskGroup for concurrent related-data requests.",
+}
+
+KNOWN_PARITY_DRIFT: dict[str, str] = {
+    # Temporary drift: this operation is expected to gain a sync counterpart.
+    "update_post": "Async domain operation awaiting a future sync counterpart.",
+    # Temporary drift: this operation is expected to gain a sync counterpart.
+    "delete_post": "Async domain operation awaiting a future sync counterpart.",
+    # Temporary drift: this operation is expected to gain a sync counterpart.
+    "create_user": "Async domain operation awaiting a future sync counterpart.",
+}
+
+
+def _public_methods(client_class: type[Any]) -> dict[str, Callable[..., Any]]:
+    """Return public methods defined directly on a client class."""
+    methods: dict[str, Callable[..., Any]] = {}
+    for name, raw_member in vars(client_class).items():
+        if name.startswith("_"):
+            continue
+
+        member: Any = raw_member
+        if isinstance(member, (staticmethod, classmethod)):
+            member = member.__func__
+        if inspect.isfunction(member):
+            methods[name] = member
+    return methods
+
+
+def test_sync_async_domain_method_parity() -> None:
+    sync_methods = _public_methods(SyncJSONPlaceholderClient)
+    async_methods = _public_methods(AsyncJSONPlaceholderClient)
+    sync_names = set(sync_methods)
+    async_names = set(async_methods)
+    expected_async_only = set(INTENTIONALLY_ASYNC_ONLY) | set(KNOWN_PARITY_DRIFT)
+
+    assert all(reason.strip() for reason in INTENTIONALLY_ASYNC_ONLY.values()), (
+        "Every intentional async-only method must have a non-empty reason."
+    )
+    assert all(reason.strip() for reason in KNOWN_PARITY_DRIFT.values()), (
+        "Every known parity drift method must have a non-empty reason."
+    )
+    assert set(INTENTIONALLY_ASYNC_ONLY).isdisjoint(KNOWN_PARITY_DRIFT), (
+        "Async-only allowlists must remain separate so intentional methods and parity drift "
+        "can be reviewed independently."
+    )
+    assert sync_names - async_names == set(), (
+        "Sync-only public methods are not allowed. Add the method to both domain classes. "
+        f"Found: {sorted(sync_names - async_names)}"
+    )
+    assert async_names - sync_names == expected_async_only, (
+        "Unexpected async-only public methods. Add the method to both domain classes or "
+        "update the appropriate reasoned allowlist. "
+        f"Found: {sorted(async_names - sync_names)}"
+    )
+
+    common_names = sync_names & async_names
+    signature_mismatches = {
+        name: (
+            str(inspect.signature(sync_methods[name])),
+            str(inspect.signature(async_methods[name])),
+        )
+        for name in common_names
+        if inspect.signature(sync_methods[name]) != inspect.signature(async_methods[name])
+    }
+    assert signature_mismatches == {}, (
+        "Common sync/async methods must have identical signatures (parameter names, "
+        "annotations, defaults, and return type). Align both definitions before updating "
+        f"an allowlist. Found: {signature_mismatches}"
+    )
+
+    coroutine_mismatches = {
+        name
+        for name in common_names
+        if inspect.iscoroutinefunction(sync_methods[name])
+        or not inspect.iscoroutinefunction(async_methods[name])
+    }
+    assert coroutine_mismatches == set(), (
+        "Common methods must differ only by the async/await boundary. Keep the sync "
+        "definition synchronous and the async definition coroutine-based. "
+        f"Coroutine-shape mismatches: {sorted(coroutine_mismatches)}"
+    )

--- a/tests/unit/test_api_parity.py
+++ b/tests/unit/test_api_parity.py
@@ -99,3 +99,12 @@ def test_sync_async_domain_method_parity() -> None:
         "definition synchronous and the async definition coroutine-based. "
         f"Coroutine-shape mismatches: {sorted(coroutine_mismatches)}"
     )
+
+    async_only_coroutine_mismatches = {
+        name for name in expected_async_only if not inspect.iscoroutinefunction(async_methods[name])
+    }
+    assert async_only_coroutine_mismatches == set(), (
+        "Allowlisted async-only methods must be coroutine-based. Convert the definition to "
+        "'async def' or drop the entry from INTENTIONALLY_ASYNC_ONLY / KNOWN_PARITY_DRIFT. "
+        f"Found: {sorted(async_only_coroutine_mismatches)}"
+    )


### PR DESCRIPTION
## 概要
Sync/AsyncのJSONPlaceholderクライアント間でメソッド集合・シグネチャが将来乖離しても検知できる契約テストを追加。

## 変更内容
- `tests/unit/test_api_parity.py` を新規追加（101行）
  - 公開メソッド名の集合差分を検証
  - 共通メソッドのシグネチャ一致を検証
  - sync/asyncのcoroutine境界を検証
  - 意図的なasync専用メソッドと一時的なparity drift（`update_post`/`delete_post`/`create_user`）を理由付き許可リストで分離

## テスト
- [x] ローカルテスト完了（1493 passed / 97.62% coverage / ruff 0 errors / mypy 0 errors）
- [ ] CI/CD パイプライン確認

## 関連Issue/PR
Closes #589 (Issue)

---
このPRは /push-pr スキルで自動生成されました。